### PR TITLE
fix: Bloom mode toggle shows localized label

### DIFF
--- a/GraceNotes/GraceNotes/Localizable.xcstrings
+++ b/GraceNotes/GraceNotes/Localizable.xcstrings
@@ -466,7 +466,22 @@
         }
       }
     },
-    "journal.growthStage.bloom": {},
+    "journal.growthStage.bloom": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bloom"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "花开有成"
+          }
+        }
+      }
+    },
     "review.insights.bothThemesMultiple": {
       "localizations": {
         "en": {


### PR DESCRIPTION
## Summary

The Advanced Settings toggle for today’s journal Bloom appearance used `journal.growthStage.bloom`, but `Localizable.xcstrings` had an empty entry for that key, so SwiftUI displayed the raw key.

## Change

- Filled `journal.growthStage.bloom` with the same English and Simplified Chinese copy as `journal.growthStage.full` (**Bloom** / **花开有成**).

## Testing

- `grace test --kind unit` (iPhone 17 Pro, iOS 26.4) — pass
- `grace l10n audit` — pass

`main` is unchanged; work is on this branch only.

Made with [Cursor](https://cursor.com)