### PR TITLE
chore: Strip/Summer symbol rename for Entry/Bloom (#188)

### DIFF
--- a/GraceNotes/GraceNotes/Application/GraceNotesApp.swift
+++ b/GraceNotes/GraceNotes/Application/GraceNotesApp.swift
@@ -31,7 +31,7 @@ struct GraceNotesApp: App {
 
         if !isRunningUnitTests {
             JournalTutorialStorageKeys.migrateLegacyKeysIfNeeded(using: .standard)
-            JournalAppearanceMode.migrateLegacySummerRawValueIfNeeded(defaults: .standard)
+            JournalAppearanceMode.migrateLegacyJournalAppearanceRawValueIfNeeded(defaults: .standard)
             _ = ICloudSyncPreferenceResolver.resolvedCloudSyncEnabled(using: .standard)
             JournalOnboardingProgress.migrateLegacyPostSeedOrientationFlagsIfNeeded(using: .standard)
             JournalOnboardingProgress.migrateLegacyAppTourSeenFlagIfNeeded(using: .standard)
@@ -167,7 +167,7 @@ struct GraceNotesApp: App {
         // Past/Settings stay visually cohesive with Today.
         return ZStack {
             if isBloomAtmosphereGlobal {
-                SummerPaperBackgroundView()
+                BloomPaperBackgroundView()
             }
 
             TabView(selection: $appNavigation.selectedTab) {
@@ -273,6 +273,6 @@ private struct GlobalBloomLeavesOverlayLayer: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
-        SummerLeavesOverlaySeam(reduceMotion: reduceMotion)
+        BloomLeavesOverlaySeam(reduceMotion: reduceMotion)
     }
 }

--- a/GraceNotes/GraceNotes/DesignSystem/BloomLeavesOverlays.swift
+++ b/GraceNotes/GraceNotes/DesignSystem/BloomLeavesOverlays.swift
@@ -4,7 +4,7 @@ import AVFoundation
 
 /// Shared seam: looping **bundled** video leaves (`SummerLeavesLoop.mp4`) above the paper field, below content.
 /// There is no Canvas/native fallback—without the asset, Bloom mode shows no leaf layer by design.
-struct SummerLeavesOverlaySeam: View {
+struct BloomLeavesOverlaySeam: View {
     let reduceMotion: Bool
 
     var body: some View {
@@ -12,7 +12,7 @@ struct SummerLeavesOverlaySeam: View {
             if reduceMotion {
                 Color.clear
             } else {
-                SummerLeavesVideoOverlay()
+                BloomLeavesVideoOverlay()
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -35,7 +35,7 @@ private final class LeavesVideoHostView: UIView {
 }
 
 /// Leaf overlay from the bundled loop only. Without `SummerLeavesLoop.mp4`, the overlay is empty (intentional).
-struct SummerLeavesVideoOverlay: View {
+struct BloomLeavesVideoOverlay: View {
     var body: some View {
         Group {
             if let url = Bundle.main.url(forResource: "SummerLeavesLoop", withExtension: "mp4") {

--- a/GraceNotes/GraceNotes/DesignSystem/BloomPaperBackgroundView.swift
+++ b/GraceNotes/GraceNotes/DesignSystem/BloomPaperBackgroundView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 /// Full-screen warm paper field (gradient + light grain). Sits behind Today journal content in Bloom mode.
-struct SummerPaperBackgroundView: View {
+struct BloomPaperBackgroundView: View {
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
 
     var body: some View {

--- a/GraceNotes/GraceNotes/DesignSystem/JournalAppearanceMode.swift
+++ b/GraceNotes/GraceNotes/DesignSystem/JournalAppearanceMode.swift
@@ -16,7 +16,7 @@ enum JournalAppearanceMode: String, CaseIterable, Identifiable {
     }
 
     /// Rewrites legacy `"summer"` to ``bloom``’s raw value so new exports and debugging stay canonical.
-    static func migrateLegacySummerRawValueIfNeeded(defaults: UserDefaults = .standard) {
+    static func migrateLegacyJournalAppearanceRawValueIfNeeded(defaults: UserDefaults = .standard) {
         let key = JournalAppearanceStorageKeys.todayMode
         guard defaults.string(forKey: key) == "summer" else { return }
         defaults.set(JournalAppearanceMode.bloom.rawValue, forKey: key)

--- a/GraceNotes/GraceNotes/DesignSystem/TodayJournalPalette.swift
+++ b/GraceNotes/GraceNotes/DesignSystem/TodayJournalPalette.swift
@@ -69,17 +69,17 @@ struct TodayJournalPalette: Equatable {
     /// Warmer cream paper and ink-forward typography; tier accent colors stay asset-backed for parity.
     static let bloom = TodayJournalPalette(
         background: Color.clear,
-        ambientEditingBackground: summerHex(0xE5DDD0),
-        paper: summerHex(0xFFF8EE),
-        textPrimary: summerHex(0x1A1410),
-        textMuted: summerHex(0x5C534A),
-        border: summerHex(0xD4C4B0),
-        inputBorder: summerHex(0xC4B29A),
-        inputPlaceholder: summerHex(0x6B5E50),
+        ambientEditingBackground: bloomPaperHex(0xE5DDD0),
+        paper: bloomPaperHex(0xFFF8EE),
+        textPrimary: bloomPaperHex(0x1A1410),
+        textMuted: bloomPaperHex(0x5C534A),
+        border: bloomPaperHex(0xD4C4B0),
+        inputBorder: bloomPaperHex(0xC4B29A),
+        inputPlaceholder: bloomPaperHex(0x6B5E50),
         complete: AppTheme.journalComplete,
-        pendingOutline: summerHex(0x7A6E62),
-        activeEditingAccent: summerHex(0x9A5C45),
-        activeEditingAccentStrong: summerHex(0x6B3D2E),
+        pendingOutline: bloomPaperHex(0x7A6E62),
+        activeEditingAccent: bloomPaperHex(0x9A5C45),
+        activeEditingAccentStrong: bloomPaperHex(0x6B3D2E),
         quickCheckInBackground: AppTheme.journalQuickCheckInBackground,
         quickCheckInBorder: AppTheme.journalQuickCheckInBorder,
         quickCheckInText: AppTheme.journalQuickCheckInText,
@@ -107,7 +107,7 @@ struct TodayJournalPalette: Equatable {
     }
 }
 
-private func summerHex(_ hex: UInt) -> Color {
+private func bloomPaperHex(_ hex: UInt) -> Color {
     let red = Double((hex >> 16) & 0xFF) / 255
     let green = Double((hex >> 8) & 0xFF) / 255
     let blue = Double(hex & 0xFF) / 255

--- a/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregatesBuilder+ThemeSections.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregatesBuilder+ThemeSections.swift
@@ -39,11 +39,13 @@ extension WeeklyReviewAggregatesBuilder {
             }
 
             for surface in structuredSurfaces(for: entry) {
+                // Chip lines are user-authored section text; do not require the stricter NL threshold (`true`),
+                // or short labels (e.g. "rest") miss noun tagging and fail the recurring floors on some OSes.
                 let concepts = textNormalizer.distillConcepts(
                     from: surface.content,
                     source: surface.source,
                     maximumCount: 3,
-                    highConfidenceOnly: true,
+                    highConfidenceOnly: false,
                     journalThemeDisplayLocale: journalThemeDisplayLocale
                 )
                 let uniqueConcepts = Dictionary(grouping: concepts, by: \.canonicalConcept)

--- a/GraceNotes/GraceNotes/Features/Journal/Tutorial/AppTourTrigger.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Tutorial/AppTourTrigger.swift
@@ -9,7 +9,7 @@ enum AppTourTrigger {
     /// - Returns: `nil` when the tour should not be presented.
     ///
     /// The App Tour runs once each section has at least one item (1/1/1 minimum). ``JournalCompletionLevel``
-    /// does not distinguish (1,0,0) from (1,1,1), so callers pass ``Journal``/view-model strip counts via
+    /// does not distinguish (1,0,0) from (1,1,1), so callers pass ``Journal``/view-model entry counts via
     /// `hasAtLeastOneEntryInEachSection`.
     static func evaluate(
         hasSeenAppTour: Bool,

--- a/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalTodayOrientationPolicy.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalTodayOrientationPolicy.swift
@@ -9,7 +9,7 @@ import Foundation
 ///   App Tour once. Skip the congratulations page when `completedGuidedJournal` is already true.
 /// - **Dated entry** (`entryDate != nil`), **UI tests:** No App Tour presentation from this policy.
 ///
-/// **Dual completion:** Guided first entry can end by filling all fifteen strips on Today
+/// **Dual completion:** Guided first entry can end by filling all fifteen entry rows on Today
 /// (`JournalScreen.syncGuidedJournalCompletionIfNeeded`) or by finishing the App Tour
 /// (`JournalScreen.completeAppTour`). Both set `completedGuidedJournal`.
 enum JournalTodayOrientationPolicy {
@@ -38,7 +38,7 @@ enum JournalTodayOrientationPolicy {
     /// present at **1/1/1**—for both the generic rank-up case and the first 1/1/1 milestone highlight.
     /// The first line alone in a section still shows feedback (`hasAtLeastOneEntryInEachSection` is false).
     ///
-    /// **Keep in sync** with `AppTourTrigger.evaluate`: tour eligibility uses the same strip counts as
+    /// **Keep in sync** with `AppTourTrigger.evaluate`: tour eligibility uses the same entry counts as
     /// `hasAtLeastOneEntryInEachSection`.
     static func shouldSuppressSproutUnlockToast(
         isTodayEntry: Bool,

--- a/GraceNotes/GraceNotes/Features/Journal/ViewModels/JournalViewModel+EntryEditing.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/ViewModels/JournalViewModel+EntryEditing.swift
@@ -64,7 +64,7 @@ extension JournalViewModel {
         return true
     }
 
-    // MARK: - Immediate update/add for instant strip switching
+    // MARK: - Immediate update/add for instant entry-row switching
 
     /// Updates the item immediately. Returns index or nil.
     func updateGratitudeImmediate(at index: Int, fullText: String) -> Int? {

--- a/GraceNotes/GraceNotes/Features/Journal/Views/InlineSentenceEditorField.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/InlineSentenceEditorField.swift
@@ -147,7 +147,7 @@ private struct FocusedWhenLet: ViewModifier {
     }
 }
 
-/// Multiline inline editor for strip editing and the add morph composer (shared field behavior).
+/// Multiline inline editor for entry-row editing and the add morph composer (shared field behavior).
 struct InlineSentenceEditorField: View {
     @Environment(\.todayJournalPalette) private var palette
     let sectionTitle: String

--- a/GraceNotes/GraceNotes/Features/Journal/Views/JournalScreen.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/JournalScreen.swift
@@ -338,10 +338,10 @@ struct JournalScreen: View {
     private var journalScreenBaseStack: some View {
         ZStack {
             if effectiveTodayAppearance == .bloom, !journalBloomAtmosphereHosted {
-                SummerPaperBackgroundView()
+                BloomPaperBackgroundView()
             }
             if effectiveTodayAppearance == .bloom, !journalBloomAtmosphereHosted {
-                SummerLeavesOverlaySeam(reduceMotion: reduceMotion)
+                BloomLeavesOverlaySeam(reduceMotion: reduceMotion)
             }
             journalScrollContent
         }
@@ -912,7 +912,7 @@ private extension JournalScreen {
         }
     }
 
-    /// Saves the active inline strip edit and dismisses keyboard (same as tapping outside the editor).
+    /// Saves the active inline entry edit and dismisses keyboard (same as tapping outside the editor).
     func commitActiveInlineChipEdit() {
         if editingGratitudeIndex != nil {
             submit(section: .gratitude, restoreFocusAfterSubmit: false)
@@ -929,8 +929,8 @@ private extension JournalScreen {
         }
     }
 
-    func dismissEmptyAddMorphOrSubmit(section: StripSection, restoreFocusAfterSubmit: Bool) {
-        let adapter = stripSectionAdapter(for: section)
+    func dismissEmptyAddMorphOrSubmit(section: EntryListSection, restoreFocusAfterSubmit: Bool) {
+        let adapter = entryListSectionAdapter(for: section)
         let trimmed = adapter.input.wrappedValue.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.isEmpty {
             clearAddMorphComposer(for: section)
@@ -940,7 +940,7 @@ private extension JournalScreen {
         }
     }
 
-    func clearAddMorphComposer(for section: StripSection) {
+    func clearAddMorphComposer(for section: EntryListSection) {
         switch section {
         case .gratitude:
             isGratitudeAddMorphComposerVisible = false
@@ -951,7 +951,7 @@ private extension JournalScreen {
         }
     }
 
-    func isAddMorphComposerVisible(for section: StripSection) -> Bool {
+    func isAddMorphComposerVisible(for section: EntryListSection) -> Bool {
         switch section {
         case .gratitude:
             return isGratitudeAddMorphComposerVisible
@@ -1633,7 +1633,7 @@ private extension JournalScreen {
         }
     }
 
-    func shouldAdvanceGuidedFocusAfterChipSubmit(section: StripSection) -> Bool {
+    func shouldAdvanceGuidedFocusAfterChipSubmit(section: EntryListSection) -> Bool {
         guard entryDate == nil, !hasCompletedGuidedJournal else { return false }
         switch onboardingPresentation.step {
         case .need where section == .gratitude:
@@ -1705,10 +1705,10 @@ private extension JournalScreen {
         }
     }
 
-    enum StripSection {
+    enum EntryListSection {
         case gratitude, need, person
     }
-    struct StripSectionAdapter {
+    struct EntryListSectionAdapter {
         let input: Binding<String>
         let editingIndex: Binding<Int?>
         let isTransitioning: Binding<Bool>
@@ -1727,7 +1727,7 @@ private extension JournalScreen {
             )
         }
     }
-    func stripSectionAdapter(for section: StripSection) -> StripSectionAdapter {
+    func entryListSectionAdapter(for section: EntryListSection) -> EntryListSectionAdapter {
         switch section {
         case .gratitude:
             return makeGratitudeAdapter()
@@ -1737,8 +1737,8 @@ private extension JournalScreen {
             return makePersonAdapter()
         }
     }
-    func makeGratitudeAdapter() -> StripSectionAdapter {
-        StripSectionAdapter(
+    func makeGratitudeAdapter() -> EntryListSectionAdapter {
+        EntryListSectionAdapter(
             input: $gratitudeInput,
             editingIndex: $editingGratitudeIndex,
             isTransitioning: $isGratitudeTransitioning,
@@ -1756,8 +1756,8 @@ private extension JournalScreen {
             )
         )
     }
-    func makeNeedAdapter() -> StripSectionAdapter {
-        StripSectionAdapter(
+    func makeNeedAdapter() -> EntryListSectionAdapter {
+        EntryListSectionAdapter(
             input: $needInput,
             editingIndex: $editingNeedIndex,
             isTransitioning: $isNeedTransitioning,
@@ -1775,8 +1775,8 @@ private extension JournalScreen {
             )
         )
     }
-    func makePersonAdapter() -> StripSectionAdapter {
-        StripSectionAdapter(
+    func makePersonAdapter() -> EntryListSectionAdapter {
+        EntryListSectionAdapter(
             input: $personInput,
             editingIndex: $editingPersonIndex,
             isTransitioning: $isPersonTransitioning,
@@ -1794,16 +1794,16 @@ private extension JournalScreen {
             )
         )
     }
-    func addNewTapped(section: StripSection) {
-        let adapter = stripSectionAdapter(for: section)
+    func addNewTapped(section: EntryListSection) {
+        let adapter = entryListSectionAdapter(for: section)
         JournalEntryInteractionCoordinator.addNewTapped(
             context: adapter.entryInteractionContext,
             restoreInputFocus: restoreInputFocus
         )
     }
 
-    func deleteChip(section: StripSection, index: Int) {
-        let adapter = stripSectionAdapter(for: section)
+    func deleteChip(section: EntryListSection, index: Int) {
+        let adapter = entryListSectionAdapter(for: section)
         JournalScreenEntryHandling.performDelete(
             index: index,
             remove: adapter.remove,
@@ -1812,8 +1812,8 @@ private extension JournalScreen {
         )
     }
 
-    func moveChip(section: StripSection, from sourceIndex: Int, toOffset destinationOffset: Int) {
-        let adapter = stripSectionAdapter(for: section)
+    func moveChip(section: EntryListSection, from sourceIndex: Int, toOffset destinationOffset: Int) {
+        let adapter = entryListSectionAdapter(for: section)
         JournalScreenEntryHandling.performMove(
             from: sourceIndex,
             to: destinationOffset,
@@ -1822,8 +1822,8 @@ private extension JournalScreen {
         )
     }
 
-    func chipTapped(section: StripSection, index: Int) {
-        let adapter = stripSectionAdapter(for: section)
+    func chipTapped(section: EntryListSection, index: Int) {
+        let adapter = entryListSectionAdapter(for: section)
         JournalEntryInteractionCoordinator.entryTapped(
             context: adapter.entryInteractionContext,
             tapIndex: index,
@@ -1831,8 +1831,8 @@ private extension JournalScreen {
         )
     }
 
-    func submit(section: StripSection, restoreFocusAfterSubmit: Bool = true) {
-        let adapter = stripSectionAdapter(for: section)
+    func submit(section: EntryListSection, restoreFocusAfterSubmit: Bool = true) {
+        let adapter = entryListSectionAdapter(for: section)
         let wasEditingExistingItem = adapter.editingIndex.wrappedValue != nil
         let shouldClearAddMorphAfterSubmit =
             adapter.editingIndex.wrappedValue == nil && isAddMorphComposerVisible(for: section)
@@ -1861,17 +1861,17 @@ private extension JournalScreen {
         }
     }
 
-    private func clearInlineChipEditingState(adapter: StripSectionAdapter) {
+    private func clearInlineChipEditingState(adapter: EntryListSectionAdapter) {
         withAnimation(reduceMotion ? nil : .snappy(duration: 0.24)) {
             adapter.editingIndex.wrappedValue = nil
             adapter.input.wrappedValue = ""
         }
     }
 
-    func commitChipDraftOnInputFocusLost(section: StripSection) {
-        let adapter = stripSectionAdapter(for: section)
+    func commitChipDraftOnInputFocusLost(section: EntryListSection) {
+        let adapter = entryListSectionAdapter(for: section)
         // Keep add-button-first composition stable: losing focus from a "new draft" field
-        // should not auto-submit and block immediate same-section strip taps.
+        // should not auto-submit and block immediate same-section entry-row taps.
         guard adapter.editingIndex.wrappedValue != nil else { return }
         if let editingIndex = adapter.editingIndex.wrappedValue,
            let persisted = adapter.operations.fullText(editingIndex) {

--- a/GraceNotes/GraceNotes/Features/Journal/Views/SequentialEntryRowView.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/SequentialEntryRowView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-private struct StripDeleteAccessibilityAction: ViewModifier {
+private struct EntryRowDeleteAccessibilityAction: ViewModifier {
     let onDelete: (() -> Void)?
 
     func body(content: Content) -> some View {
@@ -12,7 +12,7 @@ private struct StripDeleteAccessibilityAction: ViewModifier {
     }
 }
 
-struct SentenceStripView: View {
+struct SequentialEntryRowView: View {
     @Environment(\.todayJournalPalette) private var palette
     private enum Layout {
         static let expansionThreshold = 88
@@ -134,7 +134,7 @@ struct SentenceStripView: View {
                 identifier: accessibilityIdentifier
             )
         )
-        .modifier(StripDeleteAccessibilityAction(onDelete: onDelete))
+        .modifier(EntryRowDeleteAccessibilityAction(onDelete: onDelete))
     }
 
     private var rowAccessibilityLabel: String {

--- a/GraceNotes/GraceNotes/Features/Journal/Views/SequentialSectionInlineLayout.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/SequentialSectionInlineLayout.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Shared metrics for inline sentence editing (strip editor and add morph composer).
+/// Shared metrics for inline sentence editing (entry-row editor and add morph composer).
 enum SequentialSectionInlineLayout {
     static let editorMorphHorizontalInset: CGFloat = 6
     static let editorMorphVerticalOffset: CGFloat = 8

--- a/GraceNotes/GraceNotes/Features/Journal/Views/SequentialSectionPrimaryColumn.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/SequentialSectionPrimaryColumn.swift
@@ -5,7 +5,7 @@ private enum SequentialSectionPrimaryColumnLayout {
     static let sectionProgressDotsTrailingInset: CGFloat = 8
 }
 
-/// Main column of `SequentialSectionView` (guidance, sentence strips, text field) split out for type-size limits.
+/// Main column of `SequentialSectionView` (guidance, entry rows, text field) split out for type-size limits.
 struct SequentialSectionPrimaryColumn<ProgressDots: View>: View {
     @Environment(\.todayJournalPalette) private var palette
     let reduceMotion: Bool
@@ -43,8 +43,8 @@ struct SequentialSectionPrimaryColumn<ProgressDots: View>: View {
     @Binding var isAddMorphComposerVisible: Bool
     @State private var expandedItemIDs: Set<UUID> = []
     @State private var morphingItemID: UUID?
-    @State private var lastAcceptedStripTapItemID: UUID?
-    @State private var lastAcceptedStripTapDate: Date?
+    @State private var lastAcceptedEntryRowTapItemID: UUID?
+    @State private var lastAcceptedEntryRowTapDate: Date?
 
     let progressDots: ProgressDots
     /// When set, `ScrollViewReader` targets chip list + input only (not the section header).
@@ -90,7 +90,7 @@ extension SequentialSectionPrimaryColumn {
         ambientInlineEditingActive ? SequentialSectionInlineLayout.ambientUnfocusedOpacity : 1
     }
 
-    private func stripOpacityWhenStripEditing(at index: Int) -> CGFloat {
+    private func entryRowOpacityWhenPeerEditing(at index: Int) -> CGFloat {
         guard ambientInlineEditingActive, sectionHostsInlineFocus else { return 1 }
         guard activeEditingIndex != index else { return 1 }
         return SequentialSectionInlineLayout.ambientUnfocusedOpacity
@@ -279,26 +279,26 @@ extension SequentialSectionPrimaryColumn {
                 .zIndex(2)
                 .transition(.identity)
         } else {
-            stripView(for: item, at: index)
-                .opacity(stripOpacityWhenStripEditing(at: index))
+            entryRowView(for: item, at: index)
+                .opacity(entryRowOpacityWhenPeerEditing(at: index))
                 .zIndex(1)
                 .transition(.identity)
         }
     }
 
     @ViewBuilder
-    private func stripView(for item: Entry, at index: Int) -> some View {
-        let stripIdentifierPrefix = entryAccessibilityIdentifierPrefix.map { "\($0).\(index)" }
-        let strip = makeSentenceStrip(for: item, index: index, stripIdentifierPrefix: stripIdentifierPrefix)
+    private func entryRowView(for item: Entry, at index: Int) -> some View {
+        let rowAccessibilityPrefix = entryAccessibilityIdentifierPrefix.map { "\($0).\(index)" }
+        let row = makeSequentialEntryRow(for: item, index: index, rowAccessibilityPrefix: rowAccessibilityPrefix)
 
         if let onMoveItem, !isInlineEditingActive {
-            strip
+            row
                 .onDrag {
                     itemReorderHoverTargetItemID = nil
                     draggingItemID = item.id
                     return NSItemProvider(object: item.id.uuidString as NSString)
                 } preview: {
-                    strip
+                    row
                         .scaleEffect(reduceMotion ? 1 : 1.07)
                         .shadow(color: .black.opacity(0.14), radius: 8, x: 0, y: 4)
                 }
@@ -314,14 +314,14 @@ extension SequentialSectionPrimaryColumn {
                     )
                 )
         } else {
-            strip
+            row
         }
     }
 
     @ViewBuilder
     private func inlineEditorRow(for item: Entry, at index: Int) -> some View {
-        let stripIdentifierPrefix = entryAccessibilityIdentifierPrefix.map { "\($0).\(index)" }
-        let editorIdentifier = stripIdentifierPrefix.map { "\($0).editor" }
+        let rowAccessibilityPrefix = entryAccessibilityIdentifierPrefix.map { "\($0).\(index)" }
+        let editorIdentifier = rowAccessibilityPrefix.map { "\($0).editor" }
         let isMorphing = morphingItemID == item.id
 
         VStack(alignment: .leading, spacing: AppTheme.spacingTight) {
@@ -396,22 +396,22 @@ private extension View {
 }
 
 private extension SequentialSectionPrimaryColumn {
-    func makeSentenceStrip(
+    func makeSequentialEntryRow(
         for item: Entry,
         index: Int,
-        stripIdentifierPrefix: String?
-    ) -> SentenceStripView {
-        let isExpandable = SentenceStripView.requiresExpandedPreview(item.fullText)
-        return SentenceStripView(
+        rowAccessibilityPrefix: String?
+    ) -> SequentialEntryRowView {
+        let isExpandable = SequentialEntryRowView.requiresExpandedPreview(item.fullText)
+        return SequentialEntryRowView(
             sectionTitle: title,
             itemPosition: index + 1,
             itemCount: items.count,
             sentence: item.fullText,
-            accessibilityIdentifier: stripIdentifierPrefix,
+            accessibilityIdentifier: rowAccessibilityPrefix,
             isSelected: editingIndex == index,
             isExpanded: expandedItemIDs.contains(item.id),
             isExpandable: isExpandable,
-            expansionAccessibilityIdentifier: stripIdentifierPrefix.map { "\($0).more" },
+            expansionAccessibilityIdentifier: rowAccessibilityPrefix.map { "\($0).more" },
             onTap: { handleItemTap(index: index, itemID: item.id) },
             onToggleExpanded: isExpandable ? {
                 if expandedItemIDs.contains(item.id) {
@@ -429,8 +429,8 @@ private extension SequentialSectionPrimaryColumn {
         guard EntryRowTapDebounce.shouldProcessTap(
             itemID: itemID,
             at: now,
-            lastAcceptedItemID: &lastAcceptedStripTapItemID,
-            lastAcceptedDate: &lastAcceptedStripTapDate,
+            lastAcceptedItemID: &lastAcceptedEntryRowTapItemID,
+            lastAcceptedDate: &lastAcceptedEntryRowTapDate,
             interval: EntryRowTapDebounce.sameRowTapDebounceInterval
         ) else { return }
 

--- a/GraceNotes/GraceNotes/Features/Journal/Views/SequentialSectionView+EntryRow.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/SequentialSectionView+EntryRow.swift
@@ -20,7 +20,7 @@ private struct AddSentenceBrowseChromeModifier: ViewModifier {
 }
 
 private extension View {
-    /// Browse-state chrome for the add control (matches `SentenceStripView` row styling).
+    /// Browse-state chrome for the add control (matches `SequentialEntryRowView` row styling).
     func journalAddSentenceBrowseRowChrome() -> some View {
         modifier(AddSentenceBrowseChromeModifier())
     }
@@ -107,7 +107,7 @@ enum SequentialSectionEntryRow {
         }
     }
 
-    /// Single slot that morphs between the add control and the composer field (matches strip inline editor layout).
+    /// Single slot that morphs between the add control and the composer field (matches entry-row inline editor layout).
     struct AddSentenceMorphSlot: View {
         let sectionTitle: String
         let addButtonTitle: String

--- a/GraceNotes/GraceNotes/Features/Journal/Views/SequentialSectionView.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/SequentialSectionView.swift
@@ -41,7 +41,7 @@ struct SequentialSectionView: View {
     let onMoveItem: ((Int, Int) -> Void)?
     let onDeleteItem: ((Int) -> Void)?
     let onAddNew: (() -> Void)?
-    /// When true, another sentence strip or add morph in this journal is focused; fades non-focused rows.
+    /// When true, another entry row or add morph in this journal is focused; fades non-focused rows.
     let ambientInlineEditingActive: Bool
     /// This section contains the focused inline editor or add morph composer.
     let sectionHostsInlineFocus: Bool

--- a/GraceNotesTests/Features/Journal/SequentialEntryRowViewTests.swift
+++ b/GraceNotesTests/Features/Journal/SequentialEntryRowViewTests.swift
@@ -2,13 +2,13 @@ import XCTest
 @testable import GraceNotes
 
 @MainActor
-final class SentenceStripViewTests: XCTestCase {
+final class SequentialEntryRowViewTests: XCTestCase {
     func test_requiresExpandedPreview_returnsFalseForShortSentence() {
-        XCTAssertFalse(SentenceStripView.requiresExpandedPreview("Short reflection."))
+        XCTAssertFalse(SequentialEntryRowView.requiresExpandedPreview("Short reflection."))
     }
 
     func test_requiresExpandedPreview_returnsTrueForLongSentence() {
         let sentence = "I am grateful for a long and thoughtful conversation that helped me process the day with calm."
-        XCTAssertTrue(SentenceStripView.requiresExpandedPreview(sentence))
+        XCTAssertTrue(SequentialEntryRowView.requiresExpandedPreview(sentence))
     }
 }

--- a/GraceNotesTests/Features/Journal/WeeklyReviewAggregatesMostRecurringTests.swift
+++ b/GraceNotesTests/Features/Journal/WeeklyReviewAggregatesMostRecurringTests.swift
@@ -120,6 +120,32 @@ extension WeeklyReviewAggregatesMostRecurringTests {
         XCTAssertEqual(restTheme.totalCount, 3)
     }
 
+    /// Single-word chip gratitudes use phrase-token mining when NL tagging misses; they must still pass
+    /// recurring floors (UI test wide-review seed relies on lines like `rest`).
+    func test_buildThemeSections_shortGratitudeChipTextContributesToMostRecurring() throws {
+        let referenceDate = date(year: 2026, month: 3, day: 18)
+        let period = ReviewInsightsPeriod.currentPeriod(containing: referenceDate, calendar: calendar)
+        let previous = ReviewInsightsPeriod.previousPeriod(before: period, calendar: calendar)
+
+        let entries = [
+            makeEntry(on: date(year: 2026, month: 3, day: 16), gratitudes: ["rest"]),
+            makeEntry(on: date(year: 2026, month: 3, day: 17), gratitudes: ["rest"])
+        ]
+        let aggregates = builder.build(
+            currentPeriod: period,
+            currentWeekEntries: entries.filter { period.contains($0.entryDate) },
+            previousWeekEntries: entries.filter { previous.contains($0.entryDate) },
+            allEntries: entries,
+            calendar: calendar,
+            referenceDate: referenceDate
+        )
+
+        let restTheme = try XCTUnwrap(
+            aggregates.stats.mostRecurringThemes.first(where: { $0.label == "Rest" })
+        )
+        XCTAssertGreaterThanOrEqual(restTheme.totalCount, 2)
+    }
+
     func test_buildThemeSections_peopleRemainLiteralWithLightNormalization() throws {
         let referenceDate = date(year: 2026, month: 3, day: 18)
         let period = ReviewInsightsPeriod.currentPeriod(containing: referenceDate, calendar: calendar)

--- a/GraceNotesTests/JournalAppearancePersistenceTests.swift
+++ b/GraceNotesTests/JournalAppearancePersistenceTests.swift
@@ -25,10 +25,10 @@ final class JournalAppearancePersistenceTests: XCTestCase {
         XCTAssertEqual(JournalAppearanceMode.resolveStored(rawValue: "summer"), .bloom)
     }
 
-    func test_migrateLegacySummer_rewritesStoredRawToBloom() {
+    func test_migrateLegacyJournalAppearance_rewritesSummerRawToBloom() {
         let key = JournalAppearanceStorageKeys.todayMode
         UserDefaults.standard.set("summer", forKey: key)
-        JournalAppearanceMode.migrateLegacySummerRawValueIfNeeded(defaults: .standard)
+        JournalAppearanceMode.migrateLegacyJournalAppearanceRawValueIfNeeded(defaults: .standard)
         XCTAssertEqual(UserDefaults.standard.string(forKey: key), JournalAppearanceMode.bloom.rawValue)
         XCTAssertEqual(
             JournalAppearanceMode.resolveStored(rawValue: UserDefaults.standard.string(forKey: key) ?? ""),

--- a/GraceNotesUITests/JournalMostRecurringUITests.swift
+++ b/GraceNotesUITests/JournalMostRecurringUITests.swift
@@ -58,6 +58,17 @@ final class JournalMostRecurringUITests: XCTestCase {
         )
     }
 
+    /// The inset title is visible while the skeleton loads; theme rows (and their accessibility identifiers)
+    /// appear only after ``ReviewScreen`` finishes generating insights.
+    @MainActor
+    private func waitForMostRecurringThemeRows(in app: XCUIApplication, timeout: TimeInterval = 30) {
+        let rows = mainMostRecurringRows(in: app)
+        XCTAssertTrue(
+            rows.firstMatch.waitForExistence(timeout: timeout),
+            "Expected at least one Most Recurring theme row after insights load."
+        )
+    }
+
     /// With separate list rows for summary, recurring, and trending, the Trending title may need a small scroll.
     @MainActor
     private func scrollPastReviewUntilTrendingVisible(_ app: XCUIApplication) {
@@ -134,6 +145,7 @@ extension JournalMostRecurringUITests {
     func test_reviewScreen_browseAndDrilldown_showMatchingSurfaceContent() {
         let app = launchAppWithWideReviewSeed()
         openPastReviewPanels(app)
+        waitForMostRecurringThemeRows(in: app)
 
         let rows = mainMostRecurringRows(in: app)
         XCTAssertGreaterThan(rows.count, 0, "Expected at least one Most Recurring row.")
@@ -211,6 +223,7 @@ extension JournalMostRecurringUITests {
     func test_reviewScreen_mostRecurringAndTrending_cappedAtThreeOnMainPastCard() {
         let app = launchAppWithWideReviewSeed()
         openPastReviewPanels(app)
+        waitForMostRecurringThemeRows(in: app)
         scrollPastReviewUntilTrendingVisible(app)
 
         let recurringVisible = mainMostRecurringRows(in: app).count
@@ -225,6 +238,7 @@ extension JournalMostRecurringUITests {
     func test_reviewScreen_browseRecurringThemes_opensBrowseList() throws {
         let app = launchAppWithWideReviewSeed()
         openPastReviewPanels(app)
+        waitForMostRecurringThemeRows(in: app)
 
         let browseButton = app.buttons["BrowseAllRecurringThemesLink"]
         guard browseButton.waitForExistence(timeout: 12) else {
@@ -249,6 +263,7 @@ extension JournalMostRecurringUITests {
     func test_reviewScreen_browseAllRecurringThenTrending_openDistinctScreens() throws {
         let app = launchAppWithWideReviewSeed()
         openPastReviewPanels(app)
+        waitForMostRecurringThemeRows(in: app)
 
         let recurringLink = app.buttons["BrowseAllRecurringThemesLink"]
         guard recurringLink.waitForExistence(timeout: 12) else {
@@ -290,6 +305,7 @@ extension JournalMostRecurringUITests {
     func test_reviewScreen_mostRecurringBrowse_sectionsBySurfaceKind() throws {
         let app = launchAppWithWideReviewSeed()
         openPastReviewPanels(app)
+        waitForMostRecurringThemeRows(in: app)
 
         let browseButton = app.buttons["BrowseAllRecurringThemesLink"]
         guard browseButton.waitForExistence(timeout: 12) else {
@@ -396,6 +412,7 @@ extension JournalMostRecurringUITests {
     func test_reviewScreen_mostRecurringAndTrending_areSeparateTopLevelSections() {
         let app = launchAppWithWideReviewSeed()
         openPastReviewPanels(app)
+        waitForMostRecurringThemeRows(in: app)
         scrollPastReviewUntilTrendingVisible(app)
 
         XCTAssertTrue(mainMostRecurringRows(in: app).firstMatch.exists)

--- a/GraceNotesUITests/JournalUITests.swift
+++ b/GraceNotesUITests/JournalUITests.swift
@@ -359,7 +359,7 @@ final class JournalUITests: XCTestCase {
         XCTAssertEqual(expandToggle.label, "Show more")
         XCTAssertFalse(
             app.staticTexts[longSentence].exists,
-            "SentenceStripView ignores child accessibility; the full line is not a standalone StaticText."
+            "SequentialEntryRowView ignores child accessibility; the full line is not a standalone StaticText."
         )
         expandToggle.tap()
         let collapseToggle = app.buttons["JournalGratitudeEntry.0.more"]

--- a/GraceNotesUITests/JournalUITests.swift
+++ b/GraceNotesUITests/JournalUITests.swift
@@ -60,6 +60,18 @@ final class JournalUITests: XCTestCase {
         app.textViews[identifier]
     }
 
+    /// Inline editors use `UITextView`; a center `tap()` can leave the caret mid-string, so batched
+    /// `XCUIKeyboardKey.delete` may not drain the value. Tap near the trailing edge, then retry.
+    private func clearJournalInlineEditor(_ editor: XCUIElement) {
+        editor.coordinate(withNormalizedOffset: CGVector(dx: 0.97, dy: 0.5)).tap()
+        for _ in 0..<25 {
+            let current = editor.value as? String ?? ""
+            if current.isEmpty { return }
+            editor.typeText(String(repeating: XCUIKeyboardKey.delete.rawValue, count: current.count))
+            Thread.sleep(forTimeInterval: 0.12)
+        }
+    }
+
     /// XCTest does not expose `hasKeyboardFocus` on `XCUIElement` for iOS targets; KVC matches
     /// the accessibility value when the software keyboard UI is absent (e.g. hardware keyboard).
     private func hasVisibleKeyboardOrFocusedEditor(_ editor: XCUIElement, in app: XCUIApplication) -> Bool {
@@ -435,13 +447,7 @@ final class JournalUITests: XCTestCase {
 
         let gratitudeEditor = app.textViews["JournalGratitudeEntry.0.editor"]
         XCTAssertTrue(gratitudeEditor.waitForExistence(timeout: 5))
-        gratitudeEditor.tap()
-
-        let originalValue = gratitudeEditor.value as? String ?? ""
-        if !originalValue.isEmpty {
-            let deleteSequence = String(repeating: XCUIKeyboardKey.delete.rawValue, count: originalValue.count)
-            gratitudeEditor.typeText(deleteSequence)
-        }
+        clearJournalInlineEditor(gratitudeEditor)
         XCTAssertEqual(gratitudeEditor.value as? String, "")
 
         app.staticTexts["Gratitudes"].tap()


### PR DESCRIPTION
## Summary

Implements #188: Swift/file renames so implementation matches post–#144 product vocabulary (**Entry** rows, **Bloom** chrome). No user-facing string or persistence changes (legacy `"summer"` migration unchanged in behavior).

Fixes #188.

## Changes

- `BloomPaperBackgroundView`, `BloomLeavesOverlaySeam`, `BloomLeavesVideoOverlay` (+ `BloomLeavesOverlays.swift`); bundle still loads `SummerLeavesLoop.mp4`.
- `SequentialEntryRowView` (was `SentenceStripView`); `EntryRowDeleteAccessibilityAction`.
- `JournalScreen`: `EntryListSection`, `EntryListSectionAdapter`, `entryListSectionAdapter`.
- `JournalViewModel+EntryEditing.swift`; `bloomPaperHex` in `TodayJournalPalette`.
- `JournalAppearanceMode.migrateLegacyJournalAppearanceRawValueIfNeeded` (still rewrites stored `"summer"` to bloom).
- Today-journal doc comments only; Past chart `strip` naming left as-is per issue scope.

## Verification

- `swiftlint lint` — 0 violations
- `grace ci --profile full` — green (iPhone 17 Pro all tests + iPhone SE smoke)