### PR TITLE
feat: translucent SwiftUI sheets (shared stacked backdrop)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Marketing **0.5.0** / bundle **9** (git tag **`v0.5.0+9`** at release).
 
 ### Changed
 
+- Past / Settings (**#199**): SwiftUI modal **sheets** use a **translucent** system material (with **`AppTheme`** fallbacks when **Reduce Transparency** is on). **Nested** SwiftUI sheets use a clear `presentationBackground` so stacked presentations share a **single** frosted backdrop instead of compounding blur. **Share** still uses the system activity sheet (UIKit).
 - Settings (**#200**): Data / import-export surfaces show **file names**, **scheduled backup folder** titles, and **file-like** JSON names in export history (system monospaced text via `AppTheme` tokens); localized labels and prose stay Warm Paper. Localized error sentences in history stay serif.
 
 ### Fixed

--- a/GraceNotes/GraceNotes/DesignSystem/AppTranslucentSheetChrome.swift
+++ b/GraceNotes/GraceNotes/DesignSystem/AppTranslucentSheetChrome.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+
+// MARK: - Sheet stack depth (nested SwiftUI sheets)
+
+private struct AppSheetStackDepthKey: EnvironmentKey {
+    static let defaultValue = 0
+}
+
+extension EnvironmentValues {
+    /// Depth of nested SwiftUI `sheet` presentations.
+    /// Used by ``View/appTranslucentSheetChrome(fallbackSolid:)``.
+    var appSheetStackDepth: Int {
+        get { self[AppSheetStackDepthKey.self] }
+        set { self[AppSheetStackDepthKey.self] = newValue }
+    }
+}
+
+// MARK: - Translucent presentation
+
+/// Standard presentation for modal sheets: material blur when transparency is allowed,
+/// solid fallback for Reduce Transparency.
+/// Nested sheets use a clear `presentationBackground` so only the outer layer blurs;
+/// stacked sheets share one frosted backdrop.
+private struct AppTranslucentSheetChrome: ViewModifier {
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+    @Environment(\.appSheetStackDepth) private var sheetStackDepth
+
+    let fallbackSolid: Color
+
+    func body(content: Content) -> some View {
+        content
+            .environment(\.appSheetStackDepth, sheetStackDepth + 1)
+            .presentationBackground(sheetBackdrop)
+            .toolbarBackground(toolbarBackdrop, for: .navigationBar)
+    }
+
+    private var sheetBackdrop: AnyShapeStyle {
+        if reduceTransparency {
+            AnyShapeStyle(fallbackSolid)
+        } else if sheetStackDepth == 0 {
+            AnyShapeStyle(Material.regularMaterial)
+        } else {
+            AnyShapeStyle(Color.clear)
+        }
+    }
+
+    private var toolbarBackdrop: AnyShapeStyle {
+        if reduceTransparency {
+            AnyShapeStyle(fallbackSolid)
+        } else if sheetStackDepth == 0 {
+            AnyShapeStyle(Material.regularMaterial)
+        } else {
+            AnyShapeStyle(Color.clear)
+        }
+    }
+}
+
+extension View {
+    /// Applies shared translucent sheet chrome: material behind content at the root of a sheet,
+    /// clear for nested sheets, solid when Reduce Transparency is on.
+    func appTranslucentSheetChrome(fallbackSolid: Color) -> some View {
+        modifier(AppTranslucentSheetChrome(fallbackSolid: fallbackSolid))
+    }
+}

--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewHistoryDrilldownSheets.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewHistoryDrilldownSheets.swift
@@ -100,24 +100,27 @@ struct ReviewHistoryDrilldownSheetContainer: View {
     let pastStatisticsInterval: PastStatisticsIntervalSelection
 
     var body: some View {
-        switch payload {
-        case .growthStage(let level):
-            GrowthStageDrilldownSheet(
-                level: level,
-                entries: entries,
-                calendar: calendar,
-                referenceDate: referenceDate,
-                pastStatisticsInterval: pastStatisticsInterval
-            )
-        case .section(let kind):
-            SectionEntriesDrilldownSheet(
-                section: kind,
-                entries: entries,
-                calendar: calendar,
-                referenceDate: referenceDate,
-                pastStatisticsInterval: pastStatisticsInterval
-            )
+        Group {
+            switch payload {
+            case .growthStage(let level):
+                GrowthStageDrilldownSheet(
+                    level: level,
+                    entries: entries,
+                    calendar: calendar,
+                    referenceDate: referenceDate,
+                    pastStatisticsInterval: pastStatisticsInterval
+                )
+            case .section(let kind):
+                SectionEntriesDrilldownSheet(
+                    section: kind,
+                    entries: entries,
+                    calendar: calendar,
+                    referenceDate: referenceDate,
+                    pastStatisticsInterval: pastStatisticsInterval
+                )
+            }
         }
+        .appTranslucentSheetChrome(fallbackSolid: AppTheme.reviewBackground)
     }
 }
 
@@ -226,7 +229,6 @@ private struct GrowthStageDrilldownSheet: View {
                     )
                 }
             }
-            .background(AppTheme.reviewBackground)
             .navigationTitle("")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -404,7 +406,6 @@ private struct SectionEntriesDrilldownSheet: View {
                     )
                 }
             }
-            .background(AppTheme.reviewBackground)
             .navigationTitle("")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewInsightThemeCardSupport.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewInsightThemeCardSupport.swift
@@ -217,6 +217,7 @@ struct MostRecurringThemesBrowseView: View {
     let themes: [ReviewMostRecurringTheme]
     let referenceDate: Date
     let calendar: Calendar
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
     @AppStorage(PastStatisticsIntervalPreference.appStorageKey)
     private var pastStatisticsIntervalEncoded = ""
 
@@ -245,8 +246,12 @@ struct MostRecurringThemesBrowseView: View {
             }
         }
         .scrollContentBackground(.hidden)
-        .background(AppTheme.reviewBackground)
+        .listRowBackground(mostRecurringListRowBackground)
         .navigationTitle(String(localized: "Most recurring"))
+    }
+
+    private var mostRecurringListRowBackground: Color {
+        reduceTransparency ? AppTheme.reviewPaper.opacity(0.92) : .clear
     }
 
     private func recurringSection(
@@ -373,6 +378,7 @@ struct MostRecurringBrowseRowModel: Identifiable {
 
 struct TrendingThemesBrowseView: View {
     let buckets: ReviewTrendingBuckets
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
@@ -388,7 +394,7 @@ struct TrendingThemesBrowseView: View {
             }
         }
         .scrollContentBackground(.hidden)
-        .background(AppTheme.reviewBackground)
+        .listRowBackground(trendingListRowBackground)
         .navigationTitle(String(localized: "Trending"))
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
@@ -399,6 +405,10 @@ struct TrendingThemesBrowseView: View {
                 .accessibilityIdentifier("TrendingBrowseSheetDone")
             }
         }
+    }
+
+    private var trendingListRowBackground: Color {
+        reduceTransparency ? AppTheme.reviewPaper.opacity(0.92) : .clear
     }
 
     private func trendingSection(title: String, themes: [ReviewMovementTheme]) -> some View {
@@ -471,12 +481,14 @@ struct ThemeDrilldownSheet: View {
 
     var body: some View {
         ThemeDrilldownView(payload: payload, includeDoneButton: true)
+            .appTranslucentSheetChrome(fallbackSolid: AppTheme.reviewBackground)
     }
 }
 
 struct ThemeDrilldownView: View {
     let payload: ReviewThemeDrilldownPayload
     let includeDoneButton: Bool
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
     @Environment(\.dismiss) private var dismiss
     @AppStorage(ReviewWeekBoundaryPreference.userDefaultsKey)
     private var reviewWeekBoundaryRawValue = ReviewWeekBoundaryPreference.defaultValue.rawValue
@@ -566,7 +578,7 @@ struct ThemeDrilldownView: View {
                 }
             }
             .scrollContentBackground(.hidden)
-            .background(AppTheme.reviewBackground)
+            .listRowBackground(themeListRowBackground)
             .navigationTitle(String(localized: "Theme details"))
             .toolbar {
                 if includeDoneButton {
@@ -578,6 +590,10 @@ struct ThemeDrilldownView: View {
                 }
             }
         }
+    }
+
+    private var themeListRowBackground: Color {
+        reduceTransparency ? AppTheme.reviewPaper.opacity(0.92) : .clear
     }
 
     private func themeDrilldownRowAccessibilityLabel(

--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewScreen.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewScreen.swift
@@ -202,6 +202,7 @@ extension ReviewScreen {
                 }
             }
             .id(sheet.id)
+            .appTranslucentSheetChrome(fallbackSolid: AppTheme.reviewBackground)
         })
         .sheet(item: $historyDrilldown) { payload in
             ReviewHistoryDrilldownSheetContainer(
@@ -447,6 +448,7 @@ private struct ReviewJournalDaySheetHost: View {
                     }
                 }
         }
+        .appTranslucentSheetChrome(fallbackSolid: AppTheme.reviewBackground)
     }
 }
 

--- a/GraceNotes/GraceNotes/Features/Settings/ImportExportSettingsScreen.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/ImportExportSettingsScreen.swift
@@ -5,6 +5,7 @@ import SwiftData
 // Split further cautiously to avoid navigation breakages.
 // swiftlint:disable type_body_length
 struct ImportExportSettingsScreen: View {
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
     @Environment(\.modelContext) private var modelContext
 
     @State private var exportErrorMessage: String?
@@ -31,6 +32,10 @@ struct ImportExportSettingsScreen: View {
 
     private let dataExportService = JournalDataExportService()
     private let dataImportService = JournalDataImportService()
+
+    private var settingsSheetListRowBackground: Color {
+        reduceTransparency ? AppTheme.settingsPaper.opacity(0.92) : .clear
+    }
 
     @ViewBuilder
     private var scheduledBackupIntervalPicker: some View {
@@ -301,9 +306,8 @@ struct ImportExportSettingsScreen: View {
                     .accessibilityElement(children: .combine)
                 }
             }
-            .listRowBackground(AppTheme.settingsPaper.opacity(0.9))
+            .listRowBackground(settingsSheetListRowBackground)
             .scrollContentBackground(.hidden)
-            .background(AppTheme.settingsBackground)
             .navigationTitle(String(localized: "DataPrivacy.importExport.section.history"))
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
@@ -313,6 +317,7 @@ struct ImportExportSettingsScreen: View {
                 }
             }
         }
+        .appTranslucentSheetChrome(fallbackSolid: AppTheme.settingsBackground)
     }
 
     @ViewBuilder
@@ -344,6 +349,8 @@ struct ImportExportSettingsScreen: View {
                     .disabled(pendingImportURL == nil || isImportingData)
                 }
             }
+            .scrollContentBackground(.hidden)
+            .listRowBackground(settingsSheetListRowBackground)
             .navigationTitle(String(localized: "DataPrivacy.import.review.title"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -355,6 +362,7 @@ struct ImportExportSettingsScreen: View {
                 }
             }
         }
+        .appTranslucentSheetChrome(fallbackSolid: AppTheme.settingsBackground)
         .presentationDetents([.medium, .large])
     }
 


### PR DESCRIPTION
## Summary

Implements **#199**: modal SwiftUI sheets use a **translucent** presentation (system `Material.regularMaterial`) so underlying context reads through, with **`AppTheme` solid fallbacks** when **Reduce Transparency** is enabled.

**Nested** SwiftUI sheets read `appSheetStackDepth` from the environment and apply a **clear** `presentationBackground` so stacked presentations **share one frosted layer** instead of compounding blur.

## Scope

- **Past**: history drill-down container, theme drill-down sheet, recurring/trending browse sheet group, journal-day sheet host.
- **Settings**: import review + export history sheets.
- **UIKit** system share activity sheet unchanged.

## Verification

- `xcodebuild` (GraceNotes scheme, simulator) — pass.
- `grace run` on device — pass.

## Changelog

`CHANGELOG.md` → **[0.5.0] Build 9** (Changed).

Closes #199
