### PR TITLE
Remove add-row chevron from Gratitudes and Needs

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/JournalScreen.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/JournalScreen.swift
@@ -595,7 +595,6 @@ private extension JournalScreen {
                     ? String(localized: "Add person")
                     : String(localized: "Add another person"),
                 addButtonAccessibilityHint: String(localized: "Opens a text field so you can add another item."),
-                showsTrailingChevronOnAddRow: false,
                 guidanceTitle: onboardingPresentation.sectionGuidance(for: .person)?.title,
                 guidanceMessage: onboardingPresentation.sectionGuidance(for: .person)?.message,
                 items: viewModel.people,

--- a/GraceNotes/GraceNotes/Features/Journal/Views/SequentialSectionPrimaryColumn.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/SequentialSectionPrimaryColumn.swift
@@ -12,7 +12,7 @@ struct SequentialSectionPrimaryColumn<ProgressDots: View>: View {
     let title: String
     let addButtonTitle: String
     let addButtonAccessibilityHint: String
-    /// When false, the add-row chip omits the trailing chevron (e.g. People empty state).
+    /// When false, the add-row chip omits the trailing chevron (default; matches journal sentence sections).
     let showsTrailingChevronOnAddRow: Bool
     let guidanceTitle: String?
     let guidanceMessage: String?

--- a/GraceNotes/GraceNotes/Features/Journal/Views/SequentialSectionView.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/SequentialSectionView.swift
@@ -58,7 +58,7 @@ struct SequentialSectionView: View {
         title: String,
         addButtonTitle: String,
         addButtonAccessibilityHint: String,
-        showsTrailingChevronOnAddRow: Bool = true,
+        showsTrailingChevronOnAddRow: Bool = false,
         guidanceTitle: String? = nil,
         guidanceMessage: String? = nil,
         guidanceMessageSecondary: String? = nil,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The journal’s **People in Mind** section already hid the trailing chevron on the add (“Add person” / “Add another person”) chip. **Gratitudes** and **Needs** still used the default, which showed a chevron.

`SequentialSectionView` now defaults `showsTrailingChevronOnAddRow` to `false`, so all three sentence sections match. The explicit `showsTrailingChevronOnAddRow: false` on People was removed as redundant.

## Verification

- `swiftlint lint` (repo root) — passes (pre-existing warnings only; no new issues in edited files).

iOS build/simulator was not run here (Linux agent); please spot-check the Today journal screen on a simulator if needed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-816cf5b4-d8ac-4b9a-b51c-4e0d11473514"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-816cf5b4-d8ac-4b9a-b51c-4e0d11473514"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

