### PR TITLE
feat(grace): issue #223 CLI backlog (plan + implementation)

### DIFF
--- a/Scripts/gracenotes-dev/README.md
+++ b/Scripts/gracenotes-dev/README.md
@@ -9,3 +9,27 @@ uv tool install --editable ./Scripts/gracenotes-dev
 ```
 
 The console script is `grace`. See `grace --help` after install.
+
+Configuration lives in the repo root file [`gracenotes-dev.toml`](../../gracenotes-dev.toml).
+
+## Command cheat sheet
+
+| Command | Purpose | Example |
+| ------- | ------- | ------- |
+| `grace doctor` | Toolchain + destination preflight | `grace doctor` |
+| `grace doctor --json` | Machine-readable doctor output | `grace doctor --json` |
+| `grace doctor --strict` | Same as doctor, nonzero exit if any check is not ok | `grace doctor --strict` |
+| `grace sim list` | Simulator destinations | `grace sim list` |
+| `grace lint` | Run SwiftLint via `grace` (extra args forwarded) | `grace lint -- --fix` |
+| `grace build` | xcodebuild build | `grace build --clean` |
+| `grace test` | xcodebuild test (matrix supported) | `grace test --kind unit --matrix` |
+| `grace run` | Build, install, launch app | `grace run --dry-run` |
+| `grace ci` | Run a configured CI profile | `grace ci --profile lint-build` |
+| `grace config list` | Show effective config | `grace config list` |
+| `grace l10n audit` | String catalog vs Swift literals | `grace l10n audit --json` |
+
+Global flags (before the subcommand): `grace --repo-root /path/to/grace-notes …` uses that directory as the start of repo discovery; same via `GRACE_REPO_ROOT`. Use `grace COMMAND --dry-run` (or `--print-command`) on `build`, `clean`, `test`, `run`, and `ci` to print tool argv without executing.
+
+## Shell completion (optional)
+
+[Typer](https://typer.tiangolo.com/) supports shell completion for CLI apps; see Typer’s “CLI Options” / completion docs if you want to install completion for `grace` in your shell.

--- a/Scripts/gracenotes-dev/README.md
+++ b/Scripts/gracenotes-dev/README.md
@@ -28,7 +28,9 @@ Configuration lives in the repo root file [`gracenotes-dev.toml`](../../gracenot
 | `grace config list` | Show effective config | `grace config list` |
 | `grace l10n audit` | String catalog vs Swift literals | `grace l10n audit --json` |
 
-Global flags (before the subcommand): `grace --repo-root /path/to/grace-notes …` uses that directory as the start of repo discovery; same via `GRACE_REPO_ROOT`. Use `grace COMMAND --dry-run` (or `--print-command`) on `build`, `clean`, `test`, `run`, and `ci` to print tool argv without executing.
+Global flags (before the subcommand): `grace --repo-root /path/to/grace-notes …` uses that directory as the start of repo discovery; same via `GRACE_REPO_ROOT`.
+
+`--dry-run` / `--print-command` on `build`, `clean`, `test`, `run`, and `ci` prints the argv for each workflow step (build, test, install, reset, etc.) without executing those steps. **Simulator discovery** (`xcrun simctl list` and similar) may still run so resolved destinations match a normal run.
 
 ## Shell completion (optional)
 

--- a/Scripts/gracenotes-dev/src/gracenotes_dev/cli/__init__.py
+++ b/Scripts/gracenotes-dev/src/gracenotes_dev/cli/__init__.py
@@ -2,23 +2,24 @@
 
 from __future__ import annotations
 
-import importlib
+import importlib  # noqa: F401 — ``cli.importlib`` (tests patch metadata.version)
+from pathlib import Path
 from typing import Annotated
 
 import typer
 
-from gracenotes_dev import simulator_runtime
-from gracenotes_dev import xcode as xcode_helpers
+from gracenotes_dev import simulator_runtime  # noqa: F401 — ``cli.simulator_runtime`` (tests)
+from gracenotes_dev import xcode as xcode_helpers  # noqa: F401 — ``cli.xcode_helpers`` (tests)
 from gracenotes_dev.cli.apps import app, config_app, runtime_app, sim_app
 from gracenotes_dev.cli.core import (
     _cli_version,
-    _interactive_cli_allowed,
-    _prepare_xcodebuild_argv,
-    _print_error_block,
+    _interactive_cli_allowed,  # noqa: F401
+    _prepare_xcodebuild_argv,  # noqa: F401
+    _print_error_block,  # noqa: F401
     _stdout_console,
-    _supports_rich_output,
+    _supports_rich_output,  # noqa: F401
 )
-from gracenotes_dev.cli.sim import _sim_interactive
+from gracenotes_dev.cli.sim import _sim_interactive  # noqa: F401
 
 
 def _version_callback(value: bool) -> None:
@@ -30,6 +31,7 @@ def _version_callback(value: bool) -> None:
 
 @app.callback()
 def app_callback(
+    ctx: typer.Context,
     version: Annotated[
         bool,
         typer.Option(
@@ -39,8 +41,21 @@ def app_callback(
             is_eager=True,
         ),
     ] = False,
+    repo_root: Annotated[
+        Path | None,
+        typer.Option(
+            "--repo-root",
+            help=(
+                "Directory to start repo discovery from (walk-up finds GraceNotes/). "
+                "Default: current working directory."
+            ),
+            envvar="GRACE_REPO_ROOT",
+        ),
+    ] = None,
 ) -> None:
-    _ = version
+    ctx.ensure_object(dict)
+    if repo_root is not None:
+        ctx.obj["repo_root_start"] = repo_root.resolve()
 
 
 from gracenotes_dev.cli import config_cmd as _config_cmd  # noqa: E402, F401
@@ -49,23 +64,11 @@ from gracenotes_dev.cli import l10n_cmd as _l10n_cmd  # noqa: E402, F401
 from gracenotes_dev.cli import sim as _sim  # noqa: E402, F401
 from gracenotes_dev.cli import workflows as _workflows  # noqa: E402, F401
 from gracenotes_dev.cli.config_cmd import config_interactive  # noqa: E402
-from gracenotes_dev.cli.workflows import _execute_ci_profile  # noqa: E402
 
 __all__ = [
     "app",
     "config_app",
     "config_interactive",
-    "importlib",
     "runtime_app",
     "sim_app",
-    "simulator_runtime",
-    "xcode_helpers",
-    "_cli_version",
-    "_execute_ci_profile",
-    "_interactive_cli_allowed",
-    "_prepare_xcodebuild_argv",
-    "_print_error_block",
-    "_sim_interactive",
-    "_stdout_console",
-    "_supports_rich_output",
 ]

--- a/Scripts/gracenotes-dev/src/gracenotes_dev/cli/apps.py
+++ b/Scripts/gracenotes-dev/src/gracenotes_dev/cli/apps.py
@@ -17,6 +17,15 @@ app = typer.Typer(
         "  grace build --clean\n"
         '  grace test --kind unit --destination "iPhone 17 Pro@latest"\n'
         '  grace run --destination "iPhone 17 Pro@latest" -- -reset-journal-tutorial\n'
+        "\nEnvironment:\n"
+        "  NO_COLOR                 Disable Rich styling.\n"
+        "  CI                       Disallow interactive prompts; fuller xcodebuild logs "
+        "where applicable.\n"
+        "  GRACE_NONINTERACTIVE=1   Disallow interactive prompts.\n"
+        "  GRACE_RUN_STREAM_TOOL_OUTPUT  Set to 1/true/yes to stream tool output during "
+        "``grace run``.\n"
+        "  GRACE_REPO_ROOT          Optional directory for repo discovery "
+        "(see ``grace --help``).\n"
         "\nTip: run `grace --version` to confirm your installed CLI release."
     ),
 )

--- a/Scripts/gracenotes-dev/src/gracenotes_dev/cli/core.py
+++ b/Scripts/gracenotes-dev/src/gracenotes_dev/cli/core.py
@@ -580,8 +580,17 @@ def _run(
     check: bool = True,
     verbose: bool = False,
     silent: bool = False,
+    dry_run: bool = False,
 ) -> subprocess.CompletedProcess[str]:
     prepared_argv = _prepare_xcodebuild_argv(argv, verbose=verbose, silent=silent)
+    if dry_run:
+        _stdout_console().print(f"DRY-RUN: {shlex.join(prepared_argv)}")
+        return subprocess.CompletedProcess(
+            args=prepared_argv,
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
     use_capture = silent
     try:
         if use_capture:
@@ -615,8 +624,17 @@ def _run_capture(
     check: bool = True,
     verbose: bool = False,
     silent: bool = False,
+    dry_run: bool = False,
 ) -> subprocess.CompletedProcess[str]:
     prepared_argv = _prepare_xcodebuild_argv(argv, verbose=verbose, silent=silent)
+    if dry_run:
+        _stdout_console().print(f"DRY-RUN: {shlex.join(prepared_argv)}")
+        return subprocess.CompletedProcess(
+            args=prepared_argv,
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
     try:
         completed = subprocess.run(
             prepared_argv,

--- a/Scripts/gracenotes-dev/src/gracenotes_dev/cli/core.py
+++ b/Scripts/gracenotes-dev/src/gracenotes_dev/cli/core.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TypeVar
 
+import click
 import questionary
 import tomlkit
 import typer
@@ -256,6 +257,11 @@ def _run_theater(steps: list[TheaterStep], *, terse: bool = False) -> float:
 
 
 def _repo_root() -> Path:
+    ctx = click.get_current_context(silent=True)
+    if ctx is not None and isinstance(getattr(ctx, "obj", None), dict):
+        start = ctx.obj.get("repo_root_start")
+        if start is not None:
+            return xcode_helpers.repo_root_from(Path(start))
     return xcode_helpers.repo_root_from(Path.cwd())
 
 
@@ -987,6 +993,7 @@ def _run_test_once(
     kind: str,
     isolated_dd: bool,
     verbose: bool,
+    dry_run: bool = False,
 ) -> None:
     if kind == "all" and cfg.parallel_testing_unit != cfg.parallel_testing_ui:
         _run_test_once(
@@ -996,8 +1003,9 @@ def _run_test_once(
             kind="unit",
             isolated_dd=isolated_dd,
             verbose=verbose,
+            dry_run=dry_run,
         )
-        _reset_sims(repo_root)
+        _reset_sims(repo_root, dry_run=dry_run)
         _run_test_once(
             cfg=cfg,
             repo_root=repo_root,
@@ -1005,6 +1013,7 @@ def _run_test_once(
             kind="ui",
             isolated_dd=isolated_dd,
             verbose=verbose,
+            dry_run=dry_run,
         )
         return
 
@@ -1018,10 +1027,10 @@ def _run_test_once(
         parallel_testing=_parallel_testing_for_kind(cfg, kind),
         legacy_skip_flags=cfg.legacy_runtime_skip_flags,
     )
-    _run(argv, cwd=repo_root, check=True, verbose=verbose)
+    _run(argv, cwd=repo_root, check=True, verbose=verbose, dry_run=dry_run)
 
 
-def _reset_sims(repo_root: Path) -> None:
+def _reset_sims(repo_root: Path, *, dry_run: bool = False) -> None:
     shutdown, erase = xcode_helpers.simctl_reset_all_argv()
-    _run(shutdown, cwd=repo_root, check=False)
-    _run(erase, cwd=repo_root, check=False)
+    _run(shutdown, cwd=repo_root, check=False, dry_run=dry_run)
+    _run(erase, cwd=repo_root, check=False, dry_run=dry_run)

--- a/Scripts/gracenotes-dev/src/gracenotes_dev/cli/doctor_lint.py
+++ b/Scripts/gracenotes-dev/src/gracenotes_dev/cli/doctor_lint.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import shutil
 import sys
+from collections.abc import Sequence
 from typing import Annotated
 
 import typer
@@ -30,11 +31,30 @@ from gracenotes_dev.cli.workflows import (
 )
 
 
+def _doctor_strict_should_fail(checks: list[dict[str, object]]) -> bool:
+    return any(str(item["status"]) not in ("ok", "skipped") for item in checks)
+
+
+def run_lint(*, extras: Sequence[str] = (), dry_run: bool = False) -> None:
+    if not dry_run:
+        cli_core._require_swiftlint()
+    repo_root = cli_core._repo_root()
+    argv = ["swiftlint", "lint", *extras]
+    cli_core._run(argv, cwd=repo_root, check=True, dry_run=dry_run)
+
+
 @app.command("doctor")
 def doctor(
     json_out: Annotated[
         bool,
         typer.Option("--json", help="Emit machine-readable health checks."),
+    ] = False,
+    strict: Annotated[
+        bool,
+        typer.Option(
+            "--strict",
+            help="Exit with code 1 when any check is not ok (skipped checks do not fail).",
+        ),
     ] = False,
 ) -> None:
     """Preflight check for local toolchain and configured simulator defaults."""
@@ -112,6 +132,8 @@ def doctor(
             indent=2,
         )
         sys.stdout.write("\n")
+        if strict and _doctor_strict_should_fail(checks):
+            raise typer.Exit(code=1)
         return
 
     table = Table(show_header=True, header_style="bold")
@@ -123,14 +145,27 @@ def doctor(
             str(item["name"]), cli_rich.status_text(str(item["status"])), str(item["detail"])
         )
     cli_core._stdout_console().print(table)
+    if strict and _doctor_strict_should_fail(checks):
+        raise typer.Exit(code=1)
 
 
-@app.command("lint")
-def lint() -> None:
-    """Run swiftlint from repository root."""
-    cli_core._require_swiftlint()
-    repo_root = cli_core._repo_root()
-    cli_core._run(["swiftlint", "lint"], cwd=repo_root, check=True)
+@app.command(
+    "lint",
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+)
+def lint(
+    ctx: typer.Context,
+    dry_run: Annotated[
+        bool,
+        typer.Option(
+            "--dry-run",
+            "--print-command",
+            help="Print the swiftlint argv without running.",
+        ),
+    ] = False,
+) -> None:
+    """Run swiftlint from repository root; extra arguments are forwarded (e.g. ``--fix``)."""
+    run_lint(extras=tuple(ctx.args), dry_run=dry_run)
 
 
 @app.command("interactive")
@@ -162,7 +197,7 @@ def interactive() -> None:
         show_verbose = cli_core._require_prompt_answer(
             cli_core._q_confirm("Show full xcodebuild logs?", default=False).ask(),
         )
-        _execute_ci_profile(cfg, profile, verbose=show_verbose)
+        _execute_ci_profile(cfg, profile, verbose=show_verbose, dry_run=False)
         return
     if choice == "Build":
         cli_core._require_macos_xcode()
@@ -239,7 +274,7 @@ def interactive() -> None:
         )
         return
     if choice == "Lint":
-        lint()
+        run_lint()
         return
     if choice == "Clean":
         cli_core._require_macos_xcode()

--- a/Scripts/gracenotes-dev/src/gracenotes_dev/cli/l10n_cmd.py
+++ b/Scripts/gracenotes-dev/src/gracenotes_dev/cli/l10n_cmd.py
@@ -17,7 +17,6 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
-from gracenotes_dev import xcode as xcode_helpers
 from gracenotes_dev.cli import core as cli_core
 from gracenotes_dev.cli.apps import l10n_app
 
@@ -144,6 +143,21 @@ def build_strings_catalog_audit(repo_root: Path) -> StringsCatalogAuditReport:
         duplicate_english_groups=duplicate_english_groups,
         multi_file_keys=multi_file_keys,
     )
+
+
+def audit_report_to_json_dict(report: StringsCatalogAuditReport) -> dict[str, object]:
+    return {
+        "catalog_key_count": report.catalog_key_count,
+        "code_key_count": report.code_key_count,
+        "unused_keys": list(report.unused_keys),
+        "missing_keys": list(report.missing_keys),
+        "duplicate_english_groups": [
+            {"english": en, "keys": list(ks)} for en, ks in report.duplicate_english_groups
+        ],
+        "multi_file_keys": [
+            {"key": k, "paths": list(paths)} for k, paths in report.multi_file_keys
+        ],
+    }
 
 
 def _render_focused_plain(report: StringsCatalogAuditReport, stream: TextIOBase) -> None:
@@ -557,9 +571,13 @@ def l10n_audit(
             help="Print exhaustive tables instead of the short summary and next steps.",
         ),
     ] = False,
+    json_out: Annotated[
+        bool,
+        typer.Option("--json", help="Emit machine-readable audit (counts and key lists)."),
+    ] = False,
 ) -> None:
     """Compare Localizable.xcstrings keys to Swift ``String(localized:)`` / ``localized:`` usage."""
-    repo_root = xcode_helpers.repo_root_from(Path.cwd())
+    repo_root = cli_core._repo_root()
     catalog = repo_root / "GraceNotes/GraceNotes/Localizable.xcstrings"
     if not catalog.is_file():
         cli_core._fail(
@@ -569,6 +587,11 @@ def l10n_audit(
             likely_cause="Run from the Grace Notes repo root (directory containing GraceNotes/).",
             try_commands=("cd …/grace-notes", "grace l10n audit"),
         )
+    if json_out:
+        report = build_strings_catalog_audit(repo_root)
+        json.dump(audit_report_to_json_dict(report), sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return
     print_strings_catalog_audit(repo_root=repo_root, full=full)
 
 
@@ -596,7 +619,7 @@ def l10n_review_cmd(
 
     Scans keys referenced from Swift (see ``grace l10n audit`` for catalog-only issues).
     """
-    repo_root = xcode_helpers.repo_root_from(Path.cwd())
+    repo_root = cli_core._repo_root()
     catalog = repo_root / "GraceNotes/GraceNotes/Localizable.xcstrings"
     if not catalog.is_file():
         cli_core._fail(

--- a/Scripts/gracenotes-dev/src/gracenotes_dev/cli/workflows.py
+++ b/Scripts/gracenotes-dev/src/gracenotes_dev/cli/workflows.py
@@ -331,8 +331,7 @@ def test(
             cli_core.TheaterStep(
                 "Reset simulators",
                 lambda dr=dry_run: (
-                    cli_core._reset_sims(repo_root, dry_run=dr)
-                    or "shutdown all + erase all"
+                    cli_core._reset_sims(repo_root, dry_run=dr) or "shutdown all + erase all"
                 ),
             ),
         )

--- a/Scripts/gracenotes-dev/src/gracenotes_dev/cli/workflows.py
+++ b/Scripts/gracenotes-dev/src/gracenotes_dev/cli/workflows.py
@@ -26,7 +26,10 @@ DryRunOption = Annotated[
     typer.Option(
         "--dry-run",
         "--print-command",
-        help="Print xcodebuild/simctl argv for each step without executing.",
+        help=(
+            "Print xcodebuild/simctl argv for workflow steps without running them. "
+            "Simulator listing (xcrun simctl) may still run so destinations match a real run."
+        ),
     ),
 ]
 

--- a/Scripts/gracenotes-dev/src/gracenotes_dev/cli/workflows.py
+++ b/Scripts/gracenotes-dev/src/gracenotes_dev/cli/workflows.py
@@ -21,6 +21,15 @@ from gracenotes_dev.cli.sim import (
     _prompt_test_options,
 )
 
+DryRunOption = Annotated[
+    bool,
+    typer.Option(
+        "--dry-run",
+        "--print-command",
+        help="Print xcodebuild/simctl argv for each step without executing.",
+    ),
+]
+
 
 @app.command("build")
 def build(
@@ -58,6 +67,7 @@ def build(
         bool,
         typer.Option("--verbose", "-v", help="Show full xcodebuild logs."),
     ] = False,
+    dry_run: DryRunOption = False,
 ) -> None:
     """Build the Grace Notes app for a Simulator or physical device destination."""
     cli_core._require_macos_xcode()
@@ -95,11 +105,11 @@ def build(
         return resolved_destination
 
     def clean_step() -> str:
-        cli_core._run(clean_argv, cwd=repo_root, check=True, verbose=verbose)
+        cli_core._run(clean_argv, cwd=repo_root, check=True, verbose=verbose, dry_run=dry_run)
         return " ".join(clean_argv)
 
     def build_step() -> str:
-        cli_core._run(build_argv, cwd=repo_root, check=True, verbose=verbose)
+        cli_core._run(build_argv, cwd=repo_root, check=True, verbose=verbose, dry_run=dry_run)
         return " ".join(build_argv)
 
     steps = [
@@ -140,6 +150,7 @@ def clean(
         bool,
         typer.Option("--verbose", "-v", help="Show full xcodebuild logs."),
     ] = False,
+    dry_run: DryRunOption = False,
 ) -> None:
     """Run xcodebuild clean for the Grace Notes scheme (Xcode Clean Build Folder scope)."""
     cli_core._require_macos_xcode()
@@ -169,7 +180,7 @@ def clean(
         return resolved_destination
 
     def clean_step() -> str:
-        cli_core._run(argv, cwd=repo_root, check=True, verbose=verbose)
+        cli_core._run(argv, cwd=repo_root, check=True, verbose=verbose, dry_run=dry_run)
         return " ".join(argv)
 
     cli_core._run_theater(
@@ -218,6 +229,7 @@ def test(
         bool,
         typer.Option("--verbose", "-v", help="Show full xcodebuild logs."),
     ] = False,
+    dry_run: DryRunOption = False,
 ) -> None:
     """Run xcodebuild tests (single destination or matrix)."""
     cli_core._require_macos_xcode()
@@ -280,13 +292,16 @@ def test(
                 steps.append(
                     cli_core.TheaterStep(
                         "Reset simulators",
-                        lambda: (cli_core._reset_sims(repo_root) or "shutdown all + erase all"),
+                        lambda dr=dry_run: (
+                            cli_core._reset_sims(repo_root, dry_run=dr)
+                            or "shutdown all + erase all"
+                        ),
                     ),
                 )
             steps.append(
                 cli_core.TheaterStep(
                     f"Run {selected_kind} tests",
-                    lambda resolved_destination=resolved_destination: (
+                    lambda resolved_destination=resolved_destination, dr=dry_run: (
                         cli_core._run_test_once(
                             cfg=cfg,
                             repo_root=repo_root,
@@ -294,6 +309,7 @@ def test(
                             kind=selected_kind,
                             isolated_dd=isolated_dd,
                             verbose=verbose,
+                            dry_run=dr,
                         )
                         or resolved_destination
                     ),
@@ -314,7 +330,10 @@ def test(
         steps.append(
             cli_core.TheaterStep(
                 "Reset simulators",
-                lambda: (cli_core._reset_sims(repo_root) or "shutdown all + erase all"),
+                lambda dr=dry_run: (
+                    cli_core._reset_sims(repo_root, dry_run=dr)
+                    or "shutdown all + erase all"
+                ),
             ),
         )
     steps.append(cli_core.TheaterStep("Resolve destination", lambda: resolved_destination))
@@ -324,9 +343,9 @@ def test(
         steps.append(
             cli_core.TheaterStep(
                 "Boot simulator",
-                lambda: (
-                    cli_core._run(boot, cwd=repo_root, check=False),
-                    cli_core._run(bootstatus, cwd=repo_root, check=False),
+                lambda dr=dry_run: (
+                    cli_core._run(boot, cwd=repo_root, check=False, dry_run=dr),
+                    cli_core._run(bootstatus, cwd=repo_root, check=False, dry_run=dr),
                 )
                 and simulator_name,
             ),
@@ -335,7 +354,7 @@ def test(
     steps.append(
         cli_core.TheaterStep(
             f"Run {selected_kind} tests",
-            lambda: (
+            lambda dr=dry_run: (
                 cli_core._run_test_once(
                     cfg=cfg,
                     repo_root=repo_root,
@@ -343,6 +362,7 @@ def test(
                     kind=selected_kind,
                     isolated_dd=isolated_dd,
                     verbose=verbose,
+                    dry_run=dr,
                 )
                 or resolved_destination
             ),
@@ -355,7 +375,13 @@ def test(
     )
 
 
-def _execute_ci_profile(cfg: config.DevConfig, profile: str, *, verbose: bool = False) -> None:
+def _execute_ci_profile(
+    cfg: config.DevConfig,
+    profile: str,
+    *,
+    verbose: bool = False,
+    dry_run: bool = False,
+) -> None:
     """Run lint / build / test / smoke gates for a configured CI profile name."""
     selected = cfg.ci_profiles.get(profile)
     if selected is None:
@@ -370,16 +396,20 @@ def _execute_ci_profile(cfg: config.DevConfig, profile: str, *, verbose: bool = 
         return
 
     if selected.lint:
-        from gracenotes_dev.cli.doctor_lint import lint as lint_command
+        from gracenotes_dev.cli.doctor_lint import run_lint
 
-        lint_command()
+        run_lint(dry_run=dry_run)
 
     needs_xcode = selected.build or selected.test or selected.smoke
     if needs_xcode:
         cli_core._require_macos_xcode()
 
     if selected.build:
-        build(destination=selected.build_destination or cfg.ci_simulator_pro, verbose=verbose)
+        build(
+            destination=selected.build_destination or cfg.ci_simulator_pro,
+            verbose=verbose,
+            dry_run=dry_run,
+        )
 
     if selected.test:
         test(
@@ -389,6 +419,7 @@ def _execute_ci_profile(cfg: config.DevConfig, profile: str, *, verbose: bool = 
             isolated_dd=selected.isolated_dd,
             no_reset_sims=not selected.reset_simulators_before_test,
             verbose=verbose,
+            dry_run=dry_run,
         )
 
     if selected.smoke:
@@ -399,6 +430,7 @@ def _execute_ci_profile(cfg: config.DevConfig, profile: str, *, verbose: bool = 
             isolated_dd=selected.isolated_dd,
             no_reset_sims=False,
             verbose=verbose,
+            dry_run=dry_run,
         )
 
 
@@ -411,7 +443,8 @@ def ci(
             help=(
                 "CI profile from config (for example: lint-build, lint-build-test, "
                 "test-all, full). "
-                "When omitted, uses defaults.default_ci_profile from gracenotes-dev.toml."
+                "When omitted, uses defaults.default_ci_profile from gracenotes-dev.toml. "
+                "List names with `grace config list`."
             ),
         ),
     ] = None,
@@ -423,6 +456,7 @@ def ci(
         bool,
         typer.Option("--verbose", "-v", help="Show full xcodebuild logs."),
     ] = False,
+    dry_run: DryRunOption = False,
 ) -> None:
     """Run a CI profile from ``gracenotes-dev.toml`` (default: ``defaults.default_ci_profile``)."""
     repo_root = cli_core._repo_root()
@@ -431,7 +465,7 @@ def ci(
         cli_core._require_interactive_cli(cfg=cfg, command_name="grace ci --interactive")
         profile = _prompt_ci_profile(cfg=cfg, profile=profile)
     resolved = (profile or "").strip() or cfg.default_ci_profile
-    _execute_ci_profile(cfg, resolved, verbose=verbose)
+    _execute_ci_profile(cfg, resolved, verbose=verbose, dry_run=dry_run)
 
 
 @app.command(
@@ -483,6 +517,7 @@ def run(
             ),
         ),
     ] = False,
+    dry_run: DryRunOption = False,
 ) -> None:
     """Build, install, and launch Grace Notes on an iOS Simulator or connected device."""
     cli_core._require_macos_xcode()
@@ -573,7 +608,14 @@ def run(
             configuration=launch_configuration,
             derived_data_path=derived_data_path,
         )
-        cli_core._run(argv, cwd=repo_root, check=True, verbose=verbose, silent=run_quiet_output)
+        cli_core._run(
+            argv,
+            cwd=repo_root,
+            check=True,
+            verbose=verbose,
+            silent=run_quiet_output,
+            dry_run=dry_run,
+        )
         return " ".join(argv)
 
     if xcode_helpers.is_physical_ios_destination(resolved_destination):
@@ -600,6 +642,7 @@ def run(
                 check=True,
                 silent=run_quiet_output,
                 verbose=verbose,
+                dry_run=dry_run,
             )
             return f"{app_path.name} -> {device_udid}"
 
@@ -614,6 +657,7 @@ def run(
                 check=True,
                 verbose=verbose,
                 silent=run_quiet_output,
+                dry_run=dry_run,
             )
             detail = completed.stdout.strip() if completed.stdout else ""
             if expanded_args:
@@ -658,6 +702,7 @@ def run(
             check=False,
             silent=run_quiet_output,
             verbose=verbose,
+            dry_run=dry_run,
         )
         cli_core._run(
             bootstatus,
@@ -665,6 +710,7 @@ def run(
             check=False,
             silent=run_quiet_output,
             verbose=verbose,
+            dry_run=dry_run,
         )
         return udid
 
@@ -681,6 +727,7 @@ def run(
             check=True,
             silent=run_quiet_output,
             verbose=verbose,
+            dry_run=dry_run,
         )
         return f"{app_path.name} -> {udid}"
 
@@ -695,6 +742,7 @@ def run(
             check=True,
             verbose=verbose,
             silent=run_quiet_output,
+            dry_run=dry_run,
         )
         detail = completed.stdout.strip() if completed.stdout else ""
         if expanded_args:

--- a/Scripts/gracenotes-dev/tests/test_cli_surface.py
+++ b/Scripts/gracenotes-dev/tests/test_cli_surface.py
@@ -1071,6 +1071,38 @@ class CLISurfaceTest(unittest.TestCase):
                 )
         self.assertEqual(argv, ["xcodebuild", "-quiet", "build"])
 
+    def test_dry_run_skips_subprocess_for_run(self) -> None:
+        argv = ["echo", "hello"]
+        calls: list[list[str]] = []
+
+        def fake_run(cmd: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+            calls.append(list(cmd))  # type: ignore[arg-type]
+            return subprocess.run(cmd, **kwargs)  # type: ignore[arg-type]
+
+        with mock.patch.object(subprocess, "run", side_effect=fake_run):
+            completed = cli_core._run(argv, cwd=Path("/tmp"), dry_run=True)
+
+        self.assertEqual(calls, [])
+        self.assertEqual(completed.returncode, 0)
+        self.assertEqual(completed.stdout, "")
+        self.assertEqual(completed.stderr, "")
+
+    def test_dry_run_skips_subprocess_for_run_capture(self) -> None:
+        argv = ["echo", "capture"]
+        calls: list[list[str]] = []
+
+        def fake_run(cmd: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+            calls.append(list(cmd))  # type: ignore[arg-type]
+            return subprocess.run(cmd, **kwargs)  # type: ignore[arg-type]
+
+        with mock.patch.object(subprocess, "run", side_effect=fake_run):
+            completed = cli_core._run_capture(argv, cwd=Path("/tmp"), dry_run=True)
+
+        self.assertEqual(calls, [])
+        self.assertEqual(completed.returncode, 0)
+        self.assertEqual(completed.stdout, "")
+        self.assertEqual(completed.stderr, "")
+
     def test_config_set_updates_value_in_toml(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/Scripts/gracenotes-dev/tests/test_cli_surface.py
+++ b/Scripts/gracenotes-dev/tests/test_cli_surface.py
@@ -49,6 +49,9 @@ class CLISurfaceTest(unittest.TestCase):
         self.assertIn("Examples:", result.output)
         self.assertIn("grace doctor", result.output)
         self.assertIn("grace build --clean", result.output)
+        self.assertIn("Environment:", result.output)
+        self.assertIn("GRACE_NONINTERACTIVE", result.output)
+        self.assertIn("--repo-root", result.output)
 
     def test_build_help_includes_clean_option(self) -> None:
         runner = CliRunner()
@@ -117,6 +120,7 @@ class CLISurfaceTest(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0, msg=result.output)
         self.assertIn("--full", result.output)
+        self.assertIn("--json", result.output)
 
     def test_l10n_audit_focused_plain_output_against_repo_fixture(self) -> None:
         repo_root = Path(__file__).resolve().parents[3]
@@ -287,6 +291,7 @@ class CLISurfaceTest(unittest.TestCase):
             cwd: Path,
             check: bool = True,
             verbose: bool = False,
+            **_: object,
         ) -> subprocess.CompletedProcess[str]:
             captured.append(list(argv))
             return subprocess.CompletedProcess(argv, 0, "", "")
@@ -329,6 +334,7 @@ class CLISurfaceTest(unittest.TestCase):
             cwd: Path,
             check: bool = True,
             verbose: bool = False,
+            **_: object,
         ) -> subprocess.CompletedProcess[str]:
             captured.append(list(argv))
             return subprocess.CompletedProcess(argv, 0, "", "")
@@ -371,6 +377,7 @@ class CLISurfaceTest(unittest.TestCase):
             cwd: Path,
             check: bool = True,
             verbose: bool = False,
+            **_: object,
         ) -> subprocess.CompletedProcess[str]:
             captured.append(list(argv))
             return subprocess.CompletedProcess(argv, 0, "", "")
@@ -452,6 +459,12 @@ class CLISurfaceTest(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 2)
 
+    def test_ci_help_mentions_config_list(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(app, ["ci", "--help"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertIn("config list", result.output)
+
     def test_unknown_ci_profile_uses_designed_error_shape(self) -> None:
         runner = CliRunner()
         result = runner.invoke(app, ["ci", "--profile", "missing-profile"])
@@ -470,7 +483,7 @@ class CLISurfaceTest(unittest.TestCase):
                     result = runner.invoke(app, ["ci"])
 
         self.assertEqual(result.exit_code, 0, msg=result.output)
-        run_ci.assert_called_once_with(cfg, "test-all", verbose=False)
+        run_ci.assert_called_once_with(cfg, "test-all", verbose=False, dry_run=False)
 
     def test_ci_with_explicit_profile_passes_through(self) -> None:
         repo_root = Path(__file__).resolve().parents[3]
@@ -482,7 +495,7 @@ class CLISurfaceTest(unittest.TestCase):
                     result = runner.invoke(app, ["ci", "--profile", "full"])
 
         self.assertEqual(result.exit_code, 0, msg=result.output)
-        run_ci.assert_called_once_with(cfg, "full", verbose=False)
+        run_ci.assert_called_once_with(cfg, "full", verbose=False, dry_run=False)
 
     def test_interactive_refused_when_stdin_not_tty(self) -> None:
         repo_root = Path(__file__).resolve().parents[3]
@@ -554,7 +567,7 @@ class CLISurfaceTest(unittest.TestCase):
                                     result = runner.invoke(app, ["interactive"])
 
         self.assertEqual(result.exit_code, 0, msg=f"{result.stdout}\n{result.stderr}")
-        run_ci.assert_called_once_with(cfg, "lint-build", verbose=True)
+        run_ci.assert_called_once_with(cfg, "lint-build", verbose=True, dry_run=False)
 
     def test_interactive_cancel_exits_with_code_one(self) -> None:
         repo_root = Path(__file__).resolve().parents[3]
@@ -610,6 +623,7 @@ class CLISurfaceTest(unittest.TestCase):
             check: bool = True,
             verbose: bool = False,
             silent: bool = False,
+            **_: object,
         ) -> subprocess.CompletedProcess[str]:
             capture_run.append(list(argv))
             return subprocess.CompletedProcess(argv, 0, "", "")
@@ -621,6 +635,7 @@ class CLISurfaceTest(unittest.TestCase):
             check: bool = True,
             verbose: bool = False,
             silent: bool = False,
+            **_: object,
         ) -> subprocess.CompletedProcess[str]:
             capture_capture.append(list(argv))
             return subprocess.CompletedProcess(argv, 0, "com.gracenotes.GraceNotes: 12345", "")
@@ -679,6 +694,7 @@ class CLISurfaceTest(unittest.TestCase):
             check: bool = True,
             verbose: bool = False,
             silent: bool = False,
+            **_: object,
         ) -> subprocess.CompletedProcess[str]:
             if argv[:1] == ["xcodebuild"]:
                 xcode_silents.append(silent)
@@ -691,6 +707,7 @@ class CLISurfaceTest(unittest.TestCase):
             check: bool = True,
             verbose: bool = False,
             silent: bool = False,
+            **_: object,
         ) -> subprocess.CompletedProcess[str]:
             return subprocess.CompletedProcess(argv, 0, "pid: 1", "")
 
@@ -731,6 +748,7 @@ class CLISurfaceTest(unittest.TestCase):
             check: bool = True,
             verbose: bool = False,
             silent: bool = False,
+            **_: object,
         ) -> subprocess.CompletedProcess[str]:
             if argv[:1] == ["xcodebuild"]:
                 xcode_silents.append(silent)
@@ -743,6 +761,7 @@ class CLISurfaceTest(unittest.TestCase):
             check: bool = True,
             verbose: bool = False,
             silent: bool = False,
+            **_: object,
         ) -> subprocess.CompletedProcess[str]:
             return subprocess.CompletedProcess(argv, 0, "pid: 1", "")
 
@@ -773,7 +792,7 @@ class CLISurfaceTest(unittest.TestCase):
         cfg = replace(config.default_config(), test_destination_matrix=("a", "b"))
         resets: list[str] = []
 
-        def count_reset(_: Path) -> None:
+        def count_reset(*_a: object, **_k: object) -> None:
             resets.append("reset")
 
         def noop_test_once(**_: object) -> None:
@@ -811,7 +830,7 @@ class CLISurfaceTest(unittest.TestCase):
         cfg = replace(config.default_config(), test_destination_matrix=("a", "b"))
         resets: list[str] = []
 
-        def count_reset(_: Path) -> None:
+        def count_reset(*_a: object, **_k: object) -> None:
             resets.append("reset")
 
         with mock.patch.object(cli_core, "_require_macos_xcode"):
@@ -1102,6 +1121,130 @@ class CLISurfaceTest(unittest.TestCase):
         self.assertEqual(completed.returncode, 0)
         self.assertEqual(completed.stdout, "")
         self.assertEqual(completed.stderr, "")
+
+    def test_build_dry_run_prints_xcodebuild_without_running(self) -> None:
+        repo_root = Path(__file__).resolve().parents[3]
+        cfg = replace(
+            config.default_config(),
+            destination="platform=iOS Simulator,name=iPhone 17 Pro,OS=latest",
+        )
+        rows = [
+            {"name": "iPhone 17 Pro", "runtime_version": "26.0", "runtime_key": "k1", "udid": "u1"},
+        ]
+
+        def fake_which(name: str) -> str | None:
+            if name in ("swiftlint", "xcodebuild", "xcrun"):
+                return f"/usr/bin/{name}"
+            return None
+
+        with mock.patch.object(cli_core, "_repo_root", return_value=repo_root):
+            with mock.patch.object(cli_core, "_load_config", return_value=cfg):
+                with mock.patch.object(simulator, "load_available_ios_devices", return_value=rows):
+                    with mock.patch.object(sys, "platform", "darwin"):
+                        with mock.patch.object(shutil, "which", side_effect=fake_which):
+                            with mock.patch.object(cli_core, "_run") as run_mock:
+                                runner = CliRunner()
+                                result = runner.invoke(app, ["build", "--dry-run"])
+
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        dry_kw = [c.kwargs.get("dry_run") for c in run_mock.call_args_list]
+        self.assertTrue(any(kw is True for kw in dry_kw))
+
+    def test_ci_dry_run_passes_through_to_execute_profile(self) -> None:
+        repo_root = Path(__file__).resolve().parents[3]
+        cfg = config.default_config()
+        with mock.patch.object(cli_core, "_repo_root", return_value=repo_root):
+            with mock.patch.object(cli_core, "_load_config", return_value=cfg):
+                with mock.patch.object(cli_workflows, "_execute_ci_profile") as run_ci:
+                    runner = CliRunner()
+                    result = runner.invoke(app, ["ci", "--dry-run"])
+
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        run_ci.assert_called_once_with(
+            cfg,
+            cfg.default_ci_profile,
+            verbose=False,
+            dry_run=True,
+        )
+
+    def test_doctor_strict_exits_nonzero_when_matrix_errors(self) -> None:
+        repo_root = Path(__file__).resolve().parents[3]
+        rows = [
+            {"name": "iPhone 17 Pro", "runtime_version": "26.0", "runtime_key": "k1", "udid": "u1"},
+        ]
+        cfg = replace(
+            config.default_config(),
+            destination="platform=iOS Simulator,name=iPhone 17 Pro,OS=latest",
+            test_destination_matrix=("iPhone 17 Pro@latest", "Nonexistent Device@latest"),
+        )
+
+        def fake_which(name: str) -> str | None:
+            if name in ("swiftlint", "xcodebuild", "xcrun"):
+                return f"/usr/bin/{name}"
+            return None
+
+        with mock.patch.object(cli_core, "_repo_root", return_value=repo_root):
+            with mock.patch.object(cli_core, "_load_config", return_value=cfg):
+                with mock.patch.object(simulator, "load_available_ios_devices", return_value=rows):
+                    with mock.patch.object(sys, "platform", "darwin"):
+                        with mock.patch.object(shutil, "which", side_effect=fake_which):
+                            runner = CliRunner()
+                            result = runner.invoke(app, ["doctor", "--strict"])
+
+        self.assertNotEqual(result.exit_code, 0, msg=result.output)
+
+    def test_doctor_json_strict_exits_nonzero_when_matrix_errors(self) -> None:
+        repo_root = Path(__file__).resolve().parents[3]
+        rows = [
+            {"name": "iPhone 17 Pro", "runtime_version": "26.0", "runtime_key": "k1", "udid": "u1"},
+        ]
+        cfg = replace(
+            config.default_config(),
+            destination="platform=iOS Simulator,name=iPhone 17 Pro,OS=latest",
+            test_destination_matrix=("iPhone 17 Pro@latest", "Nonexistent Device@latest"),
+        )
+
+        def fake_which(name: str) -> str | None:
+            if name in ("swiftlint", "xcodebuild", "xcrun"):
+                return f"/usr/bin/{name}"
+            return None
+
+        with mock.patch.object(cli_core, "_repo_root", return_value=repo_root):
+            with mock.patch.object(cli_core, "_load_config", return_value=cfg):
+                with mock.patch.object(simulator, "load_available_ios_devices", return_value=rows):
+                    with mock.patch.object(sys, "platform", "darwin"):
+                        with mock.patch.object(shutil, "which", side_effect=fake_which):
+                            runner = CliRunner()
+                            result = runner.invoke(app, ["doctor", "--json", "--strict"])
+
+        self.assertNotEqual(result.exit_code, 0, msg=result.output)
+        payload = json.loads(result.output)
+        self.assertIn("checks", payload)
+
+    def test_lint_passthrough_forwards_extra_argv(self) -> None:
+        repo_root = Path(__file__).resolve().parents[3]
+        with mock.patch.object(cli_core, "_repo_root", return_value=repo_root):
+            with mock.patch.object(cli_core, "_require_swiftlint"):
+                with mock.patch.object(cli_core, "_run") as run_mock:
+                    runner = CliRunner()
+                    result = runner.invoke(app, ["lint", "--fix"])
+
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        run_mock.assert_called_once()
+        argv = run_mock.call_args[0][0]
+        self.assertEqual(argv[:2], ["swiftlint", "lint"])
+        self.assertIn("--fix", argv)
+
+    def test_l10n_audit_json_emits_counts_and_lists(self) -> None:
+        repo_root = Path(__file__).resolve().parents[3]
+        with mock.patch.object(cli_core, "_repo_root", return_value=repo_root):
+            runner = CliRunner()
+            result = runner.invoke(app, ["l10n", "audit", "--json"])
+
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        payload = json.loads(result.output)
+        self.assertIn("missing_keys", payload)
+        self.assertIsInstance(payload["missing_keys"], list)
 
     def test_config_set_updates_value_in_toml(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/Scripts/gracenotes-dev/tests/test_cli_surface.py
+++ b/Scripts/gracenotes-dev/tests/test_cli_surface.py
@@ -59,6 +59,7 @@ class CLISurfaceTest(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0)
         self.assertIn("--clean", result.output)
+        self.assertIn("Simulator listing", result.output)
 
     def test_version_option_prints_installed_version(self) -> None:
         with mock.patch.object(cli.importlib.metadata, "version", return_value="9.9.9"):

--- a/docs/superpowers/plans/2026-04-09-issue-223-gracenotes-dev-cli-improvements.md
+++ b/docs/superpowers/plans/2026-04-09-issue-223-gracenotes-dev-cli-improvements.md
@@ -1,0 +1,502 @@
+# gracenotes-dev CLI improvements (issue #223) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the prioritized backlog in [GitHub issue #223](https://github.com/kipyin/grace-notes/issues/223) for the `grace` CLI (`Scripts/gracenotes-dev`): dry-run / print-command, strict doctor, `l10n audit --json`, environment documentation, optional `lint` passthrough, optional repo root override, optional shell completion, README cheat sheet, tighter `cli.__all__`, and a `ci --help` pointer to profile discovery.
+
+**Architecture:** Keep the existing Typer app hierarchy in `gracenotes_dev.cli.apps` and side-effect boundaries in `cli/core.py` (`_run`, `_run_capture`, `_run_theater`). Prefer a single `dry_run` flag threaded from Typer options into `_run*` so theater steps stay unchanged. Add JSON strictly via `json` module on top of existing `StringsCatalogAuditReport` from `build_strings_catalog_audit`. Strict doctor is a small post-pass over the same `checks` list the plain and `--json` paths already build.
+
+**Tech stack:** Python 3.11+, Typer, Rich, stdlib `unittest` + `typer.testing.CliRunner` in `Scripts/gracenotes-dev/tests/`.
+
+**Scope note:** The issue explicitly allows each bullet as its own small PR; this plan orders work for dependency sanity (core helpers before commands that consume them). You may still merge tasks as separate PRs linked to #223.
+
+---
+
+## File structure
+
+| Path | Role |
+|------|------|
+| `Scripts/gracenotes-dev/src/gracenotes_dev/cli/apps.py` | Root `app` epilog (examples + environment cheat sheet). |
+| `Scripts/gracenotes-dev/src/gracenotes_dev/cli/core.py` | `_repo_root`, `_run`, `_run_capture`, `_run_theater`, optional `dry_run` + optional Click context repo override. |
+| `Scripts/gracenotes-dev/src/gracenotes_dev/cli/__init__.py` | Root `@app.callback()`; narrow `__all__`. |
+| `Scripts/gracenotes-dev/src/gracenotes_dev/cli/workflows.py` | `build`, `clean`, `test`, `run`, `ci`, `_execute_ci_profile` — add flags and thread `dry_run`. |
+| `Scripts/gracenotes-dev/src/gracenotes_dev/cli/doctor_lint.py` | `doctor --strict`, `lint` passthrough args. |
+| `Scripts/gracenotes-dev/src/gracenotes_dev/cli/l10n_cmd.py` | `l10n_audit --json` emission. |
+| `Scripts/gracenotes-dev/README.md` | Command cheat sheet table. |
+| `Scripts/gracenotes-dev/tests/test_cli_surface.py` | New tests alongside existing CLI surface tests. |
+| `Scripts/gracenotes-dev/tests/test_l10n_surfaces.py` or new `test_l10n_audit_json.py` | JSON shape tests if you prefer a smaller file. |
+
+---
+
+### Task 1: Shared `dry_run` behavior in `cli/core.py`
+
+**Files:**
+
+- Modify: `Scripts/gracenotes-dev/src/gracenotes_dev/cli/core.py` (`_run`, `_run_capture`, optional `_dry_run_print`)
+
+**Design:** When `dry_run=True`, do not call `subprocess.run`. Print one line per skipped invocation to **stdout** in a stable, script-parseable form, e.g. `DRY-RUN: <shell-quoted argv>` using `shlex.join(prepared_argv)`, and return a `CompletedProcess` with `returncode=0` and empty strings for stdout/stderr (callers must not depend on captured output when `dry_run=True`). Apply `silent` / `_prepare_xcodebuild_argv` before printing so the printed command matches what a real run would use.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `Scripts/gracenotes-dev/tests/test_cli_surface.py` (new test method on `CLISurfaceTest`):
+
+```python
+def test_dry_run_skips_subprocess_for_run(self) -> None:
+    import gracenotes_dev.cli.core as cli_core
+
+    argv = ["echo", "hello"]
+    calls: list[list[str]] = []
+
+    real_run = subprocess.run
+
+    def fake_run(cmd, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(list(cmd))
+        return real_run(cmd, **kwargs)
+
+    with mock.patch.object(subprocess, "run", side_effect=fake_run):
+        cli_core._run(argv, cwd=Path("/tmp"), dry_run=True)
+
+    self.assertEqual(calls, [])
+```
+
+(Adjust imports: `subprocess`, `mock`, `Path` — follow existing imports in that test file.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd /Users/kip/Code/grace-notes/Scripts/gracenotes-dev && uv run python -m unittest tests.test_cli_surface.CLISurfaceTest.test_dry_run_skips_subprocess_for_run -v
+```
+
+Expected: **FAIL** with `TypeError: _run() got an unexpected keyword argument 'dry_run'` (or subprocess still called).
+
+- [ ] **Step 3: Implement `dry_run` on `_run` and `_run_capture`**
+
+In `core.py`, extend signatures:
+
+```python
+def _run(
+    argv: list[str],
+    *,
+    cwd: Path,
+    check: bool = True,
+    verbose: bool = False,
+    silent: bool = False,
+    dry_run: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    prepared_argv = _prepare_xcodebuild_argv(argv, verbose=verbose, silent=silent)
+    if dry_run:
+        _stdout_console().print(f"DRY-RUN: {shlex.join(prepared_argv)}")
+        return subprocess.CompletedProcess(args=prepared_argv, returncode=0, stdout="", stderr="")
+    use_capture = silent
+    # ... existing subprocess.run branches ...
+```
+
+Mirror the same early return in `_run_capture` when `dry_run=True` (still print `DRY-RUN:` once; return empty captured process).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Same `unittest` command as Step 2. Expected: **PASS**.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Scripts/gracenotes-dev/src/gracenotes_dev/cli/core.py Scripts/gracenotes-dev/tests/test_cli_surface.py
+git commit -m "feat(grace): add dry_run support to _run and _run_capture"
+```
+
+---
+
+### Task 2: `--dry-run` / `--print-command` on `build`, `clean`, `test`, `run`
+
+**Files:**
+
+- Modify: `Scripts/gracenotes-dev/src/gracenotes_dev/cli/workflows.py`
+
+Use a single Typer option with two flag names:
+
+```python
+dry_run: Annotated[
+    bool,
+    typer.Option(
+        "--dry-run",
+        "--print-command",
+        help="Print xcodebuild/simctl argv for each step without executing.",
+    ),
+] = False,
+```
+
+Thread `dry_run=dry_run` into every `cli_core._run` and `cli_core._run_capture` call in those command bodies, including steps inside `_run_test_once` if that function invokes `_run` (grep `def _run_test_once` in `core.py` and extend its parameters if needed).
+
+For theater steps whose callback returns a summary string after a successful `_run`, preserve the return value in dry-run mode as the same string you would have printed (the joined argv is already printed by `_run`).
+
+- [ ] **Step 1: Write a failing test for `grace build --dry-run`**
+
+In `test_cli_surface.py`:
+
+```python
+def test_build_dry_run_prints_xcodebuild_without_running(self) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    cfg = replace(config.default_config(), destination="platform=iOS Simulator,name=iPhone 17 Pro,OS=latest")
+    rows = [
+        {"name": "iPhone 17 Pro", "runtime_version": "26.0", "runtime_key": "k1", "udid": "u1"},
+    ]
+
+    def fake_which(name: str) -> str | None:
+        if name in ("swiftlint", "xcodebuild", "xcrun"):
+            return f"/usr/bin/{name}"
+        return None
+
+    with mock.patch.object(cli_core, "_repo_root", return_value=repo_root):
+        with mock.patch.object(cli_core, "_load_config", return_value=cfg):
+            with mock.patch.object(simulator, "load_available_ios_devices", return_value=rows):
+                with mock.patch.object(sys, "platform", "darwin"):
+                    with mock.patch.object(shutil, "which", side_effect=fake_which):
+                        with mock.patch.object(cli_core, "_run") as run_mock:
+                            runner = CliRunner()
+                            result = runner.invoke(app, ["build", "--dry-run"])
+
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    self.assertTrue(any("DRY-RUN:" in str(c) for c in run_mock.call_args_list))
+```
+
+(Adjust: import `replace` from `dataclasses`, `shutil`, `sys`, `app` from `gracenotes_dev.cli.apps` — mirror `test_doctor_json_independent_default_and_matrix_status`.)
+
+- [ ] **Step 2: Run the test — expect FAIL** (no `--dry-run` yet or `_run` not passed `dry_run=True`).
+
+```bash
+cd /Users/kip/Code/grace-notes/Scripts/gracenotes-dev && uv run python -m unittest tests.test_cli_surface.CLISurfaceTest.test_build_dry_run_prints_xcodebuild_without_running -v
+```
+
+- [ ] **Step 3: Implement options on `build`, `clean`, `test`, `run`**
+
+Add the `dry_run` Typer option to each function signature and pass through to all `_run` / `_run_capture` / `_run_test_once` internals.
+
+- [ ] **Step 4: Run full Python tests for the package**
+
+```bash
+cd /Users/kip/Code/grace-notes/Scripts/gracenotes-dev && uv run python -m unittest discover -s tests -v
+```
+
+Expected: **PASS** (entire suite).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Scripts/gracenotes-dev/src/gracenotes_dev/cli/workflows.py Scripts/gracenotes-dev/tests/test_cli_surface.py
+git commit -m "feat(grace): add --dry-run to build, clean, test, run"
+```
+
+---
+
+### Task 3: Optional `--dry-run` on `grace ci`
+
+**Files:**
+
+- Modify: `Scripts/gracenotes-dev/src/gracenotes_dev/cli/workflows.py` (`ci`, `_execute_ci_profile`)
+
+Extend `_execute_ci_profile(..., dry_run: bool = False)` and pass `dry_run` into `lint_command()` only if you add a parameter there in Task 5; for `build` / `test`, pass through as keyword args:
+
+```python
+if selected.build:
+    build(..., dry_run=dry_run)
+```
+
+- [ ] **Step 1: Test** — invoke `grace ci` with a mocked profile that only runs `lint` (or skip lint mock and use `--profile` that only builds) and assert `_run` / `lint` sees dry-run. Minimal pattern: mock `build` and assert called with `dry_run=True`.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git commit -m "feat(grace): add --dry-run to ci profile steps"
+```
+
+---
+
+### Task 4: `doctor --strict`
+
+**Files:**
+
+- Modify: `Scripts/gracenotes-dev/src/gracenotes_dev/cli/doctor_lint.py`
+
+Add:
+
+```python
+strict: Annotated[
+    bool,
+    typer.Option("--strict", help="Exit with code 1 if any check is not ok."),
+] = False,
+```
+
+After building `checks`, if `strict` is true and **not** `--json`, evaluate failure as: any item with `str(item["status"]) != "ok"`. If `--json` and `--strict` together, print JSON first, then exit with code 1 under the same rule (document that strict affects exit code only; output is unchanged).
+
+**Rationale:** Preserves today’s `doctor --json` exit 0 behavior when `--strict` is omitted (`tests.test_cli_surface.test_doctor_json_independent_default_and_matrix_status`).
+
+- [ ] **Step 1: Failing test**
+
+```python
+def test_doctor_strict_exits_nonzero_when_matrix_errors(self) -> None:
+    # Reuse patches from test_doctor_json_independent_default_and_matrix_status
+    runner = CliRunner()
+    result = runner.invoke(app, ["doctor", "--strict"])
+    self.assertNotEqual(result.exit_code, 0)
+```
+
+- [ ] **Step 2: Implement and run full unittest suite** — expect PASS.
+
+- [ ] **Step 3: Commit** — `feat(grace): add doctor --strict for CI-style gating`
+
+---
+
+### Task 5: `grace lint` extra-arg passthrough
+
+**Files:**
+
+- Modify: `Scripts/gracenotes-dev/src/gracenotes_dev/cli/doctor_lint.py`
+
+Change the Typer command to accept extra arguments:
+
+```python
+@app.command(
+    "lint",
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": False},
+)
+def lint(ctx: typer.Context) -> None:
+    cli_core._require_swiftlint()
+    repo_root = cli_core._repo_root()
+    extras = list(ctx.args)
+    cli_core._run(["swiftlint", "lint", *extras], cwd=repo_root, check=True)
+```
+
+- [ ] **Step 1: Test** — `CliRunner().invoke(app, ["lint", "--", "--help"])` or a harmless flag your SwiftLint supports in CI (if `--help` exits nonzero, prefer asserting argv passed through via mocking `_run`).
+
+```python
+def test_lint_passthrough_forwards_extra_argv(self) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    with mock.patch.object(cli_core, "_repo_root", return_value=repo_root):
+        with mock.patch.object(cli_core, "_require_swiftlint"):
+            with mock.patch.object(cli_core, "_run") as run_mock:
+                runner = CliRunner()
+                result = runner.invoke(app, ["lint", "--fix"])
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    run_mock.assert_called_once()
+    argv = run_mock.call_args[0][0]
+    self.assertIn("--fix", argv)
+```
+
+- [ ] **Step 2: Commit** — `feat(grace): forward extra args from lint to swiftlint`
+
+---
+
+### Task 6: `grace l10n audit --json`
+
+**Files:**
+
+- Modify: `Scripts/gracenotes-dev/src/gracenotes_dev/cli/l10n_cmd.py`
+
+Add `json_out` option to `l10n_audit` (name it `--json` to match `doctor`). When true, call `build_strings_catalog_audit(repo_root)` and emit:
+
+```python
+def audit_report_to_json_dict(report: StringsCatalogAuditReport) -> dict[str, object]:
+    return {
+        "catalog_key_count": report.catalog_key_count,
+        "code_key_count": report.code_key_count,
+        "unused_keys": list(report.unused_keys),
+        "missing_keys": list(report.missing_keys),
+        "duplicate_english_groups": [
+            {"english": en, "keys": list(ks)} for en, ks in report.duplicate_english_groups
+        ],
+        "multi_file_keys": [
+            {"key": k, "paths": list(paths)} for k, paths in report.multi_file_keys
+        ],
+    }
+```
+
+Use `json.dump(..., sys.stdout, indent=2)` and trailing newline; skip Rich/plain render path when `--json`.
+
+- [ ] **Step 1: Test**
+
+```python
+def test_l10n_audit_json_emits_counts_and_lists(self) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    runner = CliRunner()
+    with mock.patch.object(xcode_helpers, "repo_root_from", return_value=repo_root):
+        result = runner.invoke(app, ["l10n", "audit", "--json"])
+    self.assertEqual(result.exit_code, 0, msg=result.output)
+    payload = json.loads(result.output)
+    self.assertIn("missing_keys", payload)
+    self.assertIsInstance(payload["missing_keys"], list)
+```
+
+- [ ] **Step 2: Commit** — `feat(grace): add l10n audit --json`
+
+---
+
+### Task 7: Document environment variables on root help
+
+**Files:**
+
+- Modify: `Scripts/gracenotes-dev/src/gracenotes_dev/cli/apps.py`
+
+Extend `app = typer.Typer(..., epilog=...)` with a short section:
+
+```text
+Environment:
+  NO_COLOR            Disable Rich styling.
+  CI                  Disallow interactive flows; fuller xcodebuild logs where applicable.
+  GRACE_NONINTERACTIVE=1  Disallow interactive prompts.
+  GRACE_RUN_STREAM_TOOL_OUTPUT  Set to 1/true/yes to stream tool output during grace run.
+  GRACE_REPO_ROOT     (optional; if you implement Task 8) Override starting directory for repo discovery.
+```
+
+- [ ] **Step 1: Test** — extend `test_root_help_includes_greenfield_commands` or add `test_root_help_includes_environment_epilog` asserting substring `GRACE_NONINTERACTIVE` in `runner.invoke(app, ["--help"]).output`.
+
+- [ ] **Step 2: Commit** — `docs(grace): document key environment variables in --help epilog`
+
+---
+
+### Task 8: Optional repo root (`--repo-root` + `GRACE_REPO_ROOT`)
+
+**Files:**
+
+- Modify: `Scripts/gracenotes-dev/src/gracenotes_dev/cli/__init__.py` (`@app.callback`)
+- Modify: `Scripts/gracenotes-dev/src/gracenotes_dev/cli/core.py` (`_repo_root`)
+
+Use Typer on the root callback:
+
+```python
+@app.callback()
+def app_callback(
+    ctx: typer.Context,
+    version: Annotated[bool, typer.Option(...)] = False,
+    repo_root: Annotated[
+        Path | None,
+        typer.Option(
+            "--repo-root",
+            help="Directory to start repo discovery from (default: cwd).",
+            envvar="GRACE_REPO_ROOT",
+        ),
+    ] = None,
+) -> None:
+    ctx.obj = ctx.obj or {}
+    if repo_root is not None:
+        ctx.obj["repo_root_start"] = repo_root.resolve()
+```
+
+In `core.py` (Typer commands run on Click’s context stack):
+
+```python
+import click
+
+def _repo_root() -> Path:
+    ctx = click.get_current_context(silent=True)  # None when not inside a Typer invoke
+    start: Path | None = None
+    if ctx is not None and isinstance(ctx.obj, dict):
+        start = ctx.obj.get("repo_root_start")
+    base = Path(start) if start is not None else Path.cwd()
+    return xcode_helpers.repo_root_from(base)
+```
+
+**Note:** Ensure the root `@app.callback()` assigns `ctx.obj` to a dict (merge with any existing object) so subcommands see `repo_root_start`. Add a unit test that `invoke(app, ["--repo-root", str(some_parent), "doctor", "--json"])` still finds the repo when `some_parent` is the real repo’s parent (or a subdirectory).
+
+- [ ] **Step 1: Commit** — `feat(grace): add --repo-root and GRACE_REPO_ROOT for discovery`
+
+---
+
+### Task 9: Shell completion (optional / low maintenance)
+
+**Files:**
+
+- Modify: `Scripts/gracenotes-dev/README.md` or root `AGENTS.md` — **only** if maintainers want it; issue marks this optional.
+
+Implementation sketch (Typer): document running:
+
+```bash
+grace --help
+# shellingham + typer completion install pattern
+```
+
+If the project already avoids extra dependencies, implement **documentation-only**: how to generate completions with Typer’s built-in `typer.completion` for zsh/bash, without dynamic profile-name completion. If you do add completion hooks for `--profile`, read profile keys from `config.default_config().ci_profiles` in a static completion callback — keep it in a **single small file** e.g. `gracenotes_dev/cli/completion.py`.
+
+- [ ] **Step 1:** Spike `typer` completion for `grace` locally; if flaky on zsh, limit to README instructions only.
+
+- [ ] **Step 2: Commit** — `docs(grace): shell completion notes` (or `feat` if code landed)
+
+---
+
+### Task 10: README cheat sheet
+
+**Files:**
+
+- Modify: `Scripts/gracenotes-dev/README.md`
+
+Add a markdown table:
+
+| Command | Purpose | Example |
+|---------|---------|---------|
+| `grace doctor` | Toolchain + destination preflight | `grace doctor` |
+| `grace ci` | Run a configured CI profile | `grace ci --profile lint-build` |
+| … | … | … |
+
+Point to repo-root `gracenotes-dev.toml`.
+
+- [ ] **Step 1: Commit** — `docs(gracenotes-dev): add CLI cheat sheet`
+
+---
+
+### Task 11: Trim `gracenotes_dev.cli.__all__`
+
+**Files:**
+
+- Modify: `Scripts/gracenotes-dev/src/gracenotes_dev/cli/__init__.py`
+
+Reduce `__all__` to stable entrypoints consumers need, e.g. `app`, `config_app`, `sim_app`, `runtime_app` only — **not** `_print_error_block`, `_sim_interactive`, etc., unless grep shows external imports in docs or tests.
+
+- [ ] **Step 1:** `git grep "from gracenotes_dev.cli import"` from repo root; adjust any real external callers before shrinking.
+
+- [ ] **Step 2: Commit** — `refactor(grace): narrow cli package __all__`
+
+---
+
+### Task 12: `grace ci --help` one-liner for profiles
+
+**Files:**
+
+- Modify: `Scripts/gracenotes-dev/src/gracenotes_dev/cli/workflows.py` — extend `typer.Option` `help=` for `--profile` with: `See also: grace config list (profile names).`
+
+- [ ] **Step 1:** `CliRunner().invoke(app, ["ci", "--help"])` contains `config list`.
+
+- [ ] **Step 2: Commit** — `docs(grace): point ci profile help to config list`
+
+---
+
+## Self-review checklist
+
+| #223 item | Covered by |
+|-----------|------------|
+| Dry-run on build/clean/test/run/ci | Tasks 1–3 |
+| `doctor --strict` | Task 4 |
+| `l10n audit --json` | Task 6 |
+| Env var docs in help | Task 7 |
+| `lint` passthrough | Task 5 |
+| `--repo-root` | Task 8 |
+| Shell completion | Task 9 (optional) |
+| README cheat sheet | Task 10 |
+| `__all__` trim | Task 11 |
+| `ci --help` pointer | Task 12 |
+
+**Placeholder scan:** No TBD/TODO left; each task names files and concrete snippets.
+
+**Type consistency:** `dry_run` is `bool` everywhere; `StringsCatalogAuditReport` fields match JSON helper.
+
+---
+
+## Execution handoff
+
+**Plan complete and saved to** `docs/superpowers/plans/2026-04-09-issue-223-gracenotes-dev-cli-improvements.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — Dispatch a fresh subagent per task, review between tasks, fast iteration. REQUIRED SUB-SKILL: `superpowers:subagent-driven-development`.
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints. REQUIRED SUB-SKILL: `superpowers:executing-plans`.
+
+**Which approach?**


### PR DESCRIPTION
## Summary

Implements the gracenotes-dev / `grace` backlog from #223 in one PR, including the saved implementation plan.

## Plan
- `docs/superpowers/plans/2026-04-09-issue-223-gracenotes-dev-cli-improvements.md`

## Code (high level)
- `--dry-run` / `--print-command` on `build`, `clean`, `test`, `run`, `ci` (via `_run`, `_run_capture`, `_run_test_once`, `_reset_sims`).
- `doctor --strict`; `run_lint` + `grace lint` passthrough; `grace l10n audit --json`.
- Global `--repo-root` / `GRACE_REPO_ROOT`; env vars in root help; `ci --profile` points at `grace config list`.
- README cheat sheet + optional completion note; narrower `__all__` with explicit test re-export noqas.

## Verification
- `cd Scripts/gracenotes-dev && uv run ruff check src/gracenotes_dev/cli tests/test_cli_surface.py`
- `cd Scripts/gracenotes-dev && uv run python -m unittest discover -s tests -v` (113 tests)
- `swiftlint lint` at repo root (0 violations)

Closes #223

Made with [Cursor](https://cursor.com)

## Related
- #245 — Past tab theme chips should follow journal language (tracking / future work; not part of #223).
