### PR TITLE
chore: gitignore .worktree directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ __pycache__/
 
 # Git worktrees (local parallel checkouts)
 .worktrees/
+.worktree/
 
 # Local secrets (do not commit real keys)
 GraceNotes/Secrets.plist


### PR DESCRIPTION
Adds `.worktree/` alongside existing `.worktrees/` so single-directory worktrees (e.g. `git worktree add .worktree/...`) do not clutter `git status` on the primary checkout. Repository rules require PRs for `main`.

Made with [Cursor](https://cursor.com)