### PR TITLE
Today journal: completion pill icons + Today nav title (#147, #148)

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalTodayOrientationPolicy.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalTodayOrientationPolicy.swift
@@ -14,7 +14,7 @@ import Foundation
 enum JournalTodayOrientationPolicy {
 
     struct Inputs: Equatable {
-        /// `true` when `JournalScreen` shows Today's entry (`entryDate == nil`).
+        /// `true` when `JournalScreen` shows Today (`entryDate == nil`).
         var isTodayEntry: Bool
         var isRunningUITests: Bool
         var hasSeenPostSeedJourney: Bool

--- a/GraceNotes/GraceNotes/Features/Journal/Views/JournalCompletionPill.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/JournalCompletionPill.swift
@@ -5,6 +5,7 @@ struct JournalCompletionPill: View {
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+    @ScaledMetric(relativeTo: .body) private var completionTierIconLength: CGFloat = 17
 
     let completionLevel: JournalCompletionLevel
     let celebratingLevel: JournalCompletionLevel?
@@ -15,10 +16,7 @@ struct JournalCompletionPill: View {
 
     var body: some View {
         pillLabel
-            .font(AppTheme.warmPaperMetaEmphasis)
-            .lineLimit(dynamicTypeSize.isAccessibilitySize ? 3 : 2)
             .fixedSize(horizontal: false, vertical: true)
-            .multilineTextAlignment(.leading)
             .padding(.horizontal, AppTheme.spacingRegular)
             .padding(.vertical, AppTheme.spacingTight)
             .frame(minHeight: 44)
@@ -56,24 +54,47 @@ struct JournalCompletionPill: View {
         celebratingLevel == completionLevel && completionLevel != .empty
     }
 
-    @ViewBuilder
     private var pillLabel: some View {
+        HStack(alignment: .center, spacing: AppTheme.spacingTight) {
+            Image(ReviewRhythmFormatting.assetName(for: completionLevel))
+                .renderingMode(.template)
+                .resizable()
+                .scaledToFit()
+                .frame(width: completionTierIconLength, height: completionTierIconLength)
+                .accessibilityHidden(true)
+            Text(localizedCompletionTitle)
+                .font(AppTheme.warmPaperMetaEmphasis)
+                .lineLimit(dynamicTypeSize.isAccessibilitySize ? 3 : 2)
+                .multilineTextAlignment(.leading)
+        }
+        .foregroundStyle(completionLabelForeground)
+    }
+
+    private var localizedCompletionTitle: String {
         switch completionLevel {
         case .empty:
-            Text(String(localized: "Empty"))
-                .foregroundStyle(AppTheme.journalTextMuted)
+            String(localized: "Empty")
         case .started:
-            Text(String(localized: "Started"))
-                .foregroundStyle(AppTheme.journalQuickCheckInText)
+            String(localized: "Started")
         case .growing:
-            Text(String(localized: "Growing"))
-                .foregroundStyle(AppTheme.journalStandardText)
+            String(localized: "Growing")
         case .balanced:
-            Text(String(localized: "Balanced"))
-                .foregroundStyle(AppTheme.journalStandardText)
+            String(localized: "Balanced")
         case .full:
-            Text(String(localized: "Full"))
-                .foregroundStyle(AppTheme.journalFullText)
+            String(localized: "Full")
+        }
+    }
+
+    private var completionLabelForeground: AnyShapeStyle {
+        switch completionLevel {
+        case .empty:
+            AnyShapeStyle(AppTheme.journalTextMuted)
+        case .started:
+            AnyShapeStyle(AppTheme.journalQuickCheckInText)
+        case .growing, .balanced:
+            AnyShapeStyle(AppTheme.journalStandardText)
+        case .full:
+            AnyShapeStyle(AppTheme.journalFullText)
         }
     }
 

--- a/GraceNotes/GraceNotes/Features/Journal/Views/JournalScreen.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/JournalScreen.swift
@@ -1367,7 +1367,7 @@ private extension JournalScreen {
         if let date = entryDate {
             return date.formatted(date: .abbreviated, time: .omitted)
         }
-        return String(localized: "Today's entry")
+        return String(localized: "Today")
     }
 
     func unlockToastTransition(for level: JournalCompletionLevel) -> AnyTransition {

--- a/GraceNotes/GraceNotes/Localizable.xcstrings
+++ b/GraceNotes/GraceNotes/Localizable.xcstrings
@@ -5665,22 +5665,6 @@
         }
       }
     },
-    "Today's entry" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Today's entry"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "今天的记录"
-          }
-        }
-      }
-    },
     "Toward the end of the week, %1$@ became a clearer thread in your entries." : {
       "extractionState" : "stale",
       "localizations" : {


### PR DESCRIPTION
## Summary

Closes #147. Closes #148.

- **#148 — Navigation title:** When `entryDate == nil`, `JournalScreen` now uses the same localized **Today** string as the tab (`GraceNotesApp`), instead of **Today's entry**. Removed the orphaned `Localizable.xcstrings` key for the old nav-only phrase. Body copy and other sentences that mention “today's entry” are unchanged.
- **#147 — Completion pill:** `JournalCompletionPill` shows a leading tier glyph using `ReviewRhythmFormatting.assetName(for:)` and the same template tint as the status label per level. Icons use `@ScaledMetric` for Dynamic Type; the image is `accessibilityHidden(true)` so VoiceOver still uses the existing combined label from `DateSectionView`.
- **Docs:** `JournalTodayOrientationPolicy` comment updated to say “shows Today” for consistency.

## Verification

- `make lint` (0 serious violations; pre-existing warnings only).
- `make test-unit` — all unit tests passed.
- Full `make test` hit a UI test timeout / runner restart in this environment; recommend CI or re-run UI locally if needed.

Work developed in git worktree `.worktrees/issue-147-148-today-nav-completion-pill-icons` from `main`.

Made with [Cursor](https://cursor.com)