### PR TITLE
feat: User-selectable accent presets for interaction chrome (#215)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Marketing version **0.5.0** ships as successive **builds** (TestFlight / App Sto
 ### Added
 
 - Settings (**#215**): **Advanced** includes a **Highlight color** control with presets (Terracotta, Ocean, Plum, Forest) for tab bar tint, toggles, onboarding chips, and Past/review chrome; the choice persists across launches. Journal paper backgrounds and completion tier semantics are unchanged.
+- Accent presets now drive **primary and secondary CTAs** consistently (onboarding **Begin**, Settings reminder actions, **Open Settings**, App Tour **Next**/**Done**, journal **Share** toolbar tint) via `InteractionAccentPalette` roles.
 
 ### Build 9 — 2026-04-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Marketing **0.5.0** / bundle **9** (git tag **`v0.5.0+9`** at release).
 
 ### Changed
 
+- Settings → Advanced (**Highlight color**): section uses a list header (serif title) and a **segmented** control for the two presets instead of full-width inline radio rows; footnote sits in a tighter vertical stack for clearer hierarchy.
 - Settings (**#200**): Data / import-export surfaces show **file names**, **scheduled backup folder** titles, and **file-like** JSON names in export history (system monospaced text via `AppTheme` tokens); localized labels and prose stay Warm Paper. Localized error sentences in history stay serif.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 Marketing version **0.5.0** ships as successive **builds** (TestFlight / App Store); git tags **`v0.5.0+{build}`**. GitHub milestones **0.5.2**, **0.5.3**, etc. name **scope lanes**, not separate marketing versions — see **README.md** (Roadmap) and GitHub milestones. Older docs or issues may still mention interim labels (**0.5.1**, **0.5.2**); **ship truth** is **0.5.0 + build** below.
 
+### Added
+
+- Settings (**#215**): **Advanced** includes a **Highlight color** control with presets (Terracotta, Ocean, Plum, Forest) for tab bar tint, toggles, onboarding chips, and Past/review chrome; the choice persists across launches. Journal paper backgrounds and completion tier semantics are unchanged.
+
 ### Build 9 — 2026-04-04
 
 Marketing **0.5.0** / bundle **9** (git tag **`v0.5.0+9`** at release).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Marketing version **0.5.0** ships as successive **builds** (TestFlight / App Sto
 
 ### Added
 
-- Settings (**#215**): **Advanced** includes a **Highlight color** control with presets (Terracotta, Ocean, Plum, Forest) for tab bar tint, toggles, onboarding chips, and Past/review chrome; the choice persists across launches. Journal paper backgrounds and completion tier semantics are unchanged.
+- Settings (**#215**): **Advanced** includes a **Highlight color** control with **Terracotta** and **Forest** presets for tab bar tint, toggles, onboarding chips, and Past/review chrome; the choice persists across launches (legacy Ocean/Plum values migrate to Terracotta). Journal paper backgrounds and completion tier semantics are unchanged.
 - Accent presets now drive **primary and secondary CTAs** consistently (onboarding **Begin**, Settings reminder actions, **Open Settings**, App Tour **Next**/**Done**, journal **Share** toolbar tint) via `InteractionAccentPalette` roles.
 
 ### Build 9 — 2026-04-04

--- a/GraceNotes/GraceNotes/Application/GraceNotesApp.swift
+++ b/GraceNotes/GraceNotes/Application/GraceNotesApp.swift
@@ -34,7 +34,7 @@ struct GraceNotesApp: App {
         if !isRunningUnitTests {
             JournalTutorialStorageKeys.migrateLegacyKeysIfNeeded(using: .standard)
             JournalAppearanceMode.migrateLegacySummerRawValueIfNeeded(defaults: .standard)
-            AccentPreference.migrateRemovedCasesIfNeeded(using: .standard)
+            AccentPreference.migrateRemovedCasesIfNeeded(defaults: .standard)
             _ = ICloudSyncPreferenceResolver.resolvedCloudSyncEnabled(using: .standard)
             JournalOnboardingProgress.migrateLegacyPostSeedOrientationFlagsIfNeeded(using: .standard)
             JournalOnboardingProgress.migrateLegacyAppTourSeenFlagIfNeeded(using: .standard)

--- a/GraceNotes/GraceNotes/Application/GraceNotesApp.swift
+++ b/GraceNotes/GraceNotes/Application/GraceNotesApp.swift
@@ -34,6 +34,7 @@ struct GraceNotesApp: App {
         if !isRunningUnitTests {
             JournalTutorialStorageKeys.migrateLegacyKeysIfNeeded(using: .standard)
             JournalAppearanceMode.migrateLegacySummerRawValueIfNeeded(defaults: .standard)
+            AccentPreference.migrateRemovedCasesIfNeeded(using: .standard)
             _ = ICloudSyncPreferenceResolver.resolvedCloudSyncEnabled(using: .standard)
             JournalOnboardingProgress.migrateLegacyPostSeedOrientationFlagsIfNeeded(using: .standard)
             JournalOnboardingProgress.migrateLegacyAppTourSeenFlagIfNeeded(using: .standard)

--- a/GraceNotes/GraceNotes/Application/GraceNotesApp.swift
+++ b/GraceNotes/GraceNotes/Application/GraceNotesApp.swift
@@ -21,6 +21,8 @@ struct GraceNotesApp: App {
     @AppStorage(FirstRunOnboardingStorageKeys.completed) private var hasCompletedOnboarding = false
     @AppStorage(JournalAppearanceStorageKeys.todayMode)
     private var journalTodayAppearanceRaw = JournalAppearanceMode.standard.rawValue
+    @AppStorage(JournalAppearanceStorageKeys.accentPreference)
+    private var accentPreferenceRaw = AccentPreference.terracotta.rawValue
 
     init() {
         let startupTrace = PerformanceTrace.begin("App.init")
@@ -74,7 +76,13 @@ struct GraceNotesApp: App {
                 }
             }
             .environment(\.font, AppTheme.outfitUI)
+            .environment(\.interactionAccentPalette, resolvedInteractionAccentPalette)
         }
+    }
+
+    private var resolvedInteractionAccentPalette: InteractionAccentPalette {
+        let preference = AccentPreference.resolveStored(rawValue: accentPreferenceRaw)
+        return InteractionAccentPalette.resolve(preference)
     }
 
     @ViewBuilder
@@ -82,7 +90,7 @@ struct GraceNotesApp: App {
         mainTabView
             .background(AppTheme.background)
             .toolbarBackground(AppTheme.background, for: .tabBar)
-            .tint(AppTheme.accent)
+            .tint(resolvedInteractionAccentPalette.accent)
             .environmentObject(appNavigation)
             .modelContainer(controller.container)
             .environment(\.persistenceRuntimeSnapshot, controller.runtimeSnapshot)
@@ -107,7 +115,7 @@ struct GraceNotesApp: App {
             readyContent
                 .background(AppTheme.background)
                 .toolbarBackground(AppTheme.background, for: .tabBar)
-                .tint(AppTheme.accent)
+                .tint(resolvedInteractionAccentPalette.accent)
                 .environmentObject(appNavigation)
                 .task {
                     await runDeferredStartupTasksIfNeeded(using: controller)

--- a/GraceNotes/GraceNotes/Application/StartupLoadingView.swift
+++ b/GraceNotes/GraceNotes/Application/StartupLoadingView.swift
@@ -28,6 +28,7 @@ struct StartupLoadingView: View {
 
             ProgressView()
                 .progressViewStyle(.circular)
+                .tint(interactionAccent.accent)
                 .opacity(isFailure ? 0 : 1)
                 .accessibilityHidden(isFailure)
 

--- a/GraceNotes/GraceNotes/Application/StartupLoadingView.swift
+++ b/GraceNotes/GraceNotes/Application/StartupLoadingView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct StartupLoadingView: View {
+    @Environment(\.interactionAccentPalette) private var interactionAccent
+
     enum State {
         case loading(message: String, isReassurance: Bool)
         case retryableFailure(message: String)
@@ -52,7 +54,7 @@ struct StartupLoadingView: View {
                 .foregroundStyle(.white)
                 .padding(.horizontal, 24)
                 .padding(.vertical, 12)
-                .background(AppTheme.accent)
+                .background(interactionAccent.accent)
                 .clipShape(RoundedRectangle(cornerRadius: 14))
                 .padding(.horizontal, 24)
                 .disabled(isRetrying)

--- a/GraceNotes/GraceNotes/DesignSystem/AccentPreference.swift
+++ b/GraceNotes/GraceNotes/DesignSystem/AccentPreference.swift
@@ -1,0 +1,35 @@
+import Foundation
+import SwiftUI
+
+/// User-chosen accent for interaction chrome (tab tint, toggles, primary actions).
+/// Body paper and tier greens stay stable.
+enum AccentPreference: String, CaseIterable, Identifiable {
+    case terracotta
+    case ocean
+    case plum
+    case forest
+
+    var id: String { rawValue }
+
+    static func resolveStored(rawValue: String) -> AccentPreference {
+        AccentPreference(rawValue: rawValue) ?? .terracotta
+    }
+
+    var localizedTitle: String {
+        switch self {
+        case .terracotta:
+            return String(localized: "Settings.advanced.accent.terracotta")
+        case .ocean:
+            return String(localized: "Settings.advanced.accent.ocean")
+        case .plum:
+            return String(localized: "Settings.advanced.accent.plum")
+        case .forest:
+            return String(localized: "Settings.advanced.accent.forest")
+        }
+    }
+}
+
+enum JournalAppearanceStorageKeys {
+    static let todayMode = "journalTodayAppearanceMode"
+    static let accentPreference = "journalAccentPreference"
+}

--- a/GraceNotes/GraceNotes/DesignSystem/AccentPreference.swift
+++ b/GraceNotes/GraceNotes/DesignSystem/AccentPreference.swift
@@ -5,8 +5,6 @@ import SwiftUI
 /// Body paper and tier greens stay stable.
 enum AccentPreference: String, CaseIterable, Identifiable {
     case terracotta
-    case ocean
-    case plum
     case forest
 
     var id: String { rawValue }
@@ -15,14 +13,18 @@ enum AccentPreference: String, CaseIterable, Identifiable {
         AccentPreference(rawValue: rawValue) ?? .terracotta
     }
 
+    /// Rewrites removed preset raw values (`ocean`, `plum`) so storage stays canonical.
+    static func migrateRemovedCasesIfNeeded(defaults: UserDefaults = .standard) {
+        let key = JournalAppearanceStorageKeys.accentPreference
+        guard let raw = defaults.string(forKey: key) else { return }
+        guard raw == "ocean" || raw == "plum" else { return }
+        defaults.set(AccentPreference.terracotta.rawValue, forKey: key)
+    }
+
     var localizedTitle: String {
         switch self {
         case .terracotta:
             return String(localized: "Settings.advanced.accent.terracotta")
-        case .ocean:
-            return String(localized: "Settings.advanced.accent.ocean")
-        case .plum:
-            return String(localized: "Settings.advanced.accent.plum")
         case .forest:
             return String(localized: "Settings.advanced.accent.forest")
         }

--- a/GraceNotes/GraceNotes/DesignSystem/InteractionAccentPalette.swift
+++ b/GraceNotes/GraceNotes/DesignSystem/InteractionAccentPalette.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+import UIKit
+
+/// Accent roles for controls and Past review chrome, resolved from ``AccentPreference``.
+struct InteractionAccentPalette: Equatable {
+    var accent: Color
+    var accentText: Color
+    var onAccent: Color
+    /// Adaptive Past/review accent (search highlights, links, app tour on settings-like surfaces).
+    var reviewAccent: Color
+    var activeEditingAccent: Color
+    var activeEditingAccentStrong: Color
+
+    /// Baseline terracotta; matches ``AppTheme`` defaults.
+    static let terracotta = InteractionAccentPalette(
+        accent: Color(hex: 0xC77B5B),
+        accentText: Color(hex: 0x8A4A34),
+        onAccent: Color(hex: 0x1F1A16),
+        reviewAccent: Color.adaptive(lightHex: 0xC77B5B, darkHex: 0xD89D82),
+        activeEditingAccent: Color(hex: 0xB07358),
+        activeEditingAccentStrong: Color(hex: 0x7B4835)
+    )
+
+    static func resolve(_ preference: AccentPreference) -> InteractionAccentPalette {
+        switch preference {
+        case .terracotta:
+            return .terracotta
+        case .ocean:
+            return InteractionAccentPalette(
+                accent: Color(hex: 0x2F8F8A),
+                accentText: Color(hex: 0x1D5C58),
+                onAccent: Color(hex: 0x101A1A),
+                reviewAccent: Color.adaptive(lightHex: 0x2F8F8A, darkHex: 0x5EC4BE),
+                activeEditingAccent: Color(hex: 0x287A76),
+                activeEditingAccentStrong: Color(hex: 0x1A524F)
+            )
+        case .plum:
+            return InteractionAccentPalette(
+                accent: Color(hex: 0x8E5B8F),
+                accentText: Color(hex: 0x5C3A5D),
+                onAccent: Color(hex: 0x1A1418),
+                reviewAccent: Color.adaptive(lightHex: 0x8E5B8F, darkHex: 0xC49BC5),
+                activeEditingAccent: Color(hex: 0x7A4A7B),
+                activeEditingAccentStrong: Color(hex: 0x4F324F)
+            )
+        case .forest:
+            return InteractionAccentPalette(
+                accent: Color(hex: 0x4F6B52),
+                accentText: Color(hex: 0x344936),
+                onAccent: Color(hex: 0x121A14),
+                reviewAccent: Color.adaptive(lightHex: 0x4F6B52, darkHex: 0x8BA88E),
+                activeEditingAccent: Color(hex: 0x435A46),
+                activeEditingAccentStrong: Color(hex: 0x2C3D2E)
+            )
+        }
+    }
+}
+
+// MARK: - Color Hex (shared with Theme.swift pattern)
+
+private extension Color {
+    init(hex: UInt) {
+        let red = Double((hex >> 16) & 0xFF) / 255
+        let green = Double((hex >> 8) & 0xFF) / 255
+        let blue = Double(hex & 0xFF) / 255
+        self.init(red: red, green: green, blue: blue)
+    }
+
+    static func adaptive(lightHex: UInt, darkHex: UInt) -> Color {
+        Color(
+            UIColor { traitCollection in
+                let colorHex = traitCollection.userInterfaceStyle == .dark ? darkHex : lightHex
+                return UIColor(hex: colorHex)
+            }
+        )
+    }
+}
+
+private extension UIColor {
+    convenience init(hex: UInt) {
+        let red = CGFloat((hex >> 16) & 0xFF) / 255
+        let green = CGFloat((hex >> 8) & 0xFF) / 255
+        let blue = CGFloat(hex & 0xFF) / 255
+        self.init(red: red, green: green, blue: blue, alpha: 1)
+    }
+}
+
+private struct InteractionAccentPaletteKey: EnvironmentKey {
+    static let defaultValue = InteractionAccentPalette.terracotta
+}
+
+extension EnvironmentValues {
+    /// Resolved interaction accent; mirrors ``AppTheme`` terracotta baseline when unset.
+    var interactionAccentPalette: InteractionAccentPalette {
+        get { self[InteractionAccentPaletteKey.self] }
+        set { self[InteractionAccentPaletteKey.self] = newValue }
+    }
+}

--- a/GraceNotes/GraceNotes/DesignSystem/InteractionAccentPalette.swift
+++ b/GraceNotes/GraceNotes/DesignSystem/InteractionAccentPalette.swift
@@ -21,37 +21,22 @@ struct InteractionAccentPalette: Equatable {
         activeEditingAccentStrong: Color(hex: 0x7B4835)
     )
 
+    /// Deep green accent; harmonizes with completion tones without replacing tier semantics.
+    static let forest = InteractionAccentPalette(
+        accent: Color(hex: 0x4F6B52),
+        accentText: Color(hex: 0x344936),
+        onAccent: Color(hex: 0x121A14),
+        reviewAccent: Color.adaptive(lightHex: 0x4F6B52, darkHex: 0x8BA88E),
+        activeEditingAccent: Color(hex: 0x435A46),
+        activeEditingAccentStrong: Color(hex: 0x2C3D2E)
+    )
+
     static func resolve(_ preference: AccentPreference) -> InteractionAccentPalette {
         switch preference {
         case .terracotta:
             return .terracotta
-        case .ocean:
-            return InteractionAccentPalette(
-                accent: Color(hex: 0x2F8F8A),
-                accentText: Color(hex: 0x1D5C58),
-                onAccent: Color(hex: 0x101A1A),
-                reviewAccent: Color.adaptive(lightHex: 0x2F8F8A, darkHex: 0x5EC4BE),
-                activeEditingAccent: Color(hex: 0x287A76),
-                activeEditingAccentStrong: Color(hex: 0x1A524F)
-            )
-        case .plum:
-            return InteractionAccentPalette(
-                accent: Color(hex: 0x8E5B8F),
-                accentText: Color(hex: 0x5C3A5D),
-                onAccent: Color(hex: 0x1A1418),
-                reviewAccent: Color.adaptive(lightHex: 0x8E5B8F, darkHex: 0xC49BC5),
-                activeEditingAccent: Color(hex: 0x7A4A7B),
-                activeEditingAccentStrong: Color(hex: 0x4F324F)
-            )
         case .forest:
-            return InteractionAccentPalette(
-                accent: Color(hex: 0x4F6B52),
-                accentText: Color(hex: 0x344936),
-                onAccent: Color(hex: 0x121A14),
-                reviewAccent: Color.adaptive(lightHex: 0x4F6B52, darkHex: 0x8BA88E),
-                activeEditingAccent: Color(hex: 0x435A46),
-                activeEditingAccentStrong: Color(hex: 0x2C3D2E)
-            )
+            return .forest
         }
     }
 }

--- a/GraceNotes/GraceNotes/DesignSystem/InteractionAccentPalette.swift
+++ b/GraceNotes/GraceNotes/DesignSystem/InteractionAccentPalette.swift
@@ -56,6 +56,21 @@ struct InteractionAccentPalette: Equatable {
     }
 }
 
+// MARK: - Primary / secondary chrome (Settings, onboarding, App Tour)
+
+extension InteractionAccentPalette {
+    /// Filled primary control: Try again, Begin, App Tour Next/Done custom chrome.
+    var primaryProminentFill: Color { accent }
+
+    /// Label on ``primaryProminentFill``. Adaptive so Settings light/dark stays readable on saturated fills.
+    var primaryProminentForeground: Color {
+        Color.adaptive(lightHex: 0xF8F4EF, darkHex: 0xF8F4EF)
+    }
+
+    /// Bordered secondary and date-picker tint (matches former `reminderSecondaryActionTint` role).
+    var secondaryControlTint: Color { accentText }
+}
+
 // MARK: - Color Hex (shared with Theme.swift pattern)
 
 private extension Color {

--- a/GraceNotes/GraceNotes/DesignSystem/JournalAppearanceMode.swift
+++ b/GraceNotes/GraceNotes/DesignSystem/JournalAppearanceMode.swift
@@ -22,7 +22,3 @@ enum JournalAppearanceMode: String, CaseIterable, Identifiable {
         defaults.set(JournalAppearanceMode.bloom.rawValue, forKey: key)
     }
 }
-
-enum JournalAppearanceStorageKeys {
-    static let todayMode = "journalTodayAppearanceMode"
-}

--- a/GraceNotes/GraceNotes/DesignSystem/TodayJournalPalette.swift
+++ b/GraceNotes/GraceNotes/DesignSystem/TodayJournalPalette.swift
@@ -14,6 +14,8 @@ struct TodayJournalPalette: Equatable {
     var pendingOutline: Color
     var activeEditingAccent: Color
     var activeEditingAccentStrong: Color
+    /// Interaction chrome accent (add row, guidance); driven by ``AccentPreference`` when resolved from journal.
+    var interactionAccentText: Color
     var quickCheckInBackground: Color
     var quickCheckInBorder: Color
     var quickCheckInText: Color
@@ -47,6 +49,7 @@ struct TodayJournalPalette: Equatable {
         pendingOutline: AppTheme.journalPendingOutline,
         activeEditingAccent: AppTheme.journalActiveEditingAccent,
         activeEditingAccentStrong: AppTheme.journalActiveEditingAccentStrong,
+        interactionAccentText: AppTheme.accentText,
         quickCheckInBackground: AppTheme.journalQuickCheckInBackground,
         quickCheckInBorder: AppTheme.journalQuickCheckInBorder,
         quickCheckInText: AppTheme.journalQuickCheckInText,
@@ -80,6 +83,7 @@ struct TodayJournalPalette: Equatable {
         pendingOutline: summerHex(0x7A6E62),
         activeEditingAccent: summerHex(0x9A5C45),
         activeEditingAccentStrong: summerHex(0x6B3D2E),
+        interactionAccentText: summerHex(0x8A4A34),
         quickCheckInBackground: AppTheme.journalQuickCheckInBackground,
         quickCheckInBorder: AppTheme.journalQuickCheckInBorder,
         quickCheckInText: AppTheme.journalQuickCheckInText,
@@ -99,11 +103,19 @@ struct TodayJournalPalette: Equatable {
         sectionPaperOpacity: 0.72
     )
 
-    static func resolve(mode: JournalAppearanceMode) -> TodayJournalPalette {
+    static func resolve(mode: JournalAppearanceMode, accent: InteractionAccentPalette? = nil) -> TodayJournalPalette {
+        var base: TodayJournalPalette
         switch mode {
-        case .standard: return .standard
-        case .bloom: return .bloom
+        case .standard:
+            base = .standard
+        case .bloom:
+            base = .bloom
         }
+        guard let accent else { return base }
+        base.activeEditingAccent = accent.activeEditingAccent
+        base.activeEditingAccentStrong = accent.activeEditingAccentStrong
+        base.interactionAccentText = accent.accentText
+        return base
     }
 }
 

--- a/GraceNotes/GraceNotes/Features/Journal/Tutorial/AppTourView+Pages.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Tutorial/AppTourView+Pages.swift
@@ -5,12 +5,18 @@ extension AppTourView {
         HStack(spacing: 6) {
             ForEach(firstPageIndex ... lastPageIndex, id: \.self) { index in
                 Circle()
-                    .fill(index == pageIndex ? AppTheme.reviewAccent : AppTheme.settingsTextMuted.opacity(0.35))
+                    .fill(
+                        index == pageIndex
+                            ? interactionAccent.reviewAccent
+                            : AppTheme.settingsTextMuted.opacity(0.35)
+                    )
                     .frame(width: index == pageIndex ? 8 : 6, height: index == pageIndex ? 8 : 6)
                     .overlay(
                         Circle()
                             .stroke(
-                                index == pageIndex ? AppTheme.reviewAccent.opacity(0.45) : AppTheme.border.opacity(0.5),
+                                index == pageIndex
+                                    ? interactionAccent.reviewAccent.opacity(0.45)
+                                    : AppTheme.border.opacity(0.5),
                                 lineWidth: 1
                             )
                     )

--- a/GraceNotes/GraceNotes/Features/Journal/Tutorial/AppTourView+Pages.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Tutorial/AppTourView+Pages.swift
@@ -40,10 +40,10 @@ extension AppTourView {
                 Button(action: finishJourney) {
                     Text(String(localized: "Done"))
                         .font(AppTheme.warmPaperBody.weight(.semibold))
-                        .foregroundStyle(AppTheme.reminderPrimaryActionForeground)
+                        .foregroundStyle(interactionAccent.primaryProminentForeground)
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, AppTheme.spacingRegular)
-                        .background(AppTheme.reminderPrimaryActionBackground)
+                        .background(interactionAccent.primaryProminentFill)
                         .clipShape(RoundedRectangle(cornerRadius: AppTheme.cornerRadiusMedium))
                 }
                 .buttonStyle(WarmPaperPressStyle())
@@ -62,10 +62,10 @@ extension AppTourView {
                         label: {
                             Text(String(localized: "Next"))
                                 .font(AppTheme.warmPaperBody.weight(.semibold))
-                                .foregroundStyle(AppTheme.reminderPrimaryActionForeground)
+                                .foregroundStyle(interactionAccent.primaryProminentForeground)
                                 .padding(.horizontal, AppTheme.spacingWide)
                                 .padding(.vertical, AppTheme.spacingRegular)
-                                .background(AppTheme.reminderPrimaryActionBackground)
+                                .background(interactionAccent.primaryProminentFill)
                                 .clipShape(RoundedRectangle(cornerRadius: AppTheme.cornerRadiusMedium))
                         }
                     )

--- a/GraceNotes/GraceNotes/Features/Journal/Tutorial/AppTourView+SettingsParity.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Tutorial/AppTourView+SettingsParity.swift
@@ -96,8 +96,8 @@ extension AppTourView {
                         .frame(maxWidth: .infinity, minHeight: 44)
                 }
                 .buttonStyle(.borderedProminent)
-                .tint(AppTheme.reminderPrimaryActionBackground)
-                .foregroundStyle(AppTheme.reminderPrimaryActionForeground)
+                .tint(interactionAccent.primaryProminentFill)
+                .foregroundStyle(interactionAccent.primaryProminentForeground)
                 .font(AppTheme.warmPaperBody)
                 .disabled(reminderState.isWorking)
                 .accessibilityHint(String(localized: "Retry scheduling your daily reminder."))
@@ -111,8 +111,8 @@ extension AppTourView {
                         .frame(maxWidth: .infinity, minHeight: 44)
                 }
                 .buttonStyle(.bordered)
-                .tint(AppTheme.reminderSecondaryActionTint)
-                .foregroundStyle(AppTheme.reminderSecondaryActionTint)
+                .tint(interactionAccent.secondaryControlTint)
+                .foregroundStyle(interactionAccent.secondaryControlTint)
                 .font(AppTheme.warmPaperBody)
                 .disabled(reminderState.isWorking)
                 .accessibilityHint(String(localized: "Check if notification permissions have changed."))
@@ -132,7 +132,7 @@ extension AppTourView {
             .datePickerStyle(.compact)
             .font(AppTheme.warmPaperBody)
             .foregroundStyle(AppTheme.settingsTextPrimary)
-            .tint(AppTheme.reminderSecondaryActionTint)
+            .tint(interactionAccent.secondaryControlTint)
             .accessibilityLabel(String(localized: "Reminder time"))
             .accessibilityHint(String(localized: "Choose a reminder time."))
         } else {

--- a/GraceNotes/GraceNotes/Features/Journal/Tutorial/AppTourView+SettingsParity.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Tutorial/AppTourView+SettingsParity.swift
@@ -60,7 +60,7 @@ extension AppTourView {
 
             Toggle("", isOn: reminderToggleBinding)
                 .labelsHidden()
-                .tint(AppTheme.reviewAccent)
+                .tint(interactionAccent.reviewAccent)
                 .disabled(reminderState.isPermissionDenied || reminderState.isWorking)
                 .accessibilityLabel(String(localized: "Daily reminder"))
         }

--- a/GraceNotes/GraceNotes/Features/Journal/Tutorial/AppTourView.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Tutorial/AppTourView.swift
@@ -13,6 +13,7 @@ struct AppTourView: View {
     @Environment(\.accessibilityReduceMotion) var accessibilityReduceMotion
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
     @Environment(\.verticalSizeClass) var verticalSizeClass
+    @Environment(\.interactionAccentPalette) var interactionAccent
 
     @AppStorage(PersistenceController.iCloudSyncEnabledKey) var isICloudSyncEnabled = false
 
@@ -101,6 +102,7 @@ private enum AppTourPathTitleMetricsKey: PreferenceKey {
 
 /// One row of the path strip: timeline dot is vertically centered on the **title** line only (not the criterion).
 private struct AppTourPathStepRow: View {
+    @Environment(\.interactionAccentPalette) private var interactionAccent
     let index: Int
     let stepCount: Int
     let title: String
@@ -152,12 +154,16 @@ private struct AppTourPathStepRow: View {
                     if !titleSystemImage.isEmpty {
                         Image(systemName: titleSystemImage)
                             .font(isHighlighted ? AppTheme.warmPaperMetaEmphasis : AppTheme.warmPaperMeta)
-                            .foregroundStyle(isHighlighted ? AppTheme.reviewAccent : AppTheme.settingsTextMuted)
+                            .foregroundStyle(
+                                isHighlighted ? interactionAccent.reviewAccent : AppTheme.settingsTextMuted
+                            )
                             .accessibilityHidden(true)
                     }
                     Text(title)
                         .font(isHighlighted ? AppTheme.warmPaperMetaEmphasis : AppTheme.warmPaperMeta)
-                        .foregroundStyle(isHighlighted ? AppTheme.reviewAccent : AppTheme.settingsTextMuted)
+                        .foregroundStyle(
+                            isHighlighted ? interactionAccent.reviewAccent : AppTheme.settingsTextMuted
+                        )
                 }
                 .background {
                     GeometryReader { geometry in
@@ -242,6 +248,7 @@ private struct AppTourPathStepRow: View {
 }
 
 struct AppTourPathStrip: View {
+    @Environment(\.interactionAccentPalette) private var interactionAccent
     let highlightedLevel: JournalCompletionLevel
 
     private static let orderedLevels: [JournalCompletionLevel] = [
@@ -311,14 +318,14 @@ struct AppTourPathStrip: View {
 
     private func dotFill(for level: JournalCompletionLevel) -> Color {
         if level == highlightedLevel {
-            return AppTheme.reviewAccent.opacity(0.35)
+            return interactionAccent.reviewAccent.opacity(0.35)
         }
         return AppTheme.journalBackground
     }
 
     private func dotBorder(for level: JournalCompletionLevel) -> Color {
         if level == highlightedLevel {
-            return AppTheme.reviewAccent
+            return interactionAccent.reviewAccent
         }
         return AppTheme.journalBorder
     }
@@ -380,6 +387,7 @@ struct AppTourInsightsPreview: View {
 // MARK: - iCloud card (parity with Data & Privacy)
 
 struct AppTourICloudCard: View {
+    @Environment(\.interactionAccentPalette) private var interactionAccent
     @Binding var isICloudSyncEnabled: Bool
     @ObservedObject var iCloudAccountState: ICloudAccountStatusModel
     let persistenceRuntimeSnapshot: PersistenceRuntimeSnapshot
@@ -398,7 +406,7 @@ struct AppTourICloudCard: View {
                     Toggle(String(localized: "iCloud sync"), isOn: $isICloudSyncEnabled)
                         .font(AppTheme.warmPaperBody)
                         .foregroundStyle(AppTheme.settingsTextPrimary)
-                        .tint(AppTheme.reviewAccent)
+                        .tint(interactionAccent.reviewAccent)
                         .frame(minHeight: 44)
                 }
             }

--- a/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalOnboardingGuidanceView.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalOnboardingGuidanceView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct JournalOnboardingGuidanceView: View {
     @Environment(\.todayJournalPalette) private var palette
+    @Environment(\.interactionAccentPalette) private var interactionAccent
     let title: String
     let message: String
 
@@ -9,7 +10,7 @@ struct JournalOnboardingGuidanceView: View {
         VStack(alignment: .leading, spacing: AppTheme.spacingTight) {
             Text(title)
                 .font(AppTheme.warmPaperMetaEmphasis)
-                .foregroundStyle(AppTheme.accentText)
+                .foregroundStyle(interactionAccent.accentText)
 
             Text(message)
                 .font(AppTheme.warmPaperBody)

--- a/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalOnboardingSectionModifier.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalOnboardingSectionModifier.swift
@@ -24,7 +24,7 @@ extension JournalOnboardingSectionState {
         case .standard, .available:
             return palette.textPrimary
         case .active:
-            return AppTheme.accentText
+            return palette.interactionAccentText
         case .locked:
             return palette.textMuted
         }

--- a/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalOnboardingSuggestionView.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalOnboardingSuggestionView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct JournalOnboardingSuggestionView: View {
     @Environment(\.todayJournalPalette) private var palette
+    @Environment(\.interactionAccentPalette) private var interactionAccent
     let title: String
     let message: String
     let primaryActionTitle: String
@@ -14,7 +15,7 @@ struct JournalOnboardingSuggestionView: View {
             VStack(alignment: .leading, spacing: AppTheme.spacingTight) {
                 Text(title)
                     .font(AppTheme.warmPaperMetaEmphasis)
-                    .foregroundStyle(AppTheme.accentText)
+                    .foregroundStyle(interactionAccent.accentText)
 
                 Text(message)
                     .font(AppTheme.warmPaperBody)
@@ -28,16 +29,16 @@ struct JournalOnboardingSuggestionView: View {
                         .frame(maxWidth: .infinity, minHeight: 44)
                 }
                 .buttonStyle(.borderedProminent)
-                .tint(AppTheme.accent)
-                .foregroundStyle(AppTheme.onAccent)
+                .tint(interactionAccent.accent)
+                .foregroundStyle(interactionAccent.onAccent)
 
                 Button(action: onSecondaryAction) {
                     Text(secondaryActionTitle)
                         .frame(maxWidth: .infinity, minHeight: 44)
                 }
                 .buttonStyle(.bordered)
-                .tint(AppTheme.accentText)
-                .foregroundStyle(AppTheme.accentText)
+                .tint(interactionAccent.accentText)
+                .foregroundStyle(interactionAccent.accentText)
             }
             .font(AppTheme.warmPaperBody)
         }

--- a/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalTutorialHintView.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalTutorialHintView.swift
@@ -30,6 +30,7 @@ enum JournalTutorialHintPresentation {
 /// Dismissible nudge to keep writing toward Started or Full chip milestones (issue #60).
 struct JournalTutorialHintView: View {
     @Environment(\.todayJournalPalette) private var palette
+    @Environment(\.interactionAccentPalette) private var interactionAccent
     let kind: JournalTutorialHintKind
     let onDismiss: () -> Void
 
@@ -43,7 +44,7 @@ struct JournalTutorialHintView: View {
             Button(action: onDismiss) {
                 Text(String(localized: "Got it"))
                     .font(AppTheme.warmPaperMetaEmphasis)
-                    .foregroundStyle(AppTheme.accentText)
+                    .foregroundStyle(interactionAccent.accentText)
             }
             .buttonStyle(.plain)
             .accessibilityHint(String(localized: "Dismisses this tip."))

--- a/GraceNotes/GraceNotes/Features/Journal/Views/EditableTextSection.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/EditableTextSection.swift
@@ -48,7 +48,7 @@ struct EditableTextSection: View {
                     if let guidanceTitle, !guidanceTitle.isEmpty {
                         Text(guidanceTitle)
                             .font(AppTheme.warmPaperMetaEmphasis)
-                            .foregroundStyle(AppTheme.accentText)
+                            .foregroundStyle(palette.interactionAccentText)
                     }
                     Text(guidanceMessage)
                         .font(AppTheme.warmPaperBody)

--- a/GraceNotes/GraceNotes/Features/Journal/Views/JournalScreen.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/JournalScreen.swift
@@ -155,6 +155,7 @@ struct JournalScreen: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(\.scenePhase) private var scenePhase
     @Environment(\.journalBloomAtmosphereHosted) private var journalBloomAtmosphereHosted
+    @Environment(\.interactionAccentPalette) private var interactionAccentPalette
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @Environment(\.verticalSizeClass) private var verticalSizeClass
@@ -225,7 +226,7 @@ struct JournalScreen: View {
     @FocusState private var isReflectionsFocused: Bool
     var entryDate: Date?
     var body: some View {
-        let palette = TodayJournalPalette.resolve(mode: effectiveTodayAppearance)
+        let palette = TodayJournalPalette.resolve(mode: effectiveTodayAppearance, accent: interactionAccentPalette)
         ZStack {
             if effectiveTodayAppearance == .bloom, !journalBloomAtmosphereHosted {
                 SummerPaperBackgroundView()

--- a/GraceNotes/GraceNotes/Features/Journal/Views/JournalScreen.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/JournalScreen.swift
@@ -247,6 +247,7 @@ struct JournalScreen: View {
                     Image(systemName: "square.and.arrow.up")
                         .font(AppTheme.outfitSemiboldHeadline)
                 }
+                .tint(interactionAccentPalette.accent)
                 .accessibilityLabel(String(localized: "Share"))
                 .accessibilityIdentifier("Share")
             }

--- a/GraceNotes/GraceNotes/Features/Journal/Views/PastJournalSearchViews.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/PastJournalSearchViews.swift
@@ -79,7 +79,6 @@ private enum PastJournalSearchHighlighting {
     /// Body size matches ``AppTheme.warmPaperBody`` (17pt, scaled for Dynamic Type).
     private static let bodyPointSize: CGFloat = 17
     private static let serifRegularPostScriptName = "SourceSerif4Roman-Regular"
-    private static let matchBackgroundFill = UIColor(AppTheme.reviewAccent).withAlphaComponent(0.15)
     private static var bodyTextColor: UIColor { UIColor(AppTheme.reviewTextPrimary) }
 
     private static func bodyUIFont(semibold: Bool) -> UIFont {
@@ -109,7 +108,7 @@ private enum PastJournalSearchHighlighting {
         return ranges
     }
 
-    static func text(content: String, highlightQuery: String) -> Text {
+    static func text(content: String, highlightQuery: String, matchBackgroundFill: UIColor) -> Text {
         let trimmed = highlightQuery.trimmingCharacters(in: .whitespacesAndNewlines)
         let ranges: [Range<String.Index>] = if trimmed.isEmpty {
             []
@@ -263,6 +262,7 @@ struct PastJournalSearchFieldRow: View {
 }
 
 private struct PastJournalSearchDayCard: View {
+    @Environment(\.interactionAccentPalette) private var interactionAccent
     let day: Date
     let sections: [(source: ReviewThemeSourceCategory, rows: [JournalSearchMatch])]
     let calendar: Calendar
@@ -296,7 +296,9 @@ private struct PastJournalSearchDayCard: View {
                                     HStack(alignment: .firstTextBaseline, spacing: 10) {
                                         PastJournalSearchHighlighting.text(
                                             content: match.content,
-                                            highlightQuery: highlightQuery
+                                            highlightQuery: highlightQuery,
+                                            matchBackgroundFill: UIColor(interactionAccent.reviewAccent)
+                                                .withAlphaComponent(0.15)
                                         )
                                         .multilineTextAlignment(.leading)
                                         .fixedSize(horizontal: false, vertical: true)

--- a/GraceNotes/GraceNotes/Features/Journal/Views/PastTappablePressStyle.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/PastTappablePressStyle.swift
@@ -42,6 +42,7 @@ struct PastToolbarDoneButtonStyle: ButtonStyle {
 }
 
 struct PastToolbarDoneButton: View {
+    @Environment(\.interactionAccentPalette) private var interactionAccent
     let action: () -> Void
     var appearance: PastToolbarDoneAppearance = .review
     var accessibilityIdentifier: String?
@@ -59,7 +60,7 @@ struct PastToolbarDoneButton: View {
     private var foreground: Color {
         switch appearance {
         case .review:
-            AppTheme.reviewAccent
+            interactionAccent.reviewAccent
         case .journal:
             AppTheme.journalTextPrimary
         }

--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewInsightThemeCardSupport.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewInsightThemeCardSupport.swift
@@ -214,6 +214,7 @@ struct TrendingBrowseSheetContainer: View {
 }
 
 struct MostRecurringThemesBrowseView: View {
+    @Environment(\.interactionAccentPalette) private var interactionAccent
     let themes: [ReviewMostRecurringTheme]
     let referenceDate: Date
     let calendar: Calendar
@@ -270,7 +271,7 @@ struct MostRecurringThemesBrowseView: View {
                         Spacer(minLength: 8)
                         ReviewCountBadge(
                             value: row.mentionCount.formatted(),
-                            accent: AppTheme.reviewAccent
+                            accent: interactionAccent.reviewAccent
                         )
                     }
                 }

--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewMostRecurringCard.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewMostRecurringCard.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct ReviewMostRecurringCard: View {
+    @Environment(\.interactionAccentPalette) private var interactionAccent
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @AppStorage(ReviewWeekBoundaryPreference.userDefaultsKey)
     private var reviewWeekBoundaryRawValue = ReviewWeekBoundaryPreference.defaultValue.rawValue
@@ -112,7 +113,7 @@ struct ReviewMostRecurringCard: View {
                     .lineLimit(2)
                     .multilineTextAlignment(.leading)
                 Spacer(minLength: 8)
-                ReviewCountBadge(value: theme.totalCount.formatted(), accent: AppTheme.reviewAccent)
+                ReviewCountBadge(value: theme.totalCount.formatted(), accent: interactionAccent.reviewAccent)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .contentShape(Rectangle())
@@ -148,7 +149,7 @@ struct ReviewMostRecurringCard: View {
             Image(systemName: "chevron.right")
                 .font(.caption.weight(.semibold))
         }
-        .foregroundStyle(AppTheme.reviewAccent)
+        .foregroundStyle(interactionAccent.reviewAccent)
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 

--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewTrendingCard.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewTrendingCard.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct ReviewTrendingCard: View {
+    @Environment(\.interactionAccentPalette) private var interactionAccent
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     @Binding var themeDrilldown: ReviewThemeDrilldownPayload?
@@ -163,7 +164,7 @@ struct ReviewTrendingCard: View {
             Image(systemName: "chevron.right")
                 .font(.caption.weight(.semibold))
         }
-        .foregroundStyle(AppTheme.reviewAccent)
+        .foregroundStyle(interactionAccent.reviewAccent)
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 }

--- a/GraceNotes/GraceNotes/Features/Journal/Views/SentenceStripView.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/SentenceStripView.swift
@@ -71,7 +71,7 @@ struct SentenceStripView: View {
                             .font(AppTheme.outfitSemiboldCaption)
                     }
                     .font(AppTheme.outfitSemiboldSubheadline)
-                    .foregroundStyle(AppTheme.accentText)
+                    .foregroundStyle(palette.interactionAccentText)
                     .padding(.leading, AppTheme.spacingRegular)
                     .frame(minHeight: 44, alignment: .leading)
                 }

--- a/GraceNotes/GraceNotes/Features/Journal/Views/SequentialSectionPrimaryColumn.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/SequentialSectionPrimaryColumn.swift
@@ -149,7 +149,7 @@ extension SequentialSectionPrimaryColumn {
                             if let guidanceTitle, !guidanceTitle.isEmpty {
                                 Text(guidanceTitle)
                                     .font(AppTheme.warmPaperMetaEmphasis)
-                                    .foregroundStyle(AppTheme.accentText)
+                                    .foregroundStyle(palette.interactionAccentText)
                             }
                             Text(guidanceMessage)
                                 .font(AppTheme.warmPaperBody)

--- a/GraceNotes/GraceNotes/Features/Journal/Views/SequentialSectionView+EntryRow.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/SequentialSectionView+EntryRow.swift
@@ -73,7 +73,7 @@ enum SequentialSectionEntryRow {
             HStack(spacing: AppTheme.spacingTight) {
                 Image(systemName: "plus.circle.fill")
                     .font(AppTheme.outfitRegularTitle3)
-                    .foregroundStyle(AppTheme.accentText)
+                    .foregroundStyle(palette.interactionAccentText)
                 Text(title)
                 .font(AppTheme.warmPaperMetaEmphasis)
                 .foregroundStyle(palette.textPrimary)

--- a/GraceNotes/GraceNotes/Features/Onboarding/OnboardingScreen.swift
+++ b/GraceNotes/GraceNotes/Features/Onboarding/OnboardingScreen.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct OnboardingScreen: View {
+    @Environment(\.interactionAccentPalette) private var interactionAccent
     let onGetStarted: () -> Void
 
     var body: some View {
@@ -14,7 +15,7 @@ struct OnboardingScreen: View {
             VStack(alignment: .leading, spacing: AppTheme.spacingRegular) {
                 Text(String(localized: "Start with one gratitude, and the rest will follow."))
                     .font(AppTheme.warmPaperMetaEmphasis)
-                    .foregroundStyle(AppTheme.reminderSecondaryActionTint)
+                    .foregroundStyle(interactionAccent.secondaryControlTint)
             }
             .padding(AppTheme.spacingWide)
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -28,10 +29,10 @@ struct OnboardingScreen: View {
             Button(action: onGetStarted) {
                 Text(String(localized: "Begin today's entry"))
                     .font(AppTheme.warmPaperBody.weight(.semibold))
-                    .foregroundStyle(AppTheme.reminderPrimaryActionForeground)
+                    .foregroundStyle(interactionAccent.primaryProminentForeground)
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, AppTheme.spacingRegular)
-                    .background(AppTheme.reminderPrimaryActionBackground)
+                    .background(interactionAccent.primaryProminentFill)
                     .clipShape(RoundedRectangle(cornerRadius: AppTheme.cornerRadiusMedium))
             }
             .buttonStyle(WarmPaperPressStyle())

--- a/GraceNotes/GraceNotes/Features/Settings/AdvancedSettingsScreen.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/AdvancedSettingsScreen.swift
@@ -118,6 +118,7 @@ struct AdvancedSettingsScreen: View {
                         EmptyView()
                     }
                     .pickerStyle(.segmented)
+                    .tint(interactionAccent.accent)
                     .font(AppTheme.outfitSemiboldSubheadline)
                     .accessibilityLabel(String(localized: "Settings.advanced.accent.label"))
 

--- a/GraceNotes/GraceNotes/Features/Settings/AdvancedSettingsScreen.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/AdvancedSettingsScreen.swift
@@ -8,6 +8,7 @@ private enum PastStatisticsIntervalPickerMode: String, CaseIterable, Identifiabl
 }
 
 struct AdvancedSettingsScreen: View {
+    @Environment(\.interactionAccentPalette) private var interactionAccent
     @AppStorage(ReviewWeekBoundaryPreference.userDefaultsKey)
     private var reviewWeekBoundaryRawValue = ReviewWeekBoundaryPreference.defaultValue.rawValue
     @AppStorage(PastStatisticsIntervalPreference.appStorageKey)
@@ -15,6 +16,8 @@ struct AdvancedSettingsScreen: View {
     @AppStorage(JournalTutorialStorageKeys.celebratedFirstBloom) private var hasCelebratedFirstBloom = false
     @AppStorage(JournalAppearanceStorageKeys.todayMode)
     private var journalTodayAppearanceRaw = JournalAppearanceMode.standard.rawValue
+    @AppStorage(JournalAppearanceStorageKeys.accentPreference)
+    private var accentPreferenceRaw = AccentPreference.terracotta.rawValue
 
     @State private var intervalMode: PastStatisticsIntervalPickerMode = .all
     @State private var customQuantity: Int = 4
@@ -100,9 +103,28 @@ struct AdvancedSettingsScreen: View {
                             .font(AppTheme.warmPaperBody)
                             .foregroundStyle(AppTheme.settingsTextPrimary)
                     }
-                    .tint(AppTheme.accent)
+                    .tint(interactionAccent.accent)
                     .accessibilityHint(String(localized: "Settings.todayJournalAppearance.bloomToggleA11yHint"))
                 }
+            }
+
+            Section {
+                Picker(
+                    String(localized: "Settings.advanced.accent.label"),
+                    selection: accentPreferenceBinding
+                ) {
+                    ForEach(AccentPreference.allCases) { option in
+                        Text(option.localizedTitle).tag(option)
+                    }
+                }
+                .pickerStyle(.inline)
+                .font(AppTheme.warmPaperBody)
+                .foregroundStyle(AppTheme.settingsTextPrimary)
+
+                Text(String(localized: "Settings.advanced.accent.footnote"))
+                    .font(AppTheme.warmPaperMeta)
+                    .foregroundStyle(AppTheme.settingsTextMuted)
+                    .fixedSize(horizontal: false, vertical: true)
             }
         }
         .listRowBackground(AppTheme.settingsPaper.opacity(0.9))
@@ -136,6 +158,13 @@ struct AdvancedSettingsScreen: View {
                     ? JournalAppearanceMode.bloom.rawValue
                     : JournalAppearanceMode.standard.rawValue
             }
+        )
+    }
+
+    private var accentPreferenceBinding: Binding<AccentPreference> {
+        Binding(
+            get: { AccentPreference.resolveStored(rawValue: accentPreferenceRaw) },
+            set: { accentPreferenceRaw = $0.rawValue }
         )
     }
 

--- a/GraceNotes/GraceNotes/Features/Settings/AdvancedSettingsScreen.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/AdvancedSettingsScreen.swift
@@ -109,22 +109,30 @@ struct AdvancedSettingsScreen: View {
             }
 
             Section {
-                Picker(
-                    String(localized: "Settings.advanced.accent.label"),
-                    selection: accentPreferenceBinding
-                ) {
-                    ForEach(AccentPreference.allCases) { option in
-                        Text(option.localizedTitle).tag(option)
+                VStack(alignment: .leading, spacing: AppTheme.spacingRegular) {
+                    Picker(selection: accentPreferenceBinding) {
+                        ForEach(AccentPreference.allCases) { option in
+                            Text(option.localizedTitle).tag(option)
+                        }
+                    } label: {
+                        EmptyView()
                     }
-                }
-                .pickerStyle(.inline)
-                .font(AppTheme.warmPaperBody)
-                .foregroundStyle(AppTheme.settingsTextPrimary)
+                    .pickerStyle(.segmented)
+                    .font(AppTheme.outfitSemiboldSubheadline)
+                    .accessibilityLabel(String(localized: "Settings.advanced.accent.label"))
 
-                Text(String(localized: "Settings.advanced.accent.footnote"))
-                    .font(AppTheme.warmPaperMeta)
-                    .foregroundStyle(AppTheme.settingsTextMuted)
-                    .fixedSize(horizontal: false, vertical: true)
+                    Text(String(localized: "Settings.advanced.accent.footnote"))
+                        .font(AppTheme.warmPaperMeta)
+                        .foregroundStyle(AppTheme.settingsTextMuted)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.vertical, AppTheme.spacingTight / 2)
+            } header: {
+                Text(String(localized: "Settings.advanced.accent.label"))
+                    .font(AppTheme.warmPaperHeader)
+                    .foregroundStyle(AppTheme.settingsTextPrimary)
+                    .textCase(nil)
             }
         }
         .listRowBackground(AppTheme.settingsPaper.opacity(0.9))

--- a/GraceNotes/GraceNotes/Features/Settings/DataPrivacySettingsSection.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/DataPrivacySettingsSection.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct DataPrivacySettingsSection: View {
+    @Environment(\.interactionAccentPalette) private var interactionAccent
     @Binding var isICloudSyncEnabled: Bool
     @ObservedObject var iCloudAccountState: ICloudAccountStatusModel
     let persistenceRuntimeSnapshot: PersistenceRuntimeSnapshot
@@ -22,7 +23,7 @@ struct DataPrivacySettingsSection: View {
                     Toggle(String(localized: "iCloud sync"), isOn: $isICloudSyncEnabled)
                         .font(AppTheme.warmPaperBody)
                         .foregroundStyle(AppTheme.settingsTextPrimary)
-                        .tint(AppTheme.accent)
+                        .tint(interactionAccent.accent)
                         .frame(minHeight: 44)
 
                     if isJournalOnCloudKitStore, let lastICloudSyncSubtitle {

--- a/GraceNotes/GraceNotes/Features/Settings/SettingsOpenSystemSettingsButton.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/SettingsOpenSystemSettingsButton.swift
@@ -24,6 +24,7 @@ struct SettingsOpenSystemSettingsButton: View {
 }
 
 private struct OpenSystemSettingsButtonStyle: ViewModifier {
+    @Environment(\.interactionAccentPalette) private var interactionAccent
     let emphasis: SettingsOpenSystemSettingsButtonEmphasis
 
     func body(content: Content) -> some View {
@@ -31,13 +32,13 @@ private struct OpenSystemSettingsButtonStyle: ViewModifier {
         case .standard:
             content
                 .buttonStyle(.bordered)
-                .tint(AppTheme.reminderSecondaryActionTint)
-                .foregroundStyle(AppTheme.reminderSecondaryActionTint)
+                .tint(interactionAccent.secondaryControlTint)
+                .foregroundStyle(interactionAccent.secondaryControlTint)
         case .prominent:
             content
                 .buttonStyle(.borderedProminent)
-                .tint(AppTheme.reminderPrimaryActionBackground)
-                .foregroundStyle(AppTheme.reminderPrimaryActionForeground)
+                .tint(interactionAccent.primaryProminentFill)
+                .foregroundStyle(interactionAccent.primaryProminentForeground)
         }
     }
 }

--- a/GraceNotes/GraceNotes/Features/Settings/SettingsScreen.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/SettingsScreen.swift
@@ -3,6 +3,7 @@ import UIKit
 
 struct SettingsScreen: View {
     @AppStorage(PersistenceController.iCloudSyncEnabledKey) private var isICloudSyncEnabled = false
+    @Environment(\.interactionAccentPalette) private var interactionAccent
     @EnvironmentObject private var appNavigation: AppNavigationModel
     @Environment(\.modelContext) private var modelContext
     @Environment(\.openURL) private var openURL
@@ -241,7 +242,7 @@ private extension SettingsScreen {
 
             Toggle("", isOn: reminderToggleBinding)
                 .labelsHidden()
-                .tint(AppTheme.accent)
+                .tint(interactionAccent.accent)
                 .disabled(reminderState.isPermissionDenied || reminderState.isWorking)
                 .accessibilityLabel(String(localized: "Daily reminder"))
         }

--- a/GraceNotes/GraceNotes/Features/Settings/SettingsScreen.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/SettingsScreen.swift
@@ -278,8 +278,8 @@ private extension SettingsScreen {
                         .frame(maxWidth: .infinity, minHeight: 44)
                 }
                 .buttonStyle(.borderedProminent)
-                .tint(AppTheme.reminderPrimaryActionBackground)
-                .foregroundStyle(AppTheme.reminderPrimaryActionForeground)
+                .tint(interactionAccent.primaryProminentFill)
+                .foregroundStyle(interactionAccent.primaryProminentForeground)
                 .font(AppTheme.warmPaperBody)
                 .disabled(reminderState.isWorking)
                 .accessibilityHint(String(localized: "Retry scheduling your daily reminder."))
@@ -293,8 +293,8 @@ private extension SettingsScreen {
                         .frame(maxWidth: .infinity, minHeight: 44)
                 }
                 .buttonStyle(.bordered)
-                .tint(AppTheme.reminderSecondaryActionTint)
-                .foregroundStyle(AppTheme.reminderSecondaryActionTint)
+                .tint(interactionAccent.secondaryControlTint)
+                .foregroundStyle(interactionAccent.secondaryControlTint)
                 .font(AppTheme.warmPaperBody)
                 .disabled(reminderState.isWorking)
                 .accessibilityHint(String(localized: "Check if notification permissions have changed."))
@@ -314,7 +314,7 @@ private extension SettingsScreen {
             .datePickerStyle(.compact)
             .font(AppTheme.warmPaperBody)
             .foregroundStyle(AppTheme.settingsTextPrimary)
-            .tint(AppTheme.reminderSecondaryActionTint)
+            .tint(interactionAccent.secondaryControlTint)
             .accessibilityLabel(String(localized: "Reminder time"))
             .accessibilityHint(String(localized: "Choose a reminder time."))
         } else {

--- a/GraceNotes/GraceNotes/Features/Settings/SettingsTargetHighlightModifier.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/SettingsTargetHighlightModifier.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct SettingsTargetHighlightModifier: ViewModifier {
+    @Environment(\.interactionAccentPalette) private var interactionAccent
     let isHighlighted: Bool
 
     func body(content: Content) -> some View {
@@ -16,7 +17,7 @@ struct SettingsTargetHighlightModifier: ViewModifier {
             .overlay {
                 if isHighlighted {
                     RoundedRectangle(cornerRadius: AppTheme.cornerRadiusMedium)
-                        .stroke(AppTheme.accent, lineWidth: 1)
+                        .stroke(interactionAccent.accent, lineWidth: 1)
                 }
             }
     }

--- a/GraceNotes/GraceNotes/Localizable.xcstrings
+++ b/GraceNotes/GraceNotes/Localizable.xcstrings
@@ -5996,6 +5996,7 @@
       }
     },
     "Settings.advanced.accent.ocean": {
+      "extractionState": "stale",
       "localizations": {
         "en": {
           "stringUnit": {
@@ -6012,6 +6013,7 @@
       }
     },
     "Settings.advanced.accent.plum": {
+      "extractionState": "stale",
       "localizations": {
         "en": {
           "stringUnit": {

--- a/GraceNotes/GraceNotes/Localizable.xcstrings
+++ b/GraceNotes/GraceNotes/Localizable.xcstrings
@@ -5947,6 +5947,102 @@
         }
       }
     },
+    "Settings.advanced.accent.label": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Highlight color"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "高亮色"
+          }
+        }
+      }
+    },
+    "Settings.advanced.accent.footnote": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Applies to tabs, buttons, and other controls—not the journal page background."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "用于标签栏、按钮等控件，不包括日记页背景。"
+          }
+        }
+      }
+    },
+    "Settings.advanced.accent.terracotta": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terracotta"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "陶土色"
+          }
+        }
+      }
+    },
+    "Settings.advanced.accent.ocean": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ocean"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "海洋色"
+          }
+        }
+      }
+    },
+    "Settings.advanced.accent.plum": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Plum"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "梅紫色"
+          }
+        }
+      }
+    },
+    "Settings.advanced.accent.forest": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Forest"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "森林绿"
+          }
+        }
+      }
+    },
     "Settings.ai.a11y.enableForConnectionCheck": {
       "extractionState": "stale",
       "localizations": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements [GitHub issue #215](https://github.com/kipyin/grace-notes/issues/215): **Highlight color** presets under **Settings → Advanced** (Terracotta, Ocean, Plum, Forest). The choice is stored in `UserDefaults` (`journalAccentPreference`) and drives app-wide interaction chrome: tab bar `.tint`, toggles, onboarding/tutorial chips, Past/review accents, and **Today** journal chrome tokens (`activeEditingAccent*`, add-row accent text) via `TodayJournalPalette` + `JournalScreen`.

Paper backgrounds, body text assets, and completion/tier greens are unchanged.

## Verification

- `swiftlint lint` on touched files (Linux static binary); no new violations in edited paths.
- iOS build and simulator tests were **not** run here (Linux agent); please run `grace ci` on macOS before merge.

Closes #215.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4c589abc-cedc-42b2-8829-8d1cf93e6725"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c589abc-cedc-42b2-8829-8d1cf93e6725"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

