### PR TITLE
UX: toolbar Done uses SF Symbols; VoiceOver keeps "Done"

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/PastTappablePressStyle.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/PastTappablePressStyle.swift
@@ -32,7 +32,8 @@ enum PastToolbarDoneSymbol: String {
     case xmark
 }
 
-/// ``Done`` in navigation bars for Past-related sheets: Warm Paper + semantic tint; light press fade and haptic.
+/// Symbol-based toolbar control styling for Past-related sheets: semantic tint, light press fade and haptic.
+/// VoiceOver uses the localized “Done” label.
 struct PastToolbarDoneButtonStyle: ButtonStyle {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
@@ -50,18 +51,32 @@ struct PastToolbarDoneButtonStyle: ButtonStyle {
 struct PastToolbarDoneButton: View {
     let action: () -> Void
     var appearance: PastToolbarDoneAppearance = .review
-    var symbol: PastToolbarDoneSymbol = .checkmark
+    /// When `nil`, icon follows ``appearance``: ``PastToolbarDoneAppearance/review`` is `.xmark`,
+    /// ``PastToolbarDoneAppearance/journal`` is `.checkmark`.
+    var symbol: PastToolbarDoneSymbol?
     var accessibilityIdentifier: String?
 
     var body: some View {
         Button(action: action) {
-            Image(systemName: symbol.rawValue)
+            Image(systemName: resolvedSymbol.rawValue)
                 .font(AppTheme.warmPaperBody.weight(.semibold))
                 .foregroundStyle(foreground)
         }
         .buttonStyle(PastToolbarDoneButtonStyle())
         .accessibilityLabel(String(localized: "Done"))
         .optionalToolbarDoneAccessibilityIdentifier(accessibilityIdentifier)
+    }
+
+    private var resolvedSymbol: PastToolbarDoneSymbol {
+        if let symbol {
+            return symbol
+        }
+        switch appearance {
+        case .review:
+            return .xmark
+        case .journal:
+            return .checkmark
+        }
     }
 
     private var foreground: Color {

--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewHistoryDrilldownSheets.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewHistoryDrilldownSheets.swift
@@ -234,7 +234,6 @@ private struct JournalingDaysDrilldownSheet: View {
                 ToolbarItem(placement: .topBarTrailing) {
                     PastToolbarDoneButton(
                         action: { dismiss() },
-                        symbol: .xmark,
                         accessibilityIdentifier: "ReviewHistoryJournalingDaysDrilldownDone"
                     )
                 }
@@ -380,7 +379,7 @@ private struct GrowthStageDrilldownSheet: View {
                     )
                 }
                 ToolbarItem(placement: .topBarTrailing) {
-                    PastToolbarDoneButton(action: { dismiss() }, symbol: .xmark)
+                    PastToolbarDoneButton(action: { dismiss() })
                 }
             }
             .navigationDestination(item: $journalNavigationDay) { item in
@@ -549,7 +548,7 @@ private struct SectionEntriesDrilldownSheet: View {
                         .foregroundStyle(AppTheme.reviewTextPrimary)
                 }
                 ToolbarItem(placement: .topBarTrailing) {
-                    PastToolbarDoneButton(action: { dismiss() }, symbol: .xmark)
+                    PastToolbarDoneButton(action: { dismiss() })
                 }
             }
             .navigationDestination(item: $journalNavigationDay) { item in

--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewInsightThemeCardSupport.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewInsightThemeCardSupport.swift
@@ -195,7 +195,6 @@ struct MostRecurringBrowseSheetContainer: View {
                     ToolbarItem(placement: .topBarTrailing) {
                         PastToolbarDoneButton(
                             action: { dismiss() },
-                            symbol: .xmark,
                             accessibilityIdentifier: "MostRecurringBrowseSheetDone"
                         )
                     }
@@ -397,7 +396,6 @@ struct TrendingThemesBrowseView: View {
             ToolbarItem(placement: .topBarTrailing) {
                 PastToolbarDoneButton(
                     action: { dismiss() },
-                    symbol: .xmark,
                     accessibilityIdentifier: "TrendingBrowseSheetDone"
                 )
             }
@@ -575,7 +573,7 @@ struct ThemeDrilldownView: View {
             .toolbar {
                 if includeDoneButton {
                     ToolbarItem(placement: .topBarTrailing) {
-                        PastToolbarDoneButton(action: { dismiss() }, symbol: .xmark)
+                        PastToolbarDoneButton(action: { dismiss() })
                     }
                 }
             }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Implements [issue #213](https://github.com/kipyin/grace-notes/issues/213): replace visible **Done** text on shared toolbar dismiss controls with **SF Symbols**, while keeping **accessibility** discoverable via the localized **Done** label so UI tests that query `buttons["Done"]` remain valid.

## Behavior
- **`PastToolbarDoneButton`**: shows `checkmark` or `xmark`; `accessibilityLabel` = localized "Done".
- **Contextual symbols**: **xmark** for dismiss-only review/browse/drilldown sheets; **checkmark** for the journal day sheet opened from Past (commit/return-to-context).
- **Import/Export** export history sheet: **xmark** in the toolbar with the same Done accessibility label.
- **App tour** last-page control: left as full-width **Done** text for onboarding clarity (per issue open question).

## Verification
- `swiftlint lint` on touched files (Linux static binary).
- iOS build/UI tests not run in this environment (requires Xcode).

Closes #213
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1fc661ca-79d0-4ff0-b06a-7c710d9a0ee7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1fc661ca-79d0-4ff0-b06a-7c710d9a0ee7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

