### PR TITLE
Phase 3: Line length and remaining lint fixes

### DIFF
--- a/FiveCubedMoments/FiveCubedMoments/Features/Settings/SettingsScreen.swift
+++ b/FiveCubedMoments/FiveCubedMoments/Features/Settings/SettingsScreen.swift
@@ -16,7 +16,8 @@ struct SettingsScreen: View {
                     .font(AppTheme.warmPaperHeader)
                     .foregroundStyle(AppTheme.textPrimary)
             } footer: {
-                Text("When on, long-pressing a chip shows a confirmation before deleting. When off, long-press deletes immediately.")
+                Text("When on, long-pressing a chip shows a confirmation before deleting. "
+                    + "When off, long-press deletes immediately.")
                     .font(AppTheme.warmPaperBody)
                     .foregroundStyle(AppTheme.textMuted)
             }
@@ -30,7 +31,8 @@ struct SettingsScreen: View {
                     .font(AppTheme.warmPaperHeader)
                     .foregroundStyle(AppTheme.textPrimary)
             } footer: {
-                Text("When on, chip labels use an online service for better summaries. When off, labels use on-device processing only.")
+                Text("When on, chip labels use an online service for better summaries. "
+                    + "When off, labels use on-device processing only.")
                     .font(AppTheme.warmPaperBody)
                     .foregroundStyle(AppTheme.textMuted)
             }

--- a/FiveCubedMoments/FiveCubedMoments/Services/Summarization/CloudSummarizer.swift
+++ b/FiveCubedMoments/FiveCubedMoments/Services/Summarization/CloudSummarizer.swift
@@ -42,12 +42,14 @@ struct CloudSummarizer: Summarizer {
             if let result = try? await fallback.summarize(sentence, section: section) {
                 return result
             }
-            return SummarizationResult(label: String(trimmed.prefix(maxLabelChars)), isTruncated: trimmed.count > maxLabelChars)
+            let fallbackLabel = String(trimmed.prefix(maxLabelChars))
+            return SummarizationResult(label: fallbackLabel, isTruncated: trimmed.count > maxLabelChars)
         }
     }
 
     private func prompt(for section: SummarizationSection, sentence: String) -> String {
-        let bilingualNote = " Input may be in English or Chinese (中文); respond in the same language as the input with a short chip label (1–5 words or 1–5 字)."
+        let bilingualNote = " Input may be in English or Chinese (中文); respond in the same language " +
+            "as the input with a short chip label (1–5 words or 1–5 字)."
         let baseSuffix = " Reply with only the label, no punctuation."
         switch section {
         case .gratitude:

--- a/FiveCubedMoments/FiveCubedMoments/Services/Summarization/NaturalLanguageSummarizer.swift
+++ b/FiveCubedMoments/FiveCubedMoments/Services/Summarization/NaturalLanguageSummarizer.swift
@@ -86,7 +86,9 @@ struct NaturalLanguageSummarizer: Summarizer {
         let range = text.startIndex..<text.endIndex
         let options: NLTagger.Options = [.joinNames, .omitPunctuation, .omitWhitespace]
 
-        tagger.enumerateTags(in: range, unit: .word, scheme: .nameTypeOrLexicalClass, options: options) { tag, tokenRange in
+        tagger.enumerateTags(
+            in: range, unit: .word, scheme: .nameTypeOrLexicalClass, options: options
+        ) { tag, tokenRange in
             let word = String(text[tokenRange])
             guard word.count >= minNounLength else { return true }
 

--- a/FiveCubedMomentsTests/Features/Journal/JournalViewModelTests.swift
+++ b/FiveCubedMomentsTests/Features/Journal/JournalViewModelTests.swift
@@ -130,7 +130,11 @@ final class JournalViewModelTests: XCTestCase {
     func test_exportSnapshot_trimsTextFromFieldsAndOmitsEmptySubmissions() async throws {
         let context = try makeInMemoryContext()
         let now = Date(timeIntervalSince1970: 1_742_147_200)
-        let viewModel = JournalViewModel(calendar: calendar, nowProvider: { now }, summarizerProvider: SummarizerProvider(fixedSummarizer: MockSummarizer()))
+        let viewModel = JournalViewModel(
+            calendar: calendar,
+            nowProvider: { now },
+            summarizerProvider: SummarizerProvider(fixedSummarizer: MockSummarizer())
+        )
 
         viewModel.loadEntry(for: now, using: context)
         await viewModel.addGratitude("  Family  ")
@@ -153,7 +157,11 @@ final class JournalViewModelTests: XCTestCase {
     func test_exportSnapshot_partialEntry_producesValidPayload() async throws {
         let context = try makeInMemoryContext()
         let now = Date(timeIntervalSince1970: 1_742_147_200)
-        let viewModel = JournalViewModel(calendar: calendar, nowProvider: { now }, summarizerProvider: SummarizerProvider(fixedSummarizer: MockSummarizer()))
+        let viewModel = JournalViewModel(
+            calendar: calendar,
+            nowProvider: { now },
+            summarizerProvider: SummarizerProvider(fixedSummarizer: MockSummarizer())
+        )
 
         viewModel.loadEntry(for: now, using: context)
         await viewModel.addGratitude("One gratitude")
@@ -171,7 +179,11 @@ final class JournalViewModelTests: XCTestCase {
     func test_updateGratitudeRejectsEmptyString_leavesOriginalUnchanged() async throws {
         let context = try makeInMemoryContext()
         let now = Date(timeIntervalSince1970: 1_742_147_200)
-        let viewModel = JournalViewModel(calendar: calendar, nowProvider: { now }, summarizerProvider: SummarizerProvider(fixedSummarizer: MockSummarizer()))
+        let viewModel = JournalViewModel(
+            calendar: calendar,
+            nowProvider: { now },
+            summarizerProvider: SummarizerProvider(fixedSummarizer: MockSummarizer())
+        )
 
         viewModel.loadEntry(for: now, using: context)
         await viewModel.addGratitude("Family")
@@ -183,7 +195,11 @@ final class JournalViewModelTests: XCTestCase {
     func test_updateNeedRejectsEmptyString_leavesOriginalUnchanged() async throws {
         let context = try makeInMemoryContext()
         let now = Date(timeIntervalSince1970: 1_742_147_200)
-        let viewModel = JournalViewModel(calendar: calendar, nowProvider: { now }, summarizerProvider: SummarizerProvider(fixedSummarizer: MockSummarizer()))
+        let viewModel = JournalViewModel(
+            calendar: calendar,
+            nowProvider: { now },
+            summarizerProvider: SummarizerProvider(fixedSummarizer: MockSummarizer())
+        )
 
         viewModel.loadEntry(for: now, using: context)
         await viewModel.addNeed("Peace")
@@ -195,7 +211,11 @@ final class JournalViewModelTests: XCTestCase {
     func test_updatePersonRejectsEmptyString_leavesOriginalUnchanged() async throws {
         let context = try makeInMemoryContext()
         let now = Date(timeIntervalSince1970: 1_742_147_200)
-        let viewModel = JournalViewModel(calendar: calendar, nowProvider: { now }, summarizerProvider: SummarizerProvider(fixedSummarizer: MockSummarizer()))
+        let viewModel = JournalViewModel(
+            calendar: calendar,
+            nowProvider: { now },
+            summarizerProvider: SummarizerProvider(fixedSummarizer: MockSummarizer())
+        )
 
         viewModel.loadEntry(for: now, using: context)
         await viewModel.addPerson("Alice")
@@ -207,7 +227,11 @@ final class JournalViewModelTests: XCTestCase {
     func test_updatesPersistAfterDebouncedAutosave() async throws {
         let context = try makeInMemoryContext()
         let now = Date(timeIntervalSince1970: 1_742_147_200)
-        let viewModel = JournalViewModel(calendar: calendar, nowProvider: { now }, summarizerProvider: SummarizerProvider(fixedSummarizer: MockSummarizer()))
+        let viewModel = JournalViewModel(
+            calendar: calendar,
+            nowProvider: { now },
+            summarizerProvider: SummarizerProvider(fixedSummarizer: MockSummarizer())
+        )
 
         viewModel.loadEntry(for: now, using: context)
         await viewModel.addGratitude("  Family  ")
@@ -231,7 +255,11 @@ final class JournalViewModelTests: XCTestCase {
     func test_removeGratitude_validIndex_removesAndPersists() async throws {
         let context = try makeInMemoryContext()
         let now = Date(timeIntervalSince1970: 1_742_147_200)
-        let viewModel = JournalViewModel(calendar: calendar, nowProvider: { now }, summarizerProvider: SummarizerProvider(fixedSummarizer: MockSummarizer()))
+        let viewModel = JournalViewModel(
+            calendar: calendar,
+            nowProvider: { now },
+            summarizerProvider: SummarizerProvider(fixedSummarizer: MockSummarizer())
+        )
 
         viewModel.loadEntry(for: now, using: context)
         await viewModel.addGratitude("First")
@@ -260,7 +288,11 @@ final class JournalViewModelTests: XCTestCase {
     func test_removeNeed_validIndex_removesAndPersists() async throws {
         let context = try makeInMemoryContext()
         let now = Date(timeIntervalSince1970: 1_742_147_200)
-        let viewModel = JournalViewModel(calendar: calendar, nowProvider: { now }, summarizerProvider: SummarizerProvider(fixedSummarizer: MockSummarizer()))
+        let viewModel = JournalViewModel(
+            calendar: calendar,
+            nowProvider: { now },
+            summarizerProvider: SummarizerProvider(fixedSummarizer: MockSummarizer())
+        )
 
         viewModel.loadEntry(for: now, using: context)
         await viewModel.addNeed("Peace")
@@ -276,7 +308,11 @@ final class JournalViewModelTests: XCTestCase {
     func test_removePerson_validIndex_removesAndPersists() async throws {
         let context = try makeInMemoryContext()
         let now = Date(timeIntervalSince1970: 1_742_147_200)
-        let viewModel = JournalViewModel(calendar: calendar, nowProvider: { now }, summarizerProvider: SummarizerProvider(fixedSummarizer: MockSummarizer()))
+        let viewModel = JournalViewModel(
+            calendar: calendar,
+            nowProvider: { now },
+            summarizerProvider: SummarizerProvider(fixedSummarizer: MockSummarizer())
+        )
 
         viewModel.loadEntry(for: now, using: context)
         await viewModel.addPerson("Alice")

--- a/FiveCubedMomentsTests/Services/Summarization/NaturalLanguageSummarizerTests.swift
+++ b/FiveCubedMomentsTests/Services/Summarization/NaturalLanguageSummarizerTests.swift
@@ -59,11 +59,13 @@ final class NaturalLanguageSummarizerTests: XCTestCase {
     /// Long extracted labels (e.g. place names) should be truncated with isTruncated = true
     /// so chips render the gradient fade and avoid overflow.
     func test_summarize_longExtractedLabel_returnsTruncatedWithIsTruncatedTrue() async throws {
-        let result = try await sut.summarize("I traveled through John Smith International Airport today", section: .person)
+        let input = "I traveled through John Smith International Airport today"
+        let result = try await sut.summarize(input, section: .person)
         XCTAssertFalse(result.label.isEmpty)
         if result.isTruncated {
-            XCTAssertLessThanOrEqual(result.label.count, 20,
-                                    "When truncated, label must be at most 20 chars, got: '\(result.label)' (\(result.label.count) chars)")
+            let msg = "When truncated, label must be at most 20 chars, got: '\(result.label)' "
+                + "(\(result.label.count) chars)"
+            XCTAssertLessThanOrEqual(result.label.count, 20, msg)
         }
     }
 

--- a/FiveCubedMomentsUITests/FiveCubedMomentsUITests.swift
+++ b/FiveCubedMomentsUITests/FiveCubedMomentsUITests.swift
@@ -15,7 +15,9 @@ final class FiveCubedMomentsUITests: XCTestCase {
         // In UI tests it is usually best to stop immediately when a failure occurs.
         continueAfterFailure = false
 
-        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+        // In UI tests it’s important to set the initial state - such as interface orientation -
+        // required for your tests before they run.
+        // The setUp method is a good place to do this.
     }
 
     override func tearDownWithError() throws {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Implements Phase 3 of the [Code Quality Implementation Path](FiveCubedMoments/docs/CODE_QUALITY_IMPLEMENTATION_PATH.md): fixes line length and remaining lint violations.

## Changes

### 3.1 CloudSummarizer
- Extracted `fallbackLabel` to avoid a 128-character line in the error-handling path
- Split `bilingualNote` string across two lines using concatenation (159 → <120 chars)

### 3.2 SettingsScreen
- Split long footer text using string concatenation (`+`) for both Chips and Summarization sections

### 3.3 NaturalLanguageSummarizer
- Wrapped `tagger.enumerateTags(in:unit:scheme:options:)` call across multiple lines

### 3.4 JournalViewModelTests
- Broke long `JournalViewModel(...)` initializations across multiple lines (9 occurrences)

### 3.5 NaturalLanguageSummarizerTests
- Extracted long input string to a local variable
- Split long `XCTAssertLessThanOrEqual` message across lines

### 3.6 FiveCubedMomentsUITests
- Split 182-character comment across two lines

## Validation
- `swiftlint lint`: All Phase 3 line length violations resolved
- Remaining violations (JournalScreen cyclomatic complexity, type_body_length) are Phase 2 scope
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-19668c61-e87c-4d40-a436-7ca2d4c05e09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-19668c61-e87c-4d40-a436-7ca2d4c05e09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

