### PR TITLE
Phase 4: Test Additions (SummarizerProvider, CloudSummarizer, completedToday, slot limit)

### DIFF
--- a/FiveCubedMoments/FiveCubedMoments/Services/Summarization/CloudSummarizer.swift
+++ b/FiveCubedMoments/FiveCubedMoments/Services/Summarization/CloudSummarizer.swift
@@ -4,7 +4,8 @@ import os
 private let log = Logger(subsystem: "com.fivecubedmoments.FiveCubedMoments", category: "CloudSummarizer")
 
 /// Calls OpenAI-compatible chat completions API at chat.cloudapi.vip.
-/// On any failure (network, timeout, invalid key, empty response), falls back to NaturalLanguageSummarizer.
+/// On any failure (network, timeout, invalid key, empty response), falls back to NaturalLanguageSummarizer
+/// by default; a different summarizer may be injected (e.g., for tests).
 /// See doc.newapi.pro for API details.
 struct CloudSummarizer: Summarizer {
     private let baseURL: String
@@ -38,7 +39,7 @@ struct CloudSummarizer: Summarizer {
             log.debug("Cloud summarization succeeded: \"\(trimmed)\" -> \"\(capped)\"")
             return SummarizationResult(label: capped, isTruncated: label.count > maxLabelChars)
         } catch {
-            log.info("Cloud API failed, using NL fallback: \(String(describing: error))")
+            log.info("Cloud API failed, using fallback summarizer: \(String(describing: error))")
             if let result = try? await fallback.summarize(sentence, section: section) {
                 return result
             }

--- a/FiveCubedMoments/FiveCubedMoments/Services/Summarization/SummarizerProvider.swift
+++ b/FiveCubedMoments/FiveCubedMoments/Services/Summarization/SummarizerProvider.swift
@@ -1,12 +1,14 @@
 import Foundation
 
-private let useCloudKey = "useCloudSummarization"
-
 private let placeholderApiKey = "YOUR_KEY_HERE"
 
 /// Provides the current summarizer based on user settings.
 /// For testing, pass a fixed summarizer; otherwise reads UserDefaults.
 struct SummarizerProvider {
+    /// UserDefaults key for cloud summarization setting. Exposed for tests to avoid key drift.
+    static let useCloudUserDefaultsKey = "useCloudSummarization"
+
+    private static let useCloudKey = useCloudUserDefaultsKey
     private let fixedSummarizer: (any Summarizer)?
 
     init(fixedSummarizer: (any Summarizer)? = nil) {
@@ -18,7 +20,7 @@ struct SummarizerProvider {
         if let fixed = fixedSummarizer {
             return fixed
         }
-        let useCloud = UserDefaults.standard.object(forKey: useCloudKey) as? Bool ?? false
+        let useCloud = UserDefaults.standard.object(forKey: Self.useCloudKey) as? Bool ?? false
         if useCloud, ApiSecrets.cloudApiKey != placeholderApiKey {
             return CloudSummarizer(apiKey: ApiSecrets.cloudApiKey)
         }

--- a/FiveCubedMomentsTests/Features/Journal/JournalViewModelTests.swift
+++ b/FiveCubedMomentsTests/Features/Journal/JournalViewModelTests.swift
@@ -335,7 +335,7 @@ final class JournalViewModelTests: XCTestCase {
         )
 
         viewModel.loadEntry(for: now, using: context)
-        for index in 1...5 {
+        for index in 1...JournalViewModel.slotCount {
             _ = await viewModel.addGratitude("Gratitude \(index)")
             _ = await viewModel.addNeed("Need \(index)")
             _ = await viewModel.addPerson("Person \(index)")
@@ -375,13 +375,13 @@ final class JournalViewModelTests: XCTestCase {
         )
 
         viewModel.loadEntry(for: now, using: context)
-        for index in 1...5 {
+        for index in 1...JournalViewModel.slotCount {
             _ = await viewModel.addGratitude("Gratitude \(index)")
         }
         let sixth = await viewModel.addGratitude("Sixth gratitude")
 
         XCTAssertFalse(sixth)
-        XCTAssertEqual(viewModel.gratitudes.count, 5)
+        XCTAssertEqual(viewModel.gratitudes.count, JournalViewModel.slotCount)
     }
 
     func test_addNeed_atSlotLimit_returnsFalseAndDoesNotAdd() async throws {
@@ -394,13 +394,13 @@ final class JournalViewModelTests: XCTestCase {
         )
 
         viewModel.loadEntry(for: now, using: context)
-        for index in 1...5 {
+        for index in 1...JournalViewModel.slotCount {
             _ = await viewModel.addNeed("Need \(index)")
         }
         let sixth = await viewModel.addNeed("Sixth need")
 
         XCTAssertFalse(sixth)
-        XCTAssertEqual(viewModel.needs.count, 5)
+        XCTAssertEqual(viewModel.needs.count, JournalViewModel.slotCount)
     }
 
     func test_addPerson_atSlotLimit_returnsFalseAndDoesNotAdd() async throws {
@@ -413,13 +413,13 @@ final class JournalViewModelTests: XCTestCase {
         )
 
         viewModel.loadEntry(for: now, using: context)
-        for index in 1...5 {
+        for index in 1...JournalViewModel.slotCount {
             _ = await viewModel.addPerson("Person \(index)")
         }
         let sixth = await viewModel.addPerson("Sixth person")
 
         XCTAssertFalse(sixth)
-        XCTAssertEqual(viewModel.people.count, 5)
+        XCTAssertEqual(viewModel.people.count, JournalViewModel.slotCount)
     }
 
     private func makeInMemoryContext() throws -> ModelContext {

--- a/FiveCubedMomentsTests/Services/Summarization/CloudSummarizerTests.swift
+++ b/FiveCubedMomentsTests/Services/Summarization/CloudSummarizerTests.swift
@@ -107,7 +107,7 @@ final class CloudSummarizerTests: XCTestCase {
         XCTAssertTrue(result.isTruncated)
     }
 
-    func test_summarize_httpError_fallsBackToNLSummarizer() async throws {
+    func test_summarize_httpError_fallsBackToInjectedFallback() async throws {
         MockURLProtocol.mockResponse = { _ in
             let response = HTTPURLResponse(
                 url: URL(string: "https://example.com")!,
@@ -130,7 +130,7 @@ final class CloudSummarizerTests: XCTestCase {
         XCTAssertFalse(result.isTruncated)
     }
 
-    func test_summarize_invalidJSON_fallsBackToNLSummarizer() async throws {
+    func test_summarize_invalidJSON_fallsBackToInjectedFallback() async throws {
         MockURLProtocol.mockResponse = { _ in
             let data = Data("not valid json".utf8)
             let response = HTTPURLResponse(
@@ -154,7 +154,7 @@ final class CloudSummarizerTests: XCTestCase {
         XCTAssertFalse(result.isTruncated)
     }
 
-    func test_summarize_emptyContent_fallsBackToNLSummarizer() async throws {
+    func test_summarize_emptyContent_fallsBackToInjectedFallback() async throws {
         MockURLProtocol.mockResponse = { _ in
             let json: [String: Any] = [
                 "choices": [
@@ -185,7 +185,7 @@ final class CloudSummarizerTests: XCTestCase {
         XCTAssertFalse(result.isTruncated)
     }
 
-    func test_summarize_networkError_fallsBackToNLSummarizer() async throws {
+    func test_summarize_networkError_fallsBackToInjectedFallback() async throws {
         MockURLProtocol.mockResponse = { _ in
             (nil, nil, URLError(.notConnectedToInternet))
         }

--- a/FiveCubedMomentsTests/Services/Summarization/SummarizerProviderTests.swift
+++ b/FiveCubedMomentsTests/Services/Summarization/SummarizerProviderTests.swift
@@ -2,10 +2,8 @@ import XCTest
 @testable import FiveCubedMoments
 
 final class SummarizerProviderTests: XCTestCase {
-    private let userDefaultsKey = "useCloudSummarization"
-
     override func tearDown() {
-        UserDefaults.standard.removeObject(forKey: userDefaultsKey)
+        UserDefaults.standard.removeObject(forKey: SummarizerProvider.useCloudUserDefaultsKey)
         super.tearDown()
     }
 
@@ -19,7 +17,7 @@ final class SummarizerProviderTests: XCTestCase {
     }
 
     func test_currentSummarizer_withoutFixedSummarizer_UserDefaultsKeyAbsent_returnsNaturalLanguageSummarizer() {
-        UserDefaults.standard.removeObject(forKey: userDefaultsKey)
+        UserDefaults.standard.removeObject(forKey: SummarizerProvider.useCloudUserDefaultsKey)
         let provider = SummarizerProvider()
 
         let result = provider.currentSummarizer()
@@ -28,7 +26,7 @@ final class SummarizerProviderTests: XCTestCase {
     }
 
     func test_currentSummarizer_withoutFixedSummarizer_UserDefaultsFalse_returnsNaturalLanguageSummarizer() {
-        UserDefaults.standard.set(false, forKey: userDefaultsKey)
+        UserDefaults.standard.set(false, forKey: SummarizerProvider.useCloudUserDefaultsKey)
         let provider = SummarizerProvider()
 
         let result = provider.currentSummarizer()
@@ -37,7 +35,7 @@ final class SummarizerProviderTests: XCTestCase {
     }
 
     func test_currentSummarizer_UserDefaultsTrue_placeholderKey_returnsNL() {
-        UserDefaults.standard.set(true, forKey: userDefaultsKey)
+        UserDefaults.standard.set(true, forKey: SummarizerProvider.useCloudUserDefaultsKey)
         let provider = SummarizerProvider()
 
         let result = provider.currentSummarizer()

--- a/FiveCubedMomentsTests/TestDoubles/MockURLProtocol.swift
+++ b/FiveCubedMomentsTests/TestDoubles/MockURLProtocol.swift
@@ -26,9 +26,15 @@ final class MockURLProtocol: URLProtocol {
             client?.urlProtocol(self, didFailWithError: error)
             return
         }
-        if let response = response {
-            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        guard let response = response else {
+            let err = URLError(
+                .unknown,
+                userInfo: [NSLocalizedDescriptionKey: "Mock returned nil response and nil error"]
+            )
+            client?.urlProtocol(self, didFailWithError: err)
+            return
         }
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
         if let data = data {
             client?.urlProtocol(self, didLoad: data)
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Phase 4** from `docs/CODE_QUALITY_IMPLEMENTATION_PATH.md` — Test Additions.

## Changes

### 4.1 SummarizerProvider Tests
- `SummarizerProviderTests.swift`: Tests `currentSummarizer()` with fixed summarizer, UserDefaults key absent/false/true (placeholder API key falls back to NL).
- **Copilot feedback**: Exposed `SummarizerProvider.useCloudUserDefaultsKey` as single source of truth; tests use it instead of hardcoded string.

### 4.2 CloudSummarizer with Mock URLSession
- `MockURLProtocol.swift`: URLProtocol subclass to intercept requests and return canned responses. **Copilot feedback**: Fails explicitly when handler returns nil for both response and error.
- `CloudSummarizerTests.swift`: Success path, long-label truncation, HTTP error, invalid JSON, empty content, network error. Uses injectable fallback (`MockSummarizer`) for deterministic fallback assertions. **Copilot feedback**: Renamed tests from "fallsBackToNLSummarizer" to "fallsBackToInjectedFallback".
- `CloudSummarizer.swift`: Fallback parameter changed to `(any Summarizer)?` for test injection; defaults to `NaturalLanguageSummarizer()` when nil. **Copilot feedback**: Updated doc and log to clarify that NL is default but a different summarizer may be injected (e.g., for tests).

### 4.3 JournalViewModel completedToday
- `test_completedToday_withFullEntry_returnsTrue`: 5 gratitudes, 5 needs, 5 people, non-empty notes/reflections → `completedToday` true.
- `test_completedToday_withPartialEntry_returnsFalse`: Partial entry → `completedToday` false.

### 4.4 JournalViewModel slot limit
- `test_addGratitude_atSlotLimit_returnsFalseAndDoesNotAdd`
- `test_addNeed_atSlotLimit_returnsFalseAndDoesNotAdd`
- `test_addPerson_atSlotLimit_returnsFalseAndDoesNotAdd`
- **Copilot feedback**: Uses `JournalViewModel.slotCount` instead of hardcoded `1...5`.

## Validation

- `swiftlint lint` passes (0 errors; pre-existing warnings in JournalViewModelTests remain).
- Tests require macOS + Xcode to run; AGENTS.md documents this constraint.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed0eb4d1-2693-4bfa-b941-8e70226966cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed0eb4d1-2693-4bfa-b941-8e70226966cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

