### PR TITLE
Fix Bloom leaf video resume after background (#158)

### DIFF
--- a/GraceNotes/GraceNotes/DesignSystem/SummerLeavesOverlays.swift
+++ b/GraceNotes/GraceNotes/DesignSystem/SummerLeavesOverlays.swift
@@ -67,6 +67,7 @@ struct SummerLeavesVideoOverlay: View {
 
 private struct LoopingVideoPlayerView: UIViewRepresentable {
     let url: URL
+    @Environment(\.scenePhase) private var scenePhase
 
     func makeCoordinator() -> Coordinator {
         Coordinator(url: url)
@@ -85,6 +86,9 @@ private struct LoopingVideoPlayerView: UIViewRepresentable {
 
     func updateUIView(_ uiView: LeavesVideoHostView, context: Context) {
         context.coordinator.updateBounds(uiView.bounds)
+        if scenePhase == .active {
+            context.coordinator.resumePlaybackIfAttached()
+        }
     }
 
     static func dismantleUIView(_ uiView: LeavesVideoHostView, coordinator: Coordinator) {
@@ -123,6 +127,10 @@ private struct LoopingVideoPlayerView: UIViewRepresentable {
 
         func updateBounds(_ bounds: CGRect) {
             playerLayer?.frame = bounds
+        }
+
+        func resumePlaybackIfAttached() {
+            player?.play()
         }
 
         func teardown() {


### PR DESCRIPTION
## Summary
When Bloom (Summer) is on, the bundled leaf loop (`SummerLeavesLoop.mp4`) is driven by `AVQueuePlayer`. After a normal background/foreground cycle, the system leaves the player paused and the overlay only called `play()` once inside `attach`.

## Change
- `LoopingVideoPlayerView` reads `@Environment(\.scenePhase)` and calls `resumePlaybackIfAttached()` (`player?.play()`) from `updateUIView` when `scenePhase == .active`.

## Verification
- `make ci-build`: **succeeded**
- `make test`: failed locally with simulator **Mach -308** / runner install error (environment flake), not a compile failure — please re-run tests on your machine or let CI validate.
- **Manual:** Issue #158 repro (Bloom on, Reduce Motion off, background → foreground) — leaf loop should resume without toggling Bloom or navigating away.

Fixes #158

Made with [Cursor](https://cursor.com)