### PR TITLE
docs: finalize CHANGELOG for 0.5.0 build 8 ship

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 Marketing version **0.5.0** ships as successive **builds** (TestFlight / App Store); git tags **`v0.5.0+{build}`**. GitHub milestones **0.5.2**, **0.5.3**, etc. name **scope lanes**, not separate marketing versions — see `GraceNotes/docs/07-release-roadmap.md`. Older docs or issues may still mention interim labels (**0.5.1**, **0.5.2**); **ship truth** is **0.5.0 + build** below.
 
-### Build 8 — Unreleased
+### Build 8 — 2026-03-28
 
-Work tracked toward milestone **0.5.2** (Settings cohesion and insight follow-through); ships as marketing **0.5.0**, next **bundle** increment at cut time (tag e.g. **`v0.5.0+8`**).
+Work tracked toward milestone **0.5.2** (Settings cohesion and insight follow-through); shipped as marketing **0.5.0** / bundle **8** (git tag **`v0.5.0+8`**).
 
 ### Changed
 


### PR DESCRIPTION
## Summary

Finalize **Build 8** in `CHANGELOG.md`: replace **Unreleased** with ship date **2026-03-28** and update the intro to reflect shipped **0.5.0** / bundle **8** (`v0.5.0+8`).

## Context

`v0.5.0+8` is already pushed as an annotated tag on commit `bc331b4`. Merging this PR aligns `main` on GitHub with that tip. Prefer **merge** or **rebase** if you want `main` to include the same commit as the tag; **squash** would add a new SHA and you would need to move or replace the tag.

## Verification

- Documentation-only change; no app code.
- `swiftlint` unchanged (no Swift edits).

Made with [Cursor](https://cursor.com)