### PR TITLE
fix(ui-test): stabilize journal Needs add chip on CI

### DIFF
--- a/GraceNotesUITests/JournalUITests.swift
+++ b/GraceNotesUITests/JournalUITests.swift
@@ -19,6 +19,30 @@ final class JournalUITests: XCTestCase {
         return XCTWaiter.wait(for: [expectation], timeout: timeout) == .completed
     }
 
+    /// After chip submit, the software keyboard can stay up and bury lower sections on small simulators (CI parity).
+    @MainActor
+    private func dismissSoftwareKeyboardForJournalIfPresent(in app: XCUIApplication) {
+        guard app.keyboards.firstMatch.waitForExistence(timeout: 0.5) else { return }
+        let anchor = app.staticTexts["Gratitudes"].firstMatch
+        if anchor.waitForExistence(timeout: 1) {
+            anchor.tap()
+        } else {
+            app.swipeDown()
+        }
+    }
+
+    /// Scrolls until the section add chip is hittable so `tap()` reaches the morph control, not the keyboard chrome.
+    @MainActor
+    private func ensureJournalAddButtonReady(_ addButtonIdentifier: String, in app: XCUIApplication) {
+        let addButton = app.buttons[addButtonIdentifier].firstMatch
+        for _ in 0..<10 {
+            if addButton.waitForExistence(timeout: 0.6), addButton.isHittable {
+                return
+            }
+            app.swipeUp()
+        }
+    }
+
     @MainActor
     private func launchApp(resetUITestStore: Bool = true) -> XCUIApplication {
         let app = XCUIApplication()
@@ -75,6 +99,8 @@ final class JournalUITests: XCTestCase {
     ) {
         let field = journalTextView(fieldIdentifier, in: app)
         if !field.waitForExistence(timeout: 2), let addButtonIdentifier {
+            dismissSoftwareKeyboardForJournalIfPresent(in: app)
+            ensureJournalAddButtonReady(addButtonIdentifier, in: app)
             let addButton = app.buttons[addButtonIdentifier].firstMatch
             XCTAssertTrue(
                 addButton.waitForExistence(timeout: 5),


### PR DESCRIPTION
## Headline

CI was failing on Today journal UI tests when moving from the first gratitude to **Needs**: the Need composer never appeared on the Pro simulator.

## User impact

None for app users. This only makes **UI automation reliable** so **main** and PR checks stay green.

## What changed

When a test uses `submitEntry` and must open a section via its add chip, it now **dismisses the software keyboard** (tap the Gratitudes heading, matching other tests) and **scrolls until the add control is hittable** before tapping, so the morph field consistently exposes identifiers like `Need 1`.

## Verification

- `xcodebuild test` with `-only-testing:GraceNotesUITests/JournalUITests/test_todayScreen_needsAndPeopleExposeStripIdentifiers` on iPhone 17 Pro — pass.
- Recommend `grace ci --profile full` on this PR (label **full-ci**) for matrix + SE smoke parity.