### PR TITLE
Past: swipe between journal days from Days you wrote (#253)

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/PastJournalDaySheet.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/PastJournalDaySheet.swift
@@ -1,0 +1,150 @@
+import SwiftData
+import SwiftUI
+
+// MARK: - Navigation (issue #253)
+
+/// Ordering for Past “Days you wrote” sheet paging: **global** distinct journal days, oldest → newest.
+/// Horizontal paging is enabled only when opening from the rhythm strip (not search).
+enum PastJournalDayNavigation {
+    /// Distinct calendar day starts for every persisted journal row, sorted ascending.
+    static func sortedDistinctDayStarts(from entries: [Journal], calendar: Calendar) -> [Date] {
+        let unique = Set(entries.map { calendar.startOfDay(for: $0.entryDate) })
+        return unique.sorted()
+    }
+
+    static func indexMatchingDay(dayStart: Date, in sortedDays: [Date], calendar: Calendar) -> Int? {
+        let normalized = calendar.startOfDay(for: dayStart)
+        return sortedDays.firstIndex { calendar.isDate($0, inSameDayAs: normalized) }
+    }
+}
+
+// MARK: - Sheet payload + host
+
+struct ReviewJournalDaySheetItem: Identifiable, Equatable {
+    let id: String
+    let entryDate: Date
+    /// When non-nil and count > 1, enables horizontal paging (rhythm strip only; issue #253).
+    let navigableDayStarts: [Date]?
+
+    init(dayStart: Date, calendar: Calendar, navigableDayStarts: [Date]?) {
+        let normalized = calendar.startOfDay(for: dayStart)
+        entryDate = normalized
+        let parts = calendar.dateComponents([.year, .month, .day], from: normalized)
+        let year = parts.year ?? 0
+        let month = parts.month ?? 0
+        let day = parts.day ?? 0
+        id = "\(year)-\(month)-\(day)"
+        self.navigableDayStarts = navigableDayStarts
+    }
+}
+
+struct ReviewJournalDaySheetHost: View {
+    let item: ReviewJournalDaySheetItem
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    @State private var selectedIndex: Int
+
+    init(item: ReviewJournalDaySheetItem, calendar: Calendar) {
+        self.item = item
+        let days = item.navigableDayStarts ?? []
+        let startIndex = PastJournalDayNavigation.indexMatchingDay(
+            dayStart: item.entryDate,
+            in: days,
+            calendar: calendar
+        ) ?? 0
+        _selectedIndex = State(initialValue: startIndex)
+    }
+
+    private var navigableDays: [Date] {
+        item.navigableDayStarts ?? []
+    }
+
+    private var isPagingEnabled: Bool {
+        navigableDays.count > 1
+    }
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if isPagingEnabled, reduceMotion {
+                    pagedContentReduceMotion
+                } else if isPagingEnabled {
+                    pagedContentTabView
+                } else {
+                    JournalScreen(entryDate: item.entryDate)
+                }
+            }
+            .toolbar {
+                if isPagingEnabled {
+                    ToolbarItem(placement: .topBarLeading) {
+                        dayNavigationButtons
+                    }
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    PastToolbarDoneButton(
+                        action: { dismiss() },
+                        appearance: .journal
+                    )
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var pagedContentTabView: some View {
+        TabView(selection: $selectedIndex) {
+            ForEach(0..<navigableDays.count, id: \.self) { index in
+                JournalScreen(entryDate: navigableDays[index])
+                    .tag(index)
+            }
+        }
+        .tabViewStyle(.page(indexDisplayMode: .never))
+    }
+
+    private var pagedContentReduceMotion: some View {
+        JournalScreen(entryDate: navigableDays[selectedIndex])
+            .id(navigableDays[selectedIndex].timeIntervalSince1970)
+    }
+
+    private var dayNavigationButtons: some View {
+        HStack(spacing: AppTheme.spacingRegular) {
+            Button {
+                moveToAdjacentDay(offset: -1)
+            } label: {
+                Image(systemName: "chevron.left")
+                    .font(AppTheme.warmPaperBody.weight(.semibold))
+                    .foregroundStyle(AppTheme.accent)
+            }
+            .buttonStyle(PastToolbarDoneButtonStyle())
+            .disabled(selectedIndex <= 0)
+            .accessibilityLabel(String(localized: "past.journalDay.previous"))
+            .accessibilityIdentifier("PastJournalDayPrevious")
+
+            Button {
+                moveToAdjacentDay(offset: 1)
+            } label: {
+                Image(systemName: "chevron.right")
+                    .font(AppTheme.warmPaperBody.weight(.semibold))
+                    .foregroundStyle(AppTheme.accent)
+            }
+            .buttonStyle(PastToolbarDoneButtonStyle())
+            .disabled(selectedIndex >= navigableDays.count - 1)
+            .accessibilityLabel(String(localized: "past.journalDay.next"))
+            .accessibilityIdentifier("PastJournalDayNext")
+        }
+    }
+
+    private func moveToAdjacentDay(offset: Int) {
+        let next = selectedIndex + offset
+        guard navigableDays.indices.contains(next) else { return }
+        if reduceMotion {
+            selectedIndex = next
+        } else {
+            withAnimation {
+                selectedIndex = next
+            }
+        }
+    }
+}

--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewScreen.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewScreen.swift
@@ -18,21 +18,6 @@ private enum ReviewBrowseSheet: Identifiable {
     }
 }
 
-private struct ReviewJournalDaySheetItem: Identifiable, Equatable {
-    let id: String
-    let entryDate: Date
-
-    init(dayStart: Date, calendar: Calendar) {
-        let normalized = calendar.startOfDay(for: dayStart)
-        entryDate = normalized
-        let parts = calendar.dateComponents([.year, .month, .day], from: normalized)
-        let year = parts.year ?? 0
-        let month = parts.month ?? 0
-        let day = parts.day ?? 0
-        id = "\(year)-\(month)-\(day)"
-    }
-}
-
 struct ReviewScreen: View {
     @Environment(\.modelContext) private var modelContext
     @Query(sort: \Journal.entryDate, order: .reverse) private var entries: [Journal]
@@ -213,12 +198,29 @@ extension ReviewScreen {
             )
         }
         .sheet(item: $journalDaySheetItem) { item in
-            ReviewJournalDaySheetHost(entryDate: item.entryDate)
+            ReviewJournalDaySheetHost(item: item, calendar: calendar)
         }
     }
 
-    private func presentJournalDaySheet(for day: Date) {
-        journalDaySheetItem = ReviewJournalDaySheetItem(dayStart: day, calendar: calendar)
+    private enum PastJournalSheetSource {
+        /// Issue #253: enables global day paging (distinct journal days, oldest → newest).
+        case rhythmStrip
+        case search
+    }
+
+    private func presentJournalDaySheet(for day: Date, source: PastJournalSheetSource) {
+        let navigable: [Date]?
+        switch source {
+        case .rhythmStrip:
+            navigable = PastJournalDayNavigation.sortedDistinctDayStarts(from: entries, calendar: calendar)
+        case .search:
+            navigable = nil
+        }
+        journalDaySheetItem = ReviewJournalDaySheetItem(
+            dayStart: day,
+            calendar: calendar,
+            navigableDayStarts: navigable
+        )
     }
 
     private var emptyStateWithSearch: some View {
@@ -244,7 +246,7 @@ extension ReviewScreen {
                     calendar: calendar,
                     highlightQuery: trimmedJournalSearchQuery,
                     onDismissSearchFocus: dismissPastSearchFocus,
-                    onOpenJournalDay: presentJournalDaySheet
+                    onOpenJournalDay: { presentJournalDaySheet(for: $0, source: .search) }
                 )
             }
         }
@@ -272,7 +274,7 @@ extension ReviewScreen {
                     calendar: calendar,
                     highlightQuery: trimmedJournalSearchQuery,
                     onDismissSearchFocus: dismissPastSearchFocus,
-                    onOpenJournalDay: presentJournalDaySheet
+                    onOpenJournalDay: { presentJournalDaySheet(for: $0, source: .search) }
                 )
             }
         }
@@ -303,7 +305,7 @@ extension ReviewScreen {
                 ReviewDaysYouWrotePanel(
                     insights: reviewInsights,
                     isLoading: isLoadingInsights,
-                    onRhythmDaySelected: presentJournalDaySheet,
+                    onRhythmDaySelected: { presentJournalDaySheet(for: $0, source: .rhythmStrip) },
                     onRhythmChromeTap: {
                         historyDrilldown = .journalingDays
                     }
@@ -432,25 +434,6 @@ extension ReviewScreen {
             weekBoundaryPreferenceRawValue: reviewWeekBoundaryRawValue,
             pastStatisticsIntervalToken: pastStatisticsInterval.cacheKeyToken
         )
-    }
-}
-
-private struct ReviewJournalDaySheetHost: View {
-    let entryDate: Date
-    @Environment(\.dismiss) private var dismiss
-
-    var body: some View {
-        NavigationStack {
-            JournalScreen(entryDate: entryDate)
-                .toolbar {
-                    ToolbarItem(placement: .topBarTrailing) {
-                        PastToolbarDoneButton(
-                            action: { dismiss() },
-                            appearance: .journal
-                        )
-                    }
-                }
-        }
     }
 }
 

--- a/GraceNotes/GraceNotes/Localizable.xcstrings
+++ b/GraceNotes/GraceNotes/Localizable.xcstrings
@@ -4003,6 +4003,38 @@
         }
       }
     },
+    "past.journalDay.previous": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Previous day"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "前一天"
+          }
+        }
+      }
+    },
+    "past.journalDay.next": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Next day"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "后一天"
+          }
+        }
+      }
+    },
     "past.search.noMatches.description": {
       "localizations": {
         "en": {

--- a/GraceNotesTests/Features/Journal/PastJournalDayNavigationTests.swift
+++ b/GraceNotesTests/Features/Journal/PastJournalDayNavigationTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+@testable import GraceNotes
+
+final class PastJournalDayNavigationTests: XCTestCase {
+    private var calendar: Calendar!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(secondsFromGMT: 0)!
+        calendar = cal
+    }
+
+    func test_sortedDistinctDayStarts_dedupesAndSortsAscending() {
+        let dayA = calendar.startOfDay(for: Date(timeIntervalSince1970: 1_742_056_800)) // 2025-03-04
+        let dayB = calendar.startOfDay(for: Date(timeIntervalSince1970: 1_742_147_200)) // 2025-03-15
+
+        let laterRow = Journal(entryDate: dayB, createdAt: dayB, updatedAt: dayB)
+        let earlierRow = Journal(entryDate: dayA, createdAt: dayA, updatedAt: dayA)
+        let duplicateLaterRow = Journal(entryDate: dayB, createdAt: dayB, updatedAt: dayB)
+
+        let result = PastJournalDayNavigation.sortedDistinctDayStarts(
+            from: [laterRow, earlierRow, duplicateLaterRow],
+            calendar: calendar
+        )
+
+        XCTAssertEqual(result, [dayA, dayB])
+    }
+
+    func test_indexMatchingDay_findsIndex() {
+        let dayA = calendar.startOfDay(for: Date(timeIntervalSince1970: 1_742_056_800))
+        let dayB = calendar.startOfDay(for: Date(timeIntervalSince1970: 1_742_147_200))
+        let sortedDays = [dayA, dayB]
+
+        XCTAssertEqual(
+            PastJournalDayNavigation.indexMatchingDay(dayStart: dayB, in: sortedDays, calendar: calendar),
+            1
+        )
+        XCTAssertNil(
+            PastJournalDayNavigation.indexMatchingDay(
+                dayStart: calendar.date(byAdding: .day, value: 7, to: dayB)!,
+                in: sortedDays,
+                calendar: calendar
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary
Implements horizontal paging between journal days when opening a day from **Past → Days you wrote** (issue #253).

- **Order**: distinct journal days globally, oldest → newest.
- **Scope**: paging only from the rhythm strip; **search** still opens a single day with no paging.
- **Reduce Motion off**: `TabView` page style for horizontal swipe.
- **Reduce Motion on**: instant day swap (no page animation) with the same Previous/Next toolbar controls.
- **Toolbar**: Previous/Next chevrons (VoiceOver labels + `PastJournalDayPrevious` / `PastJournalDayNext` identifiers), Done unchanged. No wrap at first/last day.

## Verification
- `swiftlint` on touched files
- `xcodebuild test -only-testing:GraceNotesTests/PastJournalDayNavigationTests` (passed)
- `grace l10n audit` (OK)

Closes #253

Made with [Cursor](https://cursor.com)