### PR TITLE
TestFlight readiness: app icon, privacy manifest, checklist

### DIFF
--- a/GraceNotes/GraceNotes/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/GraceNotes/GraceNotes/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,7 +1,7 @@
 {
   "images" : [
     {
-      "filename" : "grace-notes-icon-1024x1024.png",
+      "filename" : "five-cubed-moments-icon-1024x1024-2.png",
       "idiom" : "universal",
       "platform" : "ios",
       "size" : "1024x1024"

--- a/GraceNotes/GraceNotes/PrivacyInfo.xcprivacy
+++ b/GraceNotes/GraceNotes/PrivacyInfo.xcprivacy
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/GraceNotes/docs/testflight-readiness.md
+++ b/GraceNotes/docs/testflight-readiness.md
@@ -1,0 +1,125 @@
+# TestFlight Readiness Checklist
+
+This document captures what needs to be done to ship the first TestFlight build of Grace Notes.
+
+---
+
+## Done (Code / Project)
+
+| Item | Status |
+|------|--------|
+| App Icon filename | Fixed: `Contents.json` now references `five-cubed-moments-icon-1024x1024-2.png` (was pointing to non-existent `grace-notes-icon-1024x1024.png`) |
+| Privacy manifest | Added `PrivacyInfo.xcprivacy` with UserDefaults declaration (CA92.1) — required for App Store since May 2024 |
+| Bundle ID | `com.gracenotes.GraceNotes` |
+| Display name | "Grace Notes" |
+| Category | Lifestyle |
+| Deployment target | iOS 17.0 |
+| Signing | Automatic, DEVELOPMENT_TEAM = C2ST94AYSS |
+| Entitlements | iCloud, CloudKit, push (aps-environment) |
+| Info.plist | NSPhotoLibraryAddUsageDescription, UIBackgroundModes (remote-notification), UIAppFonts |
+
+---
+
+## You Must Do (macOS + Xcode)
+
+### 1. Verify / fix development team
+
+- Open the project in Xcode and confirm **Signing & Capabilities** uses your Apple Developer team.
+- If `C2ST94AYSS` is not your team, change it in the project settings.
+
+### 2. Archive and upload
+
+1. Select the **GraceNotes** scheme (not Demo).
+2. Choose **Any iOS Device (arm64)** or a connected device as the destination.
+3. **Product → Archive**.
+4. When the Organizer opens: **Distribute App** → **App Store Connect** → **Upload**.
+5. Follow the prompts (automatic signing, default options).
+
+### 3. Optional: Bump version before first TestFlight
+
+- Current: `MARKETING_VERSION = 0.3.2`, `CURRENT_PROJECT_VERSION = 1`
+- Branch context: `release/0.3.3` / `cursor/app-store-publishing-limitations-dddf`
+- For first TestFlight you can keep 0.3.2 build 1, or align with roadmap (e.g. 0.3.3 build 1).
+
+---
+
+## You Must Do (App Store Connect)
+
+### 4. Create the app record (if new)
+
+1. [App Store Connect](https://appstoreconnect.apple.com) → **My Apps** → **+** → **New App**.
+2. Platform: iOS.
+3. Name: **Grace Notes**.
+4. Primary language: English.
+5. Bundle ID: select `com.gracenotes.GraceNotes`.
+6. SKU: any unique string (e.g. `gracenotes-001`).
+
+### 5. Wait for build processing
+
+- After upload, the build usually processes in 15–30 minutes.
+- You’ll get an email when it’s ready.
+
+### 6. Configure TestFlight
+
+1. Open the app → **TestFlight**.
+2. Select the build.
+3. **Export compliance**: typically **No** (app uses only standard encryption).
+4. **Advertising identifier (IDFA)**: **No** (Grace Notes does not use IDFA).
+5. Add **Beta App Description** (what testers should focus on).
+6. Add **Test Information** if using external testers (contact info, what to test).
+
+### 7. Add internal testers
+
+- **Internal testing**: add people from your App Store Connect team (up to 100).
+- No Beta App Review; they get the build shortly after processing.
+
+### 8. External testers (optional)
+
+- Add external testers or groups.
+- Submit for **Beta App Review**.
+- Provide Test Information (description, contact email).
+
+---
+
+## Pre-submit Checks
+
+| Check | Notes |
+|-------|-------|
+| Build destination | Use "Any iOS Device" or a real device for Archive; Simulator builds cannot be uploaded |
+| Scheme | Use **GraceNotes**, not GraceNotes (Demo) |
+| Cloud summarization | Uses placeholder `YOUR_KEY_HERE` → falls back to on-device summarization |
+
+---
+
+## If PrivacyInfo.xcprivacy Is Not in the Bundle
+
+If the build succeeds but App Store Connect flags a missing privacy manifest:
+
+1. In Xcode, right-click the **GraceNotes** group.
+2. **Add Files to "GraceNotes"**.
+3. Select `GraceNotes/PrivacyInfo.xcprivacy`.
+4. Ensure the **GraceNotes** target is checked.
+5. Re-archive and upload.
+
+---
+
+## SwiftLint
+
+- Four style warnings (line length, file length) — non-blocking for TestFlight.
+- Run `swiftlint lint` or `make lint` before release if you want to clean these up.
+
+---
+
+## Summary
+
+**Code changes applied:**
+
+- Fixed App Icon reference in `AppIcon.appiconset/Contents.json`.
+- Added `PrivacyInfo.xcprivacy` with UserDefaults API declaration.
+
+**Your responsibilities:**
+
+- Archive and upload on macOS with Xcode.
+- Create/configure the app in App Store Connect.
+- Answer export compliance and IDFA in TestFlight.
+- Add testers and start testing.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Prepares Grace Notes for the first TestFlight build by addressing blockers and documenting the process.

## Changes

### Code / project
- **App Icon**: Fixed `AppIcon.appiconset/Contents.json` to reference the actual image file (`five-cubed-moments-icon-1024x1024-2.png`) instead of the non-existent `grace-notes-icon-1024x1024.png`. Without this fix, archive would fail or produce an invalid icon.
- **Privacy manifest**: Added `PrivacyInfo.xcprivacy` with UserDefaults API declaration (CA92.1). Required for App Store Connect since May 2024 when using UserDefaults.

### Documentation
- **TestFlight checklist**: Added `GraceNotes/docs/testflight-readiness.md` with end-to-end steps: what’s done in code, what you must do in Xcode (archive/upload), and what you must do in App Store Connect (create app, configure TestFlight, add testers).

## Status

- SwiftLint: 4 existing warnings (non-blocking)
- Scheme: GraceNotes (not Demo) is correct for archiving
- Signing: DEVELOPMENT_TEAM = C2ST94AYSS — verify this is your team in Xcode before archiving

## Next steps (outside this PR)

1. Open in Xcode, confirm signing team.
2. Product → Archive with "Any iOS Device".
3. Distribute App → App Store Connect → Upload.
4. In App Store Connect: create app (if new), configure TestFlight, answer export compliance/IDFA, add testers.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62a3da59-70df-4fcc-a67f-7450d28b5d81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62a3da59-70df-4fcc-a67f-7450d28b5d81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

