### PR TITLE
Past: Section mix shows integer % in strip; legend meta + count pills (#247)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## [Unreleased]
 
-*No entries yet.*
+### Changed
+
+- **Past (#247):** Section mix strip shows **integer percentages** in each segment; the legend keeps **mention counts** with **meta** labels and per-section **count capsules** aligned with other insight cards.
 
 ## [0.5.0]
 

--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewHistoryInsightsPanels.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewHistoryInsightsPanels.swift
@@ -232,6 +232,19 @@ enum ReviewSectionDistributionStripLayout {
         }
         return widths
     }
+
+    /// Display percentages for the section-mix strip (issue #247). Whole numbers only; rounded shares may not sum
+    /// to 100. When all counts are zero, returns `[0, 0, 0]` so each segment can show `0%` with equal thirds widths.
+    static func integerDisplayPercents(
+        gratitudeMentions: Int,
+        needMentions: Int,
+        peopleMentions: Int
+    ) -> [Int] {
+        let counts = [gratitudeMentions, needMentions, peopleMentions]
+        let total = counts.reduce(0, +)
+        guard total > 0 else { return [0, 0, 0] }
+        return counts.map { Int((Double($0) / Double(total) * 100).rounded()) }
+    }
 }
 
 /// History-scoped section line totals as a proportion strip + legend. Issue #152.
@@ -326,6 +339,11 @@ private struct ReviewHistorySectionStrip: View {
     }
 
     var body: some View {
+        let percents = ReviewSectionDistributionStripLayout.integerDisplayPercents(
+            gratitudeMentions: totals.gratitudeMentions,
+            needMentions: totals.needMentions,
+            peopleMentions: totals.peopleMentions
+        )
         VStack(alignment: .leading, spacing: 12) {
             GeometryReader { geo in
                 let width = max(geo.size.width, 1)
@@ -356,23 +374,29 @@ private struct ReviewHistorySectionStrip: View {
                                         RoundedRectangle(cornerRadius: 6, style: .continuous)
                                             .strokeBorder(border, lineWidth: 0.85)
                                     }
-                                Text("\(item.count)")
-                                    .font(AppTheme.warmPaperMeta)
-                                    .monospacedDigit()
-                                    .foregroundStyle(AppTheme.reviewTextPrimary)
-                                    .lineLimit(1)
-                                    .minimumScaleFactor(0.45)
-                                    .padding(.horizontal, 3)
-                                    .accessibilityHidden(true)
+                                Text(
+                                    String(
+                                        format: String(localized: "review.sectionMix.segmentPercent"),
+                                        locale: .current,
+                                        percents[index]
+                                    )
+                                )
+                                .font(AppTheme.warmPaperMeta)
+                                .monospacedDigit()
+                                .foregroundStyle(AppTheme.reviewTextPrimary)
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.45)
+                                .padding(.horizontal, 3)
+                                .accessibilityHidden(true)
                             }
                             .frame(width: segmentWidths[index], height: stripHeight)
                         }
                         .buttonStyle(PastTappablePressStyle())
                         .accessibilityLabel(
-                            String(
-                                format: String(localized: "journal.share.twoColumnRow"),
-                                localizedSectionName(for: item.kind),
-                                item.count
+                            sectionMixAccessibilityLabel(
+                                kind: item.kind,
+                                count: item.count,
+                                percent: percents[index]
                             )
                         )
                         .accessibilityHint(segmentAccessibilityHint(forCount: item.count))
@@ -383,11 +407,11 @@ private struct ReviewHistorySectionStrip: View {
             .frame(height: max(26, ReviewHistoryPanelLayoutScale.stripHeight(26, dynamicTypeSize: dynamicTypeSize)))
 
             VStack(alignment: .leading, spacing: 8) {
-                ForEach(Array(segments.enumerated()), id: \.offset) { _, item in
+                ForEach(Array(segments.enumerated()), id: \.offset) { index, item in
                     Button {
                         onSelectSection(item.kind)
                     } label: {
-                        HStack(alignment: .firstTextBaseline, spacing: 8) {
+                        HStack(alignment: .center, spacing: 10) {
                             Circle()
                                 .fill(ReviewSectionDistributionPalette.fill(for: item.kind))
                                 .frame(width: 10, height: 10)
@@ -400,23 +424,23 @@ private struct ReviewHistorySectionStrip: View {
                                 }
                                 .accessibilityHidden(true)
                             Text(localizedSectionName(for: item.kind))
-                                .font(AppTheme.warmPaperBody)
+                                .font(AppTheme.warmPaperMeta)
                                 .foregroundStyle(AppTheme.reviewTextPrimary)
                             Spacer(minLength: 8)
-                            Text("\(item.count)")
-                                .font(AppTheme.warmPaperMeta)
-                                .monospacedDigit()
-                                .foregroundStyle(AppTheme.reviewTextMuted)
-                                .accessibilityHidden(true)
+                            ReviewCountBadge(
+                                value: item.count.formatted(),
+                                accent: ReviewSectionDistributionPalette.countBadgeAccent(for: item.kind)
+                            )
+                            .accessibilityHidden(true)
                         }
                         .frame(maxWidth: .infinity, alignment: .leading)
                     }
                     .buttonStyle(PastTappablePressStyle())
                     .accessibilityLabel(
-                        String(
-                            format: String(localized: "journal.share.twoColumnRow"),
-                            localizedSectionName(for: item.kind),
-                            item.count
+                        sectionMixAccessibilityLabel(
+                            kind: item.kind,
+                            count: item.count,
+                            percent: percents[index]
                         )
                     )
                     .accessibilityHint(segmentAccessibilityHint(forCount: item.count))
@@ -424,6 +448,19 @@ private struct ReviewHistorySectionStrip: View {
             }
         }
         .padding(.top, 2)
+    }
+
+    private func sectionMixAccessibilityLabel(
+        kind: ReviewStatsSectionKind,
+        count: Int,
+        percent: Int
+    ) -> String {
+        String(
+            format: String(localized: "accessibility.reviewHistory.sectionMixRow"),
+            localizedSectionName(for: kind),
+            count,
+            percent
+        )
     }
 
     private func localizedSectionName(for kind: ReviewStatsSectionKind) -> String {
@@ -458,6 +495,18 @@ enum ReviewSectionDistributionPalette {
             AppTheme.reviewStandardBorder.opacity(0.88)
         case .people:
             AppTheme.reviewQuickStartBorder.opacity(0.88)
+        }
+    }
+
+    /// Accent for `ReviewCountBadge` on section-mix legend rows (full-opacity border hue, issue #247).
+    static func countBadgeAccent(for kind: ReviewStatsSectionKind) -> Color {
+        switch kind {
+        case .gratitudes:
+            AppTheme.reviewCompleteBorder
+        case .needs:
+            AppTheme.reviewStandardBorder
+        case .people:
+            AppTheme.reviewQuickStartBorder
         }
     }
 }

--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewHistoryInsightsPanels.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewHistoryInsightsPanels.swift
@@ -378,7 +378,7 @@ private struct ReviewHistorySectionStrip: View {
                                     String(
                                         format: String(localized: "review.sectionMix.segmentPercent"),
                                         locale: .current,
-                                        percents[index]
+                                        Int64(percents[index])
                                     )
                                 )
                                 .font(AppTheme.warmPaperMeta)
@@ -455,8 +455,11 @@ private struct ReviewHistorySectionStrip: View {
         count: Int,
         percent: Int
     ) -> String {
-        String(
-            format: String(localized: "accessibility.reviewHistory.sectionMixRow"),
+        let format = count == 1
+            ? String(localized: "accessibility.reviewHistory.sectionMixRow.singular")
+            : String(localized: "accessibility.reviewHistory.sectionMixRow.plural")
+        return String(
+            format: format,
             localizedSectionName(for: kind),
             count,
             percent

--- a/GraceNotes/GraceNotes/Localizable.xcstrings
+++ b/GraceNotes/GraceNotes/Localizable.xcstrings
@@ -3379,6 +3379,38 @@
         }
       }
     },
+    "accessibility.reviewHistory.sectionMixRow": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@, %2$d line mentions, %3$d percent of section mix."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@，%2$d 条行提及，占版块构成的 %3$d%%。"
+          }
+        }
+      }
+    },
+    "review.sectionMix.segmentPercent": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld%%"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld%%"
+          }
+        }
+      }
+    },
     "review.sectionDrilldown.emptyFormat": {
       "localizations": {
         "en": {

--- a/GraceNotes/GraceNotes/Localizable.xcstrings
+++ b/GraceNotes/GraceNotes/Localizable.xcstrings
@@ -3379,12 +3379,28 @@
         }
       }
     },
-    "accessibility.reviewHistory.sectionMixRow": {
+    "accessibility.reviewHistory.sectionMixRow.plural": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
             "value": "%1$@, %2$d line mentions, %3$d percent of section mix."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@，%2$d 条行提及，占版块构成的 %3$d%%。"
+          }
+        }
+      }
+    },
+    "accessibility.reviewHistory.sectionMixRow.singular": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@, %2$d line mention, %3$d percent of section mix."
           }
         },
         "zh-Hans": {

--- a/GraceNotesTests/Features/Journal/SectionDistributionStripLayoutTests.swift
+++ b/GraceNotesTests/Features/Journal/SectionDistributionStripLayoutTests.swift
@@ -68,4 +68,31 @@ final class SectionDistributionStripLayoutTests: XCTestCase {
         XCTAssertEqual(onlyGratitude.reduce(0, +), usable, accuracy: 0.02)
         XCTAssertEqual(onlyNeeds.reduce(0, +), usable, accuracy: 0.02)
     }
+
+    func test_integerDisplayPercents_allZero_isThreeZeros() {
+        let percents = ReviewSectionDistributionStripLayout.integerDisplayPercents(
+            gratitudeMentions: 0,
+            needMentions: 0,
+            peopleMentions: 0
+        )
+        XCTAssertEqual(percents, [0, 0, 0])
+    }
+
+    func test_integerDisplayPercents_proportional_6_5_5() {
+        let percents = ReviewSectionDistributionStripLayout.integerDisplayPercents(
+            gratitudeMentions: 6,
+            needMentions: 5,
+            peopleMentions: 5
+        )
+        XCTAssertEqual(percents, [38, 31, 31])
+    }
+
+    func test_integerDisplayPercents_singleSection_is100AndZeros() {
+        let percents = ReviewSectionDistributionStripLayout.integerDisplayPercents(
+            gratitudeMentions: 10,
+            needMentions: 0,
+            peopleMentions: 0
+        )
+        XCTAssertEqual(percents, [100, 0, 0])
+    }
 }

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -14,4 +14,7 @@
 
 ## Entries
 
+- 2026-04-10 | **GitHub text /gh:** Never add tool-attribution footers to issues or PRs. If a client auto-appends lines like “Made with Cursor”, remove them via `gh pr edit` so descriptions match repo rules.
+- 2026-04-10 | **Scope:** “Writing-plans” means produce the plan artifact first; **do not** implement and open a full code PR unless the user clearly asked to execute the plan in the same request (confirm when both appear).
+- 2026-04-10 | **Environment:** Treat **`user_info` OS as authoritative** (e.g. `darwin` ⇒ macOS, Xcode/iOS SDK may be available). **AGENTS.md** “Linux VM cannot compile SwiftUI” is for Cursor Cloud defaults, not a reason to skip `grace ci` when the session is on macOS.
 - 2026-04-09 | UI: Sticky journal completion toolbar chip keeps **fixed expanded layout width** when icon-only; attempts to shrink width (or clip-to-reveal) caused jump or wrong-direction expansion. **Prefer stable feel over reclaiming literal toolbar space** (documented on PR #237).

--- a/docs/superpowers/plans/2026-04-10-past-section-mix-247.md
+++ b/docs/superpowers/plans/2026-04-10-past-section-mix-247.md
@@ -1,0 +1,50 @@
+# Past Section mix strip & legend (#247) Implementation Plan
+
+> **For agentic workers:** Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** On Past → Section mix, show integer **%** in the proportional bar, keep legend counts (not %), and style the legend like Most Recurring / Trending (meta label + `ReviewCountBadge` with per-section accent).
+
+**Architecture:** Extend `ReviewSectionDistributionStripLayout` with a small pure function for display percents (integer round; all-zero totals → `[0,0,0]`). Update `ReviewHistorySectionStrip` in `ReviewHistoryInsightsPanels.swift` for bar labels, legend row layout, and richer accessibility strings. Add localized format keys for `%` text and VoiceOver.
+
+**Tech stack:** SwiftUI, SwiftData app target only; `Localizable.xcstrings`; `GraceNotesTests` unit tests.
+
+---
+
+### Task 1: Percent math (tested)
+
+**Files:**
+- Modify: `GraceNotes/GraceNotes/Features/Journal/Views/ReviewHistoryInsightsPanels.swift` (`ReviewSectionDistributionStripLayout`)
+- Modify: `GraceNotesTests/Features/Journal/SectionDistributionStripLayoutTests.swift`
+
+- [ ] **Step 1:** Add `integerDisplayPercents(gratitudeMentions:needMentions:peopleMentions:) -> [Int]` next to `segmentWidths`, same argument order. If `total == 0`, return `[0, 0, 0]`. Otherwise `Int((Double(c) / Double(total) * 100).rounded())` per segment.
+- [ ] **Step 2:** Add tests: all-zero → `[0,0,0]`; e.g. `6,5,5` → `[38, 31, 31]` or whatever rounding yields; smoke check length 3.
+- [ ] **Step 3:** `swiftlint lint` on touched Swift files.
+
+### Task 2: UI + palette + strings
+
+**Files:**
+- Modify: `ReviewHistoryInsightsPanels.swift` (`ReviewSectionDistributionPalette`, `ReviewHistorySectionStrip`)
+- Modify: `GraceNotes/GraceNotes/Localizable.xcstrings`
+
+- [ ] **Step 1:** Add `countBadgeAccent(for: ReviewStatsSectionKind) -> Color` on `ReviewSectionDistributionPalette` (reuse the same family as `border` / section chrome—full-opacity border colors are fine).
+- [ ] **Step 2:** In the strip `HStack`, compute `let percents = ReviewSectionDistributionStripLayout.integerDisplayPercents(...)` once; replace bar `Text` with localized `"\(pct)%"` via new key `review.sectionMix.segmentPercent` (`%lld%%`, en + zh-Hans).
+- [ ] **Step 3:** Legend rows: `HStack(alignment: .center, spacing: 10)`; section title `AppTheme.warmPaperMeta`; trailing `ReviewCountBadge(value: item.count.formatted(), accent: ReviewSectionDistributionPalette.countBadgeAccent(for: item.kind))`.
+- [ ] **Step 4:** Accessibility: new format key including section name, mention count, and display percent for strip buttons and legend rows (hints unchanged). Empty-total case still sensible (`0` mentions, `0` percent).
+
+### Task 3: Ship
+
+**Files:**
+- Modify: `CHANGELOG.md` (Unreleased user-facing line if warranted)
+
+- [ ] **Step 1:** Branch `feat/past-section-mix-247` from `main`, commit focused message, push.
+- [ ] **Step 2:** Open PR with `Closes #247`, labels `feat`, `past`, `p3` (omit `full-ci` unless requested). Verification: `swiftlint lint`; on macOS `grace test` or CI.
+
+---
+
+## Self-review
+
+- **Spec coverage:** Integer bar %, legend counts + meta + pill + per-section accent, a11y, zero-total → `0%` each—mapped above.
+- **Placeholders:** None.
+- **Types:** `ReviewStatsSectionKind`, `ReviewWeekSectionTotals` unchanged; percents are `[Int]` parallel to widths.
+
+**Plan complete:** `docs/superpowers/plans/2026-04-10-past-section-mix-247.md`. Execute inline in-repo (this session) or subagent-driven per your workflow.

--- a/docs/superpowers/plans/2026-04-10-past-section-mix-247.md
+++ b/docs/superpowers/plans/2026-04-10-past-section-mix-247.md
@@ -16,9 +16,9 @@
 - Modify: `GraceNotes/GraceNotes/Features/Journal/Views/ReviewHistoryInsightsPanels.swift` (`ReviewSectionDistributionStripLayout`)
 - Modify: `GraceNotesTests/Features/Journal/SectionDistributionStripLayoutTests.swift`
 
-- [ ] **Step 1:** Add `integerDisplayPercents(gratitudeMentions:needMentions:peopleMentions:) -> [Int]` next to `segmentWidths`, same argument order. If `total == 0`, return `[0, 0, 0]`. Otherwise `Int((Double(c) / Double(total) * 100).rounded())` per segment.
-- [ ] **Step 2:** Add tests: all-zero → `[0,0,0]`; e.g. `6,5,5` → `[38, 31, 31]` or whatever rounding yields; smoke check length 3.
-- [ ] **Step 3:** `swiftlint lint` on touched Swift files.
+- [x] **Step 1:** Add `integerDisplayPercents(gratitudeMentions:needMentions:peopleMentions:) -> [Int]` next to `segmentWidths`, same argument order. If `total == 0`, return `[0, 0, 0]`. Otherwise `Int((Double(c) / Double(total) * 100).rounded())` per segment.
+- [x] **Step 2:** Add tests: all-zero → `[0,0,0]`; e.g. `6,5,5` → `[38, 31, 31]` or whatever rounding yields; smoke check length 3.
+- [x] **Step 3:** `swiftlint lint` on touched Swift files.
 
 ### Task 2: UI + palette + strings
 
@@ -26,18 +26,18 @@
 - Modify: `ReviewHistoryInsightsPanels.swift` (`ReviewSectionDistributionPalette`, `ReviewHistorySectionStrip`)
 - Modify: `GraceNotes/GraceNotes/Localizable.xcstrings`
 
-- [ ] **Step 1:** Add `countBadgeAccent(for: ReviewStatsSectionKind) -> Color` on `ReviewSectionDistributionPalette` (reuse the same family as `border` / section chrome—full-opacity border colors are fine).
-- [ ] **Step 2:** In the strip `HStack`, compute `let percents = ReviewSectionDistributionStripLayout.integerDisplayPercents(...)` once; replace bar `Text` with localized `"\(pct)%"` via new key `review.sectionMix.segmentPercent` (`%lld%%`, en + zh-Hans).
-- [ ] **Step 3:** Legend rows: `HStack(alignment: .center, spacing: 10)`; section title `AppTheme.warmPaperMeta`; trailing `ReviewCountBadge(value: item.count.formatted(), accent: ReviewSectionDistributionPalette.countBadgeAccent(for: item.kind))`.
-- [ ] **Step 4:** Accessibility: new format key including section name, mention count, and display percent for strip buttons and legend rows (hints unchanged). Empty-total case still sensible (`0` mentions, `0` percent).
+- [x] **Step 1:** Add `countBadgeAccent(for: ReviewStatsSectionKind) -> Color` on `ReviewSectionDistributionPalette` (reuse the same family as `border` / section chrome—full-opacity border colors are fine).
+- [x] **Step 2:** In the strip `HStack`, compute `let percents = ReviewSectionDistributionStripLayout.integerDisplayPercents(...)` once; replace bar `Text` with localized `"\(pct)%"` via new key `review.sectionMix.segmentPercent` (`%lld%%`, en + zh-Hans).
+- [x] **Step 3:** Legend rows: `HStack(alignment: .center, spacing: 10)`; section title `AppTheme.warmPaperMeta`; trailing `ReviewCountBadge(value: item.count.formatted(), accent: ReviewSectionDistributionPalette.countBadgeAccent(for: item.kind))`.
+- [x] **Step 4:** Accessibility: new format key including section name, mention count, and display percent for strip buttons and legend rows (hints unchanged). Empty-total case still sensible (`0` mentions, `0` percent).
 
 ### Task 3: Ship
 
 **Files:**
 - Modify: `CHANGELOG.md` (Unreleased user-facing line if warranted)
 
-- [ ] **Step 1:** Branch `feat/past-section-mix-247` from `main`, commit focused message, push.
-- [ ] **Step 2:** Open PR with `Closes #247`, labels `feat`, `past`, `p3` (omit `full-ci` unless requested). Verification: `swiftlint lint`; on macOS `grace test` or CI.
+- [x] **Step 1:** Branch `feat/past-section-mix-247` from `main`, commit focused message, push.
+- [x] **Step 2:** Open PR with `Closes #247`, labels `feat`, `past`, `p3` (omit `full-ci` unless requested). Verification: `swiftlint lint`; on macOS `grace test` or CI.
 
 ---
 


### PR DESCRIPTION
## Summary
Past **Section mix** encodes the bar as **integer percentages** while the legend keeps **mention counts** in **rounded capsules** tinted per section, matching **Most recurring** / **Trending** row styling.

## User impact
The strip reads as actual **shares of the mix** (not raw totals). Legend typography and trailing counts feel consistent with neighboring Past insight cards.

## What changed
- Added `integerDisplayPercents` next to strip width math; **0%** in each segment when all counts are zero.
- Bar labels use localized `review.sectionMix.segmentPercent`; legend uses `warmPaperMeta` + `ReviewCountBadge` with `countBadgeAccent` per section.
- VoiceOver strings include mention count and percent (`accessibility.reviewHistory.sectionMixRow`), with English and Simplified Chinese catalog entries.

## Verification
- `swiftlint lint` on modified Swift files
- `grace l10n audit` (OK)
- Unit tests: `SectionDistributionStripLayoutTests` (percent rounding cases). Run `grace ci` / `grace test` on a Mac with Xcode before merge.

Closes #247