### PR TITLE
feat(settings): relative iCloud last-activity subtitle within 24 hours

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/Services/ICloudSyncLastActivityFormatting.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/Services/ICloudSyncLastActivityFormatting.swift
@@ -93,8 +93,43 @@ enum ICloudSyncLastActivityFormatting {
             )
         }
 
+        return compoundHoursMinutesPhrase(hours: hours, minutes: minutes, locale: locale)
+    }
+
+    private static func compoundHoursMinutesPhrase(hours: Int, minutes: Int, locale: Locale) -> String {
+        let hourIsPlural = hours != 1
+        let minuteIsPlural = minutes != 1
+        if !hourIsPlural && !minuteIsPlural {
+            return localized(
+                "DataPrivacy.iCloudSync.lastActivity.relative.hoursMinutes.singularSingular",
+                locale: locale
+            )
+        }
+        if !hourIsPlural && minuteIsPlural {
+            return String(
+                format: localized(
+                    "DataPrivacy.iCloudSync.lastActivity.relative.hoursMinutes.singularPlural",
+                    locale: locale
+                ),
+                locale: locale,
+                minutes
+            )
+        }
+        if hourIsPlural && !minuteIsPlural {
+            return String(
+                format: localized(
+                    "DataPrivacy.iCloudSync.lastActivity.relative.hoursMinutes.pluralSingular",
+                    locale: locale
+                ),
+                locale: locale,
+                hours
+            )
+        }
         return String(
-            format: localized("DataPrivacy.iCloudSync.lastActivity.relative.hoursMinutes", locale: locale),
+            format: localized(
+                "DataPrivacy.iCloudSync.lastActivity.relative.hoursMinutes.pluralPlural",
+                locale: locale
+            ),
             locale: locale,
             hours,
             minutes

--- a/GraceNotes/GraceNotes/Features/Settings/SettingsScreen.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/SettingsScreen.swift
@@ -177,11 +177,10 @@ private extension SettingsScreen {
             return nil
         }
         if let date = iCloudSyncActivity.lastRemoteChangeAt {
-            let formatted = ICloudSyncLastActivityFormatting.formattedActivityTime(
+            return ICloudSyncLastActivityFormatting.lastActivitySubtitle(
                 lastActivity: date,
                 referenceNow: Date()
             )
-            return String(format: String(localized: "DataPrivacy.iCloudSync.lastActivity.format"), formatted)
         }
         return String(localized: "DataPrivacy.iCloudSync.lastActivity.pending")
     }

--- a/GraceNotes/GraceNotes/Localizable.xcstrings
+++ b/GraceNotes/GraceNotes/Localizable.xcstrings
@@ -2808,7 +2808,7 @@
         }
       }
     },
-    "DataPrivacy.iCloudSync.lastActivity.relative.hoursMinutes": {
+    "DataPrivacy.iCloudSync.lastActivity.relative.hoursMinutes.pluralPlural": {
       "localizations": {
         "en": {
           "stringUnit": {
@@ -2820,6 +2820,54 @@
           "stringUnit": {
             "state": "translated",
             "value": "%1$lld 小时 %2$lld 分钟前"
+          }
+        }
+      }
+    },
+    "DataPrivacy.iCloudSync.lastActivity.relative.hoursMinutes.pluralSingular": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld hours and 1 minute ago"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 小时 1 分钟前"
+          }
+        }
+      }
+    },
+    "DataPrivacy.iCloudSync.lastActivity.relative.hoursMinutes.singularPlural": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 hour and %lld minutes ago"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 小时 %lld 分钟前"
+          }
+        }
+      }
+    },
+    "DataPrivacy.iCloudSync.lastActivity.relative.hoursMinutes.singularSingular": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 hour and 1 minute ago"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 小时 1 分钟前"
           }
         }
       }

--- a/GraceNotesTests/Features/Settings/ICloudSyncLastActivityFormattingTests.swift
+++ b/GraceNotesTests/Features/Settings/ICloudSyncLastActivityFormattingTests.swift
@@ -35,6 +35,36 @@ final class ICloudSyncLastActivityFormattingTests: XCTestCase {
         XCTAssertEqual(phrase, "5 hours and 35 minutes ago")
     }
 
+    func test_within24Hours_oneHourOneMinute_usesCompoundSingularHoursMinutes() {
+        let last = frozenNow.addingTimeInterval(-(1 * 3600 + 1 * 60))
+        let phrase = ICloudSyncLastActivityFormatting.formattedActivityTime(
+            lastActivity: last,
+            referenceNow: frozenNow,
+            localizationLocale: englishUS
+        )
+        XCTAssertEqual(phrase, "1 hour and 1 minute ago")
+    }
+
+    func test_within24Hours_oneHourFiveMinutes_usesCompoundSingularHourPluralMinutes() {
+        let last = frozenNow.addingTimeInterval(-(1 * 3600 + 5 * 60))
+        let phrase = ICloudSyncLastActivityFormatting.formattedActivityTime(
+            lastActivity: last,
+            referenceNow: frozenNow,
+            localizationLocale: englishUS
+        )
+        XCTAssertEqual(phrase, "1 hour and 5 minutes ago")
+    }
+
+    func test_within24Hours_twoHoursOneMinute_usesCompoundPluralHoursSingularMinute() {
+        let last = frozenNow.addingTimeInterval(-(2 * 3600 + 1 * 60))
+        let phrase = ICloudSyncLastActivityFormatting.formattedActivityTime(
+            lastActivity: last,
+            referenceNow: frozenNow,
+            localizationLocale: englishUS
+        )
+        XCTAssertEqual(phrase, "2 hours and 1 minute ago")
+    }
+
     func test_exactlyTwentyFourHoursFromReference_usesAbsoluteAbbreviatedStyle() {
         let last = frozenNow.addingTimeInterval(-24 * 3600)
         let got = ICloudSyncLastActivityFormatting.formattedActivityTime(


### PR DESCRIPTION
This change updates the Data & Privacy subtitle under the iCloud sync toggle so the time portion reads in plain relative language (seconds, minutes, hours, or hours and minutes) when the last observed remote activity was less than 24 hours ago, and keeps the existing abbreviated date and short time when it was 24 hours ago or older.

Implementation adds `ICloudSyncLastActivityFormatting` with optional `localizationLocale` (defaults to the user locale for production). New `Localizable.xcstrings` keys supply English and Simplified Chinese copy aligned with the Translator table in the local plan. Unit tests cover English expectations and one Simplified Chinese phrase.

Verified with `grace test --kind unit` on iPhone 17 Pro (iOS 26.4) and SwiftLint on touched Swift files. Work was done in git worktree `feature/icloud-relative-last-activity`; branch is pushed for review and left unmerged per maintainer preference.

Made with [Cursor](https://cursor.com)