### PR TITLE
Copy review: polish release 0.5.0+9 strings

### DIFF
--- a/GraceNotes/GraceNotes/Localizable.xcstrings
+++ b/GraceNotes/GraceNotes/Localizable.xcstrings
@@ -5697,13 +5697,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Turn on Summarize and Insights to generate Past insights from your entries."
+            "value": "Summarize and Insights can generate Past insights from your entries."
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "开启摘要与洞察后，感恩记会根据你的记录，在「过去」生成洞察。"
+            "value": "感恩记会根据你的记录，在「过去」生成洞察。"
           }
         }
       }
@@ -9051,13 +9051,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sample only. When Summarize and Insights is on, the insights card on Past may include more sections than this preview."
+            "value": "Sample only. The insights card on Past may include more sections than this preview."
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "仅为示例。开启「摘要与洞察」后，你在「过去」看到的洞察卡片可能还有更多栏目。"
+            "value": "仅为示例。你在「过去」看到的洞察卡片可能会比这个预览多一些栏目。"
           }
         }
       }


### PR DESCRIPTION
## Summary
- Apply the reviewed English and Simplified Chinese copy updates in `Localizable.xcstrings` for Past, Settings, onboarding, and Data & Privacy surfaces.
- Normalize Past/search wording to use consistent `记录` language instead of mixed older terms.
- Keep the branch clean by excluding temporary review/export artifacts from the final diff.

## Test plan
- [x] Validate `GraceNotes/GraceNotes/Localizable.xcstrings` parses as JSON.
- [x] Smoke test updated Past and Settings copy in the app.
- [x] Spot-check onboarding/App Tour copy in the simulator.


Made with [Cursor](https://cursor.com)