### PR TITLE
Add product strategy review document

### DIFF
--- a/FiveCubedMoments/docs/PRODUCT_STRATEGY_REVIEW_2026-03-17.md
+++ b/FiveCubedMoments/docs/PRODUCT_STRATEGY_REVIEW_2026-03-17.md
@@ -1,0 +1,789 @@
+# Product Strategy Review — Five Cubed Moments
+
+Date: 2026-03-17
+
+## Scope and constraints
+
+This document turns the repository review into a practical next-step deliverable for product, design, and engineering.
+
+It includes:
+
+- a blunt assessment of current competitiveness
+- the biggest blockers and missing pieces
+- a prioritized roadmap
+- a positioning and messaging draft
+- a feature-by-feature teardown against named competitors
+- practical operating suggestions
+
+Environment constraint: this review is based on repository analysis plus public competitor feature surfaces. The Linux review environment cannot run the iOS app in Simulator, so this is not a live UX walkthrough.
+
+---
+
+## Executive summary
+
+Five Cubed Moments is a thoughtful, calm, structured journaling product with a real product idea inside it.
+
+It is not yet a strong competitor in the broader mindfulness or journaling category.
+
+Today, the app is best understood as:
+
+- a focused guided reflection journal
+- with one distinctive ritual
+- built on a cleaner technical foundation than its current market position
+
+The strongest part of the product is the core daily structure:
+
+- 5 gratitudes
+- 5 needs
+- 5 people in mind
+- reading notes
+- reflections
+
+The weakest part of the product is what happens after the user writes.
+
+Right now, the app helps users capture reflection, but it does not yet help them compound value from reflection. There is very little in the current product that turns past writing into insight, continuity, or transformation over time.
+
+### Bottom-line judgment
+
+- **Foundation quality:** good for an early product
+- **Differentiation quality:** promising but underdeveloped
+- **Retention power:** likely weak to moderate
+- **Trust/readiness for primary journaling use:** not strong enough yet
+- **Competitiveness versus established apps:** low in breadth, potentially moderate in a narrow structured-reflection niche if the team sharpens focus
+
+### The biggest blocker
+
+The biggest blocker is not visual polish or code quality.
+
+The biggest blocker is that the product asks the user to do meaningful emotional work, but does not yet return enough value from that work.
+
+The second-biggest blocker is trust:
+
+- no visible sync story
+- no structured export/import story
+- weak long-term ownership signal for journal data
+
+---
+
+## Current-state truth
+
+## What is genuinely good
+
+### 1) The product has a real ritual
+
+The app is not a blank page. It gives users a specific reflective structure that combines:
+
+- gratitude
+- self-awareness around needs
+- attention to other people
+
+That is better than generic journaling for users who want help getting started.
+
+### 2) The product tone is unusually calm
+
+The app feels intentionally gentle rather than productivity-driven or aggressively gamified. That is a meaningful advantage for a reflective product.
+
+### 3) The flow is low-friction
+
+Today is the default destination. Entries auto-create. Edits auto-save. The app does not force the user through a lot of setup to get value.
+
+### 4) The product has a stronger technical foundation than many early apps
+
+The repository shows:
+
+- a clean SwiftUI + SwiftData app shell
+- a real view model and service structure
+- tests around key behavior
+- a clear effort to keep the code readable and boring in the good sense
+
+This matters because it means the next major problem is not basic implementation quality.
+
+## Where the product is weak
+
+### 1) The category framing is too broad
+
+If Five Cubed Moments is presented as a "mindfulness app," it is weak.
+
+It does not currently compete on:
+
+- meditation
+- breathing
+- mood coaching
+- guided audio
+- therapeutic programs
+
+It is much more accurately a structured reflection journal.
+
+### 2) The app captures entries, but does not yet create compounding value
+
+The app currently helps users write.
+
+It does not yet strongly help users:
+
+- notice patterns
+- revisit themes
+- understand recurring needs
+- reconnect with important people or recurring gratitudes
+- continue an evolving narrative
+
+This is the core product gap.
+
+### 3) The product surface is thin
+
+The app currently has a small set of features:
+
+- Today
+- History
+- Settings
+- reminders
+- streaks
+- image sharing
+
+That is enough for an MVP, but not enough to feel materially better than stronger incumbents.
+
+### 4) The structure is distinctive, but also somewhat heavy
+
+The 5-5-5 structure is a differentiator, but it can also feel demanding.
+
+Completion currently implies a fairly high bar. For many users, that risks turning reflection into obligation.
+
+### 5) The trust layer is not yet good enough for a primary journal
+
+People do not want to wonder whether their private reflections are trapped on one device or only exportable as images.
+
+For a journaling product, trust is product.
+
+---
+
+## Competitiveness assessment
+
+## Short answer
+
+For a simple mindfulness app, Five Cubed Moments is **not competitive**.
+
+For a narrow guided reflection niche, it is **promising but unfinished**.
+
+## Longer answer
+
+It loses badly on breadth against major products because it does not yet offer:
+
+- deep history/review experiences
+- search and resurfacing
+- stronger insights
+- broad prompt systems
+- media-rich capture
+- sync and backup confidence
+- deeper retention loops
+
+But it does have a potentially ownable wedge:
+
+**a calm, structured, relationship-aware daily reflection ritual**
+
+That wedge is only valuable if the team commits to it and builds the product around it.
+
+## Overall competitive grade
+
+### Against broad journaling leaders
+
+- **Breadth:** weak
+- **Polish breadth:** weak
+- **Data trust:** weak
+- **Insight value:** weak
+- **Emotional tone:** strong
+- **Clarity of ritual:** strong
+
+### Against lightweight note-taking substitutes
+
+- **Guidance:** stronger
+- **Habit framing:** stronger
+- **Reflective structure:** much stronger
+- **Flexibility:** weaker
+
+That means the app is currently better than a notes app for structured reflection, but not yet strong enough to become a user's default journaling home.
+
+---
+
+## Biggest blocker and what is lacking
+
+## Biggest blocker
+
+### The product does not yet produce enough "return on reflection"
+
+The user invests attention every day, but the app does not yet pay that attention back in a meaningful way.
+
+That is why retention risk is high.
+
+## What is lacking most
+
+### 1) Review and insight layer
+
+Missing capabilities:
+
+- weekly review
+- recurring theme detection
+- recurring needs summaries
+- people-focused resurfacing
+- "what changed?" summaries
+- continuity prompts based on prior writing
+
+### 2) Trust and ownership layer
+
+Missing capabilities:
+
+- sync or backup confidence
+- structured export/import
+- clearer privacy posture
+- optional lock/privacy controls
+
+### 3) Activation and habit design layer
+
+Missing capabilities:
+
+- onboarding that teaches the ritual gradually
+- lighter success states for busy days
+- better first-week guidance
+- more nuanced reminder and return flows
+
+### 4) Flexible reflection modes
+
+Missing capabilities:
+
+- gentler mode for low-energy days
+- weekly reflection mode
+- optional prompts beyond the default structure
+- ways to review without always writing a full new entry
+
+---
+
+## Strategic recommendation
+
+Do not try to out-Day One Day One.
+
+Do not try to out-Stoic Stoic.
+
+Do not try to become a generic mindfulness super-app.
+
+Instead, build Five Cubed Moments into the best product for:
+
+**people who want a calm, structured daily reflection ritual that helps them notice gratitude, name needs, and stay connected to the people who matter.**
+
+That is specific enough to own.
+
+---
+
+## Prioritized roadmap
+
+This roadmap is organized by strategic priority rather than calendar estimate.
+
+## Decision table
+
+| Priority | Investment area | Why now | User impact | Strategic role |
+|---|---|---|---|---|
+| 1 | Review and insight loop | Fixes the biggest blocker directly | High | Retention and differentiation |
+| 2 | Trust and ownership layer | Removes adoption anxiety for meaningful journaling | High | Trust and long-term viability |
+| 3 | Activation and habit design | Makes the ritual easier to start and sustain | Medium to High | Activation and early retention |
+| 4 | Flexible reflection depth | Broadens usefulness without losing the wedge | Medium | Expansion and habit durability |
+
+## Priority 1: Build the review and insight loop
+
+### Goal
+
+Turn writing into compounding value.
+
+### Why this is first
+
+This is the highest-leverage product investment because it directly addresses the biggest blocker: weak return on reflection.
+
+### Features
+
+1. **Review tab or mode**
+   - evolve `History` into `Review`
+   - keep chronological browsing, but add insight-oriented summaries
+
+2. **Weekly review**
+   - recurring gratitudes
+   - recurring needs
+   - people who showed up repeatedly
+   - highlights from reflections
+
+3. **Smart resurfacing**
+   - "You mentioned rest three times this week"
+   - "You have been thinking about Alex a lot lately"
+   - "Here is something you wrote last Tuesday that connects to today"
+
+4. **Prompt continuity**
+   - suggest next reflection prompts from prior entries
+   - ask follow-up questions instead of generic prompts
+
+### Success signal
+
+- users return to review prior entries, not just create new ones
+- week-over-week retention improves
+- users report that the app helps them notice patterns, not just record thoughts
+
+## Priority 2: Build the trust layer
+
+### Goal
+
+Make the app safe to adopt as a real journal.
+
+### Why this is second
+
+No matter how good reflection becomes, many users will not trust a journaling app without strong ownership signals.
+
+### Features
+
+1. **Structured export**
+   - export all entries as machine-readable data
+   - optionally export human-readable text or PDF
+
+2. **Import**
+   - allow restore from export
+
+3. **Sync/backup**
+   - simplest credible option first
+   - prioritize user confidence over architectural ambition
+
+4. **Privacy clarity**
+   - clear in-product explanation of local vs cloud behavior
+   - especially for cloud summarization
+
+5. **Optional app lock**
+   - useful for private journaling trust
+
+### Success signal
+
+- users feel safe storing meaningful reflections in the app
+- support anxiety around losing entries decreases
+
+## Priority 3: Improve activation and habit design
+
+### Goal
+
+Make the ritual easier to start and easier to keep.
+
+### Why this matters
+
+The current structure is differentiated, but can feel demanding.
+
+### Features
+
+1. **Guided onboarding**
+   - explain the value of gratitude, needs, and people in mind
+   - teach the structure instead of dumping the full template immediately
+
+2. **Lighter completion states**
+   - redefine "success" for low-energy days
+   - preserve 5 cubed as an aspirational full session
+
+3. **First-week coaching**
+   - simple educational messages
+   - examples of good entries
+   - encouragement around imperfection
+
+4. **Better reminder strategy**
+   - adaptive reminder copy
+   - missed-day recovery prompts
+
+### Success signal
+
+- higher first-week retention
+- better completion rates without harsher pressure
+
+## Priority 4: Add flexible reflection depth
+
+### Goal
+
+Broaden usefulness without losing the calm, structured core.
+
+### Features
+
+1. **Optional modes**
+   - quick reset
+   - full 5 cubed
+   - weekly reflection
+
+2. **Prompt packs**
+   - relationship reflection
+   - gratitude depth
+   - needs clarity
+
+3. **Richer review artifacts**
+   - monthly summary cards
+   - recurring theme snapshots
+
+### Success signal
+
+- users with different energy levels still stay in the product
+
+## Resource allocation recommendation
+
+If the team needs a rough strategic split for the next major cycle:
+
+- **50%** review and insight layer
+- **25%** trust and data ownership
+- **15%** onboarding and habit design
+- **10%** polish and adjacent enhancements
+
+That is a strategic weighting, not an engineering estimate.
+
+---
+
+## Positioning and messaging doc
+
+## Category choice
+
+Do **not** position this primarily as:
+
+- a generic mindfulness app
+- an AI journal
+- a meditation app
+
+Position it as:
+
+**a guided reflection journal**
+
+or more specifically:
+
+**a calm daily reflection ritual for gratitude, needs, and people in mind**
+
+## Ideal customer profile
+
+Primary user:
+
+- wants more structure than a blank journal
+- wants a calm, private reflection experience
+- is interested in gratitude and self-awareness
+- values relational reflection, not just self-tracking
+- is likely put off by productivity-style wellness apps
+
+Secondary user:
+
+- already journals inconsistently
+- wants help building a small reflective habit
+- values simplicity more than feature breadth
+
+Poor-fit user:
+
+- wants meditation content
+- wants mood analytics first
+- wants free-form power journaling
+- wants rich media capture as the main use case
+
+## Positioning statement
+
+For people who want a calmer way to reflect each day, Five Cubed Moments is a guided reflection journal that helps you notice gratitude, name what you need, and remember the people who matter.
+
+Unlike blank journaling apps or feature-heavy wellness platforms, it gives you a gentle daily structure without turning reflection into noise.
+
+## Core promise
+
+**Notice what matters, every day.**
+
+## Messaging pillars
+
+### 1) Calm structure
+
+You do not need to figure out what to write.
+
+### 2) Reflection with emotional honesty
+
+Not just gratitude. Also needs, people, and what you are learning.
+
+### 3) Gentle consistency
+
+Designed to support a daily rhythm without feeling punitive.
+
+### 4) Private and personal
+
+Your reflections should feel safe and personal, not performative.
+
+## Messaging to avoid
+
+Avoid claims like:
+
+- "all-in-one mindfulness platform"
+- "AI-powered transformation coach"
+- "best journaling app"
+
+Those claims are not credible from the current product state.
+
+## Draft App Store / site copy
+
+### Short description
+
+A calm guided journal for gratitude, needs, and people in mind.
+
+### One-line value proposition
+
+A gentle daily reflection ritual that helps you notice what matters.
+
+### Longer marketing paragraph
+
+Five Cubed Moments turns daily reflection into a simple, welcoming rhythm. Capture five gratitudes, five needs, five people in mind, plus what you are learning and feeling. It is structured enough to guide you, calm enough to keep using, and personal enough to matter.
+
+### Three-message homepage framing
+
+1. **Reflect with structure**
+   - Gratitude, needs, people, notes, and reflection in one quiet flow.
+
+2. **Build a gentle rhythm**
+   - Daily reminders and supportive progress without heavy gamification.
+
+3. **See what keeps showing up**
+   - Turn your entries into patterns, themes, and meaningful review.
+
+The third message should become stronger as the product evolves.
+
+## Naming note
+
+"FCM" should not be the lead in user-facing marketing. The acronym has no meaning to new users.
+
+Lead with the full product name plus a clear descriptor.
+
+---
+
+## Feature-by-feature teardown versus named competitors
+
+Competitors chosen:
+
+- Apple Journal
+- Day One
+- Stoic
+
+These three cover:
+
+- platform-default journaling
+- premium journaling depth
+- guided reflection and wellness overlap
+
+## Summary view
+
+| Capability | Five Cubed Moments | Apple Journal | Day One | Stoic |
+|---|---|---|---|---|
+| Distinct daily structure | Strong | Medium | Medium | Strong |
+| Free-form flexibility | Weak | Medium | Strong | Strong |
+| Guided prompts | Weak | Medium | Medium | Strong |
+| Review and insights | Weak | Medium | Medium | Strong |
+| Search / resurfacing | Weak | Medium | Strong | Medium |
+| Rich media capture | Weak | Strong | Strong | Medium |
+| Privacy trust perception | Medium | Strong | Strong | Medium to Strong |
+| Backup / sync confidence | Weak | Strong | Strong | Strong |
+| Relationship-oriented reflection | Strong | Medium | Weak | Medium |
+| Calm tone | Strong | Strong | Medium | Medium |
+| Competitive breadth | Weak | Strong | Strong | Strong |
+
+## Competitor 1: Apple Journal
+
+### Where Apple Journal is stronger
+
+- better ambient capture and suggestions
+- better use of photos, locations, and device context
+- more mature insight and streak surface
+- stronger trust perception through platform integration
+- broader discovery and search expectations
+
+### Where Five Cubed Moments is stronger
+
+- clearer deliberate ritual
+- more explicit focus on needs and people
+- more intentional structure for users who dislike blank-page journaling
+
+### Strategic takeaway
+
+Do not try to beat Apple Journal on broad native integration.
+
+Beat it by being more intentional and more emotionally structured.
+
+## Competitor 2: Day One
+
+### Where Day One is stronger
+
+- far deeper journaling feature set
+- much stronger archive value
+- sync and long-term ownership confidence
+- richer media support
+- stronger sense of journaling permanence
+
+### Where Five Cubed Moments is stronger
+
+- lower cognitive load
+- gentler daily ritual
+- clearer habit entry point for users who want guidance
+
+### Strategic takeaway
+
+Do not compete on completeness.
+
+Compete on guided clarity and emotional simplicity.
+
+## Competitor 3: Stoic
+
+### Where Stoic is stronger
+
+- broader self-reflection toolkit
+- better guided prompt system
+- stronger perceived personal coaching
+- stronger review, mood, and insight loops
+- wider wellness product surface
+
+### Where Five Cubed Moments is stronger
+
+- simpler mental model
+- less feature noise
+- less self-optimization energy
+- warmer relational framing through "people in mind"
+
+### Strategic takeaway
+
+If Stoic feels like a self-improvement operating system, Five Cubed Moments should feel like a gentle daily reset.
+
+## What this teardown says clearly
+
+Five Cubed Moments should not try to win on breadth.
+
+It should win on:
+
+- calm
+- clarity
+- structure
+- emotional honesty
+- relationship-aware reflection
+- compounding review value
+
+---
+
+## Recommended product principles
+
+1. **Return value from reflection**
+   - every week, the product should help the user see something they would not have seen alone
+
+2. **Make calm a feature**
+   - avoid noisy growth tactics and overstuffed wellness tropes
+
+3. **Keep the core ritual intact**
+   - do not dilute the wedge into generic journaling
+
+4. **Lower pressure, not meaning**
+   - support low-energy days without making the product shallow
+
+5. **Treat trust as product, not infrastructure**
+   - backup, export, privacy, and control are part of the value proposition
+
+---
+
+## Practical operating suggestions
+
+## Product practice
+
+### 1) Start measuring real retention behavior
+
+Instrument at least:
+
+- first entry started
+- first entry completed
+- reminder opt-in
+- day-2 return
+- day-7 return
+- section drop-off
+- review usage once review exists
+
+### 2) Talk to the right users
+
+Interview users who:
+
+- want structure
+- do not maintain a blank journal consistently
+- want something calmer than performance-driven self-tracking
+
+Do not overweight feedback from journaling power users if the product is not meant for them.
+
+### 3) Test lighter ritual variants
+
+Experiment with:
+
+- 1-1-1 quick mode
+- 3-3-3 medium mode
+- full 5 cubed mode
+
+The point is not to abandon the brand idea. The point is to reduce intimidation and increase habit continuity.
+
+### 4) Treat reminders as part of the product voice
+
+Reminder copy should sound supportive, not nagging.
+
+### 5) Make review emotionally useful, not just analytic
+
+The right review question is not only:
+
+- "what did you write?"
+
+It is also:
+
+- "what does this reveal about your season right now?"
+
+## Engineering practice
+
+### 1) Do not overspend on architecture churn right now
+
+The codebase already looks good enough to support the next product moves.
+
+### 2) Spend engineering effort where product leverage is highest
+
+Best product-technical investments:
+
+- review surfaces
+- structured export/import
+- sync/backup confidence
+- onboarding and success-state flexibility
+
+### 3) Be careful with cloud AI
+
+Cloud summarization is currently a small utility feature. Keep privacy posture explicit and do not let it become a vague marketing crutch.
+
+---
+
+## Recommended next deliverables after this review
+
+If the team wants to move directly from strategy to execution, the next useful artifacts are:
+
+1. **Review tab product spec**
+   - user stories
+   - information architecture
+   - summary logic
+   - UI states
+
+2. **Trust layer spec**
+   - export/import
+   - backup/sync path
+   - privacy messaging
+
+3. **Activation redesign**
+   - onboarding
+   - lighter completion model
+   - first-week user journey
+
+4. **App Store messaging draft**
+   - screenshots
+   - subtitle options
+   - product description
+   - launch messaging
+
+---
+
+## Source basis
+
+This strategy review is based on:
+
+- the current repository state
+- public README and planning docs
+- current app feature surface visible in code
+- public feature surfaces of Apple Journal, Day One, and Stoic
+
+Public competitor references used:
+
+- Apple Journal: https://support.apple.com/guide/iphone/build-a-journaling-habit-iph70107aec2/ios
+- Day One: https://dayoneapp.com/features
+- Stoic: https://www.getstoic.com/features
+
+This document intentionally favors clarity over hedging. It is meant to help the team make sharper choices, not to flatter the current state.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a new product strategy review document in `FiveCubedMoments/docs`
- include a blunt competitiveness assessment, biggest blockers, and what is lacking
- include a prioritized roadmap, positioning and messaging guidance, and a feature-by-feature teardown versus Apple Journal, Day One, and Stoic
- include practical product and engineering suggestions plus recommended follow-up deliverables

## Testing
- documentation-only change; no runtime or simulator testing required in this Linux environment
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ec81313-7fb1-44a9-b415-d5bc603a058d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ec81313-7fb1-44a9-b415-d5bc603a058d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

