### PR TITLE
chore: ignore .worktrees for local git worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ DerivedData/
 # Git worktrees (local parallel checkouts)
 .worktrees/
 
+# Git worktrees (local parallel checkouts)
+.worktrees/
+
 # Local secrets (do not commit real keys)
 GraceNotes/Secrets.plist
 GraceNotes/DeveloperSettings.local.xcconfig


### PR DESCRIPTION
## Summary

Adds `.worktrees/` to `.gitignore` so repo-local worktree checkout directories stay untracked when using `git worktree`.

## Context

Local `main` had diverged with merge commits plus this small ignore rule; `main` was reset to `origin/main` and the change is re-applied here for a clean PR.

## Verification

- No code or tests affected; `.gitignore` only.
- `swiftlint lint` unchanged scope (not run for this edit).

Made with [Cursor](https://cursor.com)