### PR TITLE
fix: Restore SwiftData entity names JournalEntry / JournalItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Work tracked toward milestone **0.5.2** (Settings cohesion and insight follow-th
 
 ### Fixed
 
+- SwiftData + CloudKit: `@Model` types are again named **`JournalEntry`** / composite **`JournalItem`**, with **`Journal`** / **`Entry`** as `typealias`es for app code, so existing on-disk stores and iCloud sync match the persisted entity identity after the #187 rename.
 - Review: **Reflection rhythm** horizontal strip pins to the trailing edge on first layout when the week is wider than the card, so the current day is not left under the trailing edge fade (`UIScrollView` KVO + `contentOffset`; issue #127).
 
 ### Developer

--- a/GraceNotes/GraceNotes/Data/Models/Entry.swift
+++ b/GraceNotes/GraceNotes/Data/Models/Entry.swift
@@ -1,6 +1,7 @@
 import Foundation
 
-struct Entry: Codable {
+/// Chip line item. Persisted composite uses the type name ``JournalItem`` inside stored journal rows.
+struct JournalItem: Codable {
     var id: UUID
     var fullText: String
 
@@ -32,3 +33,5 @@ struct Entry: Codable {
         case isTruncated
     }
 }
+
+typealias Entry = JournalItem

--- a/GraceNotes/GraceNotes/Data/Models/Journal.swift
+++ b/GraceNotes/GraceNotes/Data/Models/Journal.swift
@@ -42,8 +42,9 @@ extension JournalCompletionLevel: Codable {
     }
 }
 
+/// Persisted name must stay ``JournalEntry`` so existing stores and CloudKit keep the same entity identity.
 @Model
-final class Journal {
+final class JournalEntry {
     // CloudKit: non-optional transformable arrays do not get a recognized default in
     // the Core Data stack; use optional (`nil` = empty) so the store can load.
     var id: UUID = UUID()
@@ -170,3 +171,6 @@ final class Journal {
     /// The journal design means each section holds at most 5 items.
     static let slotCount = 5
 }
+
+/// Code name for ``JournalEntry`` (call sites stay “Journal”; persistence stays compatible).
+typealias Journal = JournalEntry


### PR DESCRIPTION
## Summary

Reverts persisted `@Model` / composite type names to **`JournalEntry`** and **`JournalItem`** so SwiftData + CloudKit continue to match stores created before the #187 `Journal` / `Entry` rename. App code keeps using **`Journal`** and **`Entry`** via `typealias`.

## Verification

- `grace run` on a physical device: prior journal rows visible again; iCloud sync working after the change.

## Notes

- Custom `SchemaMigrationPlan` was avoided: CloudKit expects lightweight migrations; aligning entity names is the reliable fix.

Made with [Cursor](https://cursor.com)