### PR TITLE
fix(copy): App Tour and l10n match on-device summarization (#202)

### DIFF
--- a/GraceNotes/GraceNotes/Localizable.xcstrings
+++ b/GraceNotes/GraceNotes/Localizable.xcstrings
@@ -7617,23 +7617,6 @@
         }
       }
     },
-    "When you want a little help with short labels or Review, you can explore AI options in Settings.": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "When you want a little help with short labels or Past insights, you can explore summarization options in Settings."
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "若想为短标签或「过去」里的洞察多要一点帮助，可到「设置」查看摘要与洞察。"
-          }
-        }
-      }
-    },
     "When you're finished, press Return or Enter on your keyboard.": {
       "localizations": {
         "en": {
@@ -9068,13 +9051,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sample only. When Summarize and Insights is on, the insights card on Past may include more sections than this preview. Gray lines on the live card are follow-up prompts. Answer in Reflections on Today, or in your next entry."
+            "value": "Sample only. When Summarize and Insights is on, the insights card on Past may include more sections than this preview."
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "仅为示例。开启「摘要与洞察」后，你在「过去」看到的洞察卡片可能还有更多栏目。真实卡片里的灰色小字是跟进提示，你也可以随后在「今天」的反思里接着写，或在下一条记录里回应。"
+            "value": "仅为示例。开启「摘要与洞察」后，你在「过去」看到的洞察卡片可能还有更多栏目。"
           }
         }
       }


### PR DESCRIPTION
Closes #202

## What changed

User-facing **English** and **Simplified Chinese** strings in `Localizable.xcstrings` no longer describe **network / 联网** summarization for the replayable App Tour, Settings hints, thin-week insight copy, or stale “AI / Settings.ai” catalog rows. Wording matches **on-device** summarization and current tab language (**Past**).

## Verification

- `python3 -m json.tool GraceNotes/GraceNotes/Localizable.xcstrings` — valid JSON
- `swiftlint lint` — no new serious violations (existing project noise unchanged)
- Manual: iOS Simulator — Settings → **Show app tour** (EN + zh-Hans if time allows); spot-check **Past** weekly card when thin-week copy applies

## Implementation plan (writing-plans skill)

A full task checklist with exact strings and commands is saved locally at `docs/superpowers/plans/2026-04-04-issue-202-app-tour-online-copy.md` (that tree is gitignored for agent-local plans; open the file in this worktree if you want the checkbox version).

**File map:** `Localizable.xcstrings` only; Swift sources use existing `String(localized:)` keys.

**Tasks executed in this PR:**

1. **AppTour.sampleInsights.filler** — Past insights card; “Summarize and Insights” / 「摘要与洞察」; removed online-summarization / 联网摘要 phrasing.
2. **Settings.showAppTour.a11yHint** — Writing path, Past insights, reminders, iCloud sync (no generic “cloud features”).
3. **Thin-week line** (catalog key still contains `cloud insight` in source key) — English `value` now “weekly theme” instead of “online insight”.
4. **When you want a little help…** — zh-Hans points to 摘要与洞察, not 联网摘要.
5. **Stale rows** — `AI connection status`, `AI features can help…`, `AI support`, `Settings.ai.*` values updated for on-device / Past alignment.
