### PR TITLE
Phase 5: Optional enhancements from CODE_QUALITY_IMPLEMENTATION_PATH

### DIFF
--- a/FiveCubedMoments/FiveCubedMoments/Data/Models/JournalEntry.swift
+++ b/FiveCubedMoments/FiveCubedMoments/Data/Models/JournalEntry.swift
@@ -50,6 +50,8 @@ final class JournalEntry {
     }
 
     /// Shared completion criteria used by JournalEntry and JournalViewModel.
+    /// An entry is complete when it has at least `slotCount` gratitudes, needs, and people,
+    /// plus non-empty (after trimming) bibleNotes and reflections.
     static func criteriaMet(
         gratitudesCount: Int,
         needsCount: Int,
@@ -66,5 +68,7 @@ final class JournalEntry {
             !reflectionsTrimmed.isEmpty
     }
 
+    /// Maximum number of items per chip section (gratitudes, needs, people).
+    /// The "5³" design means each section holds at most 5 items.
     static let slotCount = 5
 }

--- a/FiveCubedMoments/FiveCubedMoments/Data/Persistence/SwiftData/PersistenceController.swift
+++ b/FiveCubedMoments/FiveCubedMoments/Data/Persistence/SwiftData/PersistenceController.swift
@@ -7,6 +7,9 @@ final class PersistenceController {
 
     let container: ModelContainer
 
+    /// Creates the SwiftData container. On failure, calls `fatalError` because the app cannot
+    /// function without persistence. Future improvement: surface the error to the user
+    /// (e.g., show an error screen) instead of crashing for production resilience.
     private init(inMemory: Bool = false) {
         let schema = Schema([JournalEntry.self])
         let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: inMemory)

--- a/FiveCubedMoments/FiveCubedMoments/Features/Journal/ViewModels/JournalViewModel.swift
+++ b/FiveCubedMoments/FiveCubedMoments/Features/Journal/ViewModels/JournalViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Combine
+import Observation
 import SwiftData
 
 struct JournalExportPayload {
@@ -12,28 +13,29 @@ struct JournalExportPayload {
 }
 
 @MainActor
-final class JournalViewModel: ObservableObject {
-    @Published var entryDate: Date = .now
-    @Published var gratitudes: [JournalItem] = []
-    @Published var needs: [JournalItem] = []
-    @Published var people: [JournalItem] = []
-    @Published var bibleNotes: String = ""
-    @Published var reflections: String = ""
-    @Published private(set) var saveErrorMessage: String?
+@Observable
+final class JournalViewModel {
+    var entryDate: Date = .now
+    var gratitudes: [JournalItem] = []
+    var needs: [JournalItem] = []
+    var people: [JournalItem] = []
+    var bibleNotes: String = ""
+    var reflections: String = ""
+    private(set) var saveErrorMessage: String?
 
     static let slotCount = JournalEntry.slotCount
 
-    private let calendar: Calendar
-    private let nowProvider: () -> Date
-    private let repository: JournalRepository
-    private let summarizerProvider: SummarizerProvider
-    private let autosaveTrigger = PassthroughSubject<Void, Never>()
-    private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let calendar: Calendar
+    @ObservationIgnored private let nowProvider: () -> Date
+    @ObservationIgnored private let repository: JournalRepository
+    @ObservationIgnored private let summarizerProvider: SummarizerProvider
+    @ObservationIgnored private let autosaveTrigger = PassthroughSubject<Void, Never>()
+    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
 
-    private var modelContext: ModelContext?
-    private var journalEntry: JournalEntry?
-    private var hasLoadedToday = false
-    private var isHydrating = false
+    @ObservationIgnored private var modelContext: ModelContext?
+    @ObservationIgnored private var journalEntry: JournalEntry?
+    @ObservationIgnored private var hasLoadedToday = false
+    @ObservationIgnored private var isHydrating = false
 
     init(
         calendar: Calendar = .current,

--- a/FiveCubedMoments/FiveCubedMoments/Features/Journal/Views/JournalScreen.swift
+++ b/FiveCubedMoments/FiveCubedMoments/Features/Journal/Views/JournalScreen.swift
@@ -5,7 +5,7 @@ import UIKit
 
 struct JournalScreen: View {
     @Environment(\.modelContext) private var modelContext
-    @StateObject private var viewModel = JournalViewModel()
+    @State private var viewModel = JournalViewModel()
     @State private var shareableImage: ShareableImage?
     @State private var showShareError = false
     @State private var showSavedToPhotosToast = false

--- a/FiveCubedMoments/docs/CODE_QUALITY_IMPLEMENTATION_PATH.md
+++ b/FiveCubedMoments/docs/CODE_QUALITY_IMPLEMENTATION_PATH.md
@@ -204,14 +204,14 @@ identifier_name:
 
 ---
 
-### Phase 5: Optional Enhancements (Backlog)
+### Phase 5: Optional Enhancements ✅
 
 | # | Task | Notes |
 |---|------|-------|
-| 5.1 | Migrate to `@Observable` | iOS 17+; replace `ObservableObject` + `@Published` with `@Observable`. Reduces boilerplate. |
-| 5.2 | Consolidate ViewModel add/update/remove | Generic `addItem(_:section:)` etc. — only if it clearly improves readability. AGENTS.md cautions against abstraction for its own sake. |
-| 5.3 | Document assumptions | Add comments to `JournalEntry.slotCount`, `criteriaMet`; document "gratitudes count ≤ 5" in design docs. |
-| 5.4 | PersistenceController error handling | Consider surfacing to user instead of `fatalError` for production resilience. |
+| 5.1 | Migrate to `@Observable` | ✅ Done. Replaced `ObservableObject` + `@Published` with `@Observable` in JournalViewModel. JournalScreen uses `@State` instead of `@StateObject`. |
+| 5.2 | Consolidate ViewModel add/update/remove | Skipped. AGENTS.md cautions against abstraction for its own sake; current explicit methods are clear. |
+| 5.3 | Document assumptions | ✅ Done. Added comments to `JournalEntry.slotCount`, `criteriaMet`; documented "gratitudes count ≤ 5" in DESIGN_SPEC.md. |
+| 5.4 | PersistenceController error handling | ✅ Documented. Added comment explaining `fatalError` rationale and future improvement (surface to user). |
 
 ---
 

--- a/FiveCubedMoments/docs/DESIGN_SPEC.md
+++ b/FiveCubedMoments/docs/DESIGN_SPEC.md
@@ -28,6 +28,8 @@ For Gratitudes, Needs, and People To Pray For:
 4. Tag appears as chip; input **clears**; next slot ready
 5. Repeat until 5 items per section
 
+**Assumption:** Gratitudes, needs, and people each have a maximum of 5 items (`JournalEntry.slotCount`). The ViewModel and UI enforce this limit.
+
 ---
 
 ## 3. Summarization into Chips


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Phase 5 (Optional Enhancements) from `CODE_QUALITY_IMPLEMENTATION_PATH.md`.

## Changes

### 5.1 Migrate to @Observable
- Replaced `ObservableObject` + `@Published` with `@Observable` in `JournalViewModel`
- Added `@ObservationIgnored` for internal state (cancellables, modelContext, journalEntry, etc.) to avoid unnecessary observation
- `JournalScreen`: changed `@StateObject` to `@State` for view model ownership
- Import `Observation` for `@Observable` macro

### 5.2 ViewModel consolidation
- **Skipped** per AGENTS.md: "only if it clearly improves readability" — current explicit `addGratitude`/`addNeed`/`addPerson` methods are clear

### 5.3 Document assumptions
- `JournalEntry.slotCount`: Added comment explaining max 5 items per chip section
- `JournalEntry.criteriaMet`: Added comment explaining completion criteria
- `DESIGN_SPEC.md`: Documented assumption "gratitudes, needs, and people each have a maximum of 5 items"

### 5.4 PersistenceController error handling
- Added doc comment explaining `fatalError` rationale and future improvement (surface to user instead of crashing)

## Validation
- `swiftlint lint` passes (no new violations)
- Unit tests unchanged (JournalViewModel API preserved)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cffa2777-f834-4e97-91b3-d7dc0b767dc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cffa2777-f834-4e97-91b3-d7dc0b767dc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

