### PR TITLE
Past: toolbar completion parity, journal titles, unified day sheet (#257)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- **Past (#257):** Sticky completion toolbar chip matches inline completion (tap shows status info and scrolls to header; touch-and-hold toggles the expanded label). Past journal navigation titles align with search/list day captions (same calendar year omits year; **Today** / **Yesterday** unchanged). Opening a day from **Growth**, **Section mix**, **Reflection rhythm** drill-down, **theme** drill-downs, or **browse** sheets presents **Journal** in the top-level day sheet (drill-down sheet dismisses first).
+
 - **Past (#247):** Section mix strip shows **integer percentages** in each segment; the legend keeps **mention counts** with **meta** labels and per-section **count capsules** aligned with other insight cards.
 
 ## [0.5.0]

--- a/GraceNotes/GraceNotes/Features/Journal/PastSearchDayCaption.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/PastSearchDayCaption.swift
@@ -42,4 +42,15 @@ enum PastSearchDayCaption {
                 .locale(dateFormattingLocale)
         )
     }
+
+    /// Navigation bar title for a journal opened for a specific day from Past; matches search/list day captions.
+    static func journalNavigationTitle(
+        forEntryDate day: Date,
+        now: Date = Date(),
+        weekBoundaryRawValue: String,
+        dateFormattingLocale: Locale = .current
+    ) -> String {
+        let calendar = ReviewWeekBoundaryPreference.resolve(from: weekBoundaryRawValue).configuredCalendar()
+        return string(day: day, now: now, calendar: calendar, dateFormattingLocale: dateFormattingLocale)
+    }
 }

--- a/GraceNotes/GraceNotes/Features/Journal/Views/JournalCompletionBarChip.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/JournalCompletionBarChip.swift
@@ -25,14 +25,16 @@ struct JournalCompletionBarChip: View {
     let peopleCount: Int
     /// When `false`, show only the tier symbol (toolbar stays compact).
     let showsCompletionTitle: Bool
-    let onCollapseExpandTap: () -> Void
-    let onShowCompletionInfo: () -> Void
+    /// Matches inline completion: show or toggle the info card and scroll the header into view.
+    let onPrimaryTap: () -> Void
+    /// Touch-and-hold: expand or collapse the status label in the toolbar chip.
+    let onLongPressToggleLabelExpansion: () -> Void
 
     /// Matches the trailing share symbol row (Outfit 17pt headline scale).
     @ScaledMetric(relativeTo: .headline) private var tierIconLength: CGFloat = 24
 
     /// After a long-press succeeds, UIKit may still deliver the `Button` action on finger-up; skip one cycle.
-    @State private var suppressNextCollapseExpandTap = false
+    @State private var suppressNextPrimaryTapAfterLongPress = false
 
     /// Icon-only size tracks ``toolbarControlHeight``
     /// (``JournalScreen/journalToolbarControlHeight``), matching the trailing share symbol row.
@@ -66,11 +68,11 @@ struct JournalCompletionBarChip: View {
 
     var body: some View {
         Button {
-            if suppressNextCollapseExpandTap {
-                suppressNextCollapseExpandTap = false
+            if suppressNextPrimaryTapAfterLongPress {
+                suppressNextPrimaryTapAfterLongPress = false
                 return
             }
-            onCollapseExpandTap()
+            onPrimaryTap()
         } label: {
             ZStack(alignment: .leading) {
                 collapsedChipLabel
@@ -89,14 +91,14 @@ struct JournalCompletionBarChip: View {
         .dynamicTypeSize(Self.toolbarChipDynamicTypeRange)
         .simultaneousGesture(
             LongPressGesture(minimumDuration: 0.45).onEnded { _ in
-                suppressNextCollapseExpandTap = true
-                onShowCompletionInfo()
+                suppressNextPrimaryTapAfterLongPress = true
+                onLongPressToggleLabelExpansion()
             }
         )
         .accessibilityLabel(accessibilityLabelText)
         .accessibilityHint(String(localized: "accessibility.stickyCompletionChipHint"))
-        .accessibilityAction(named: String(localized: "accessibility.stickyCompletionChipShowDetailsAction")) {
-            onShowCompletionInfo()
+        .accessibilityAction(named: String(localized: "accessibility.stickyCompletionChipToggleLabelAction")) {
+            onLongPressToggleLabelExpansion()
         }
     }
 

--- a/GraceNotes/GraceNotes/Features/Journal/Views/JournalScreen.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/JournalScreen.swift
@@ -240,6 +240,8 @@ struct JournalScreen: View {
     @AppStorage(PersistenceController.iCloudSyncEnabledKey) private var isICloudSyncEnabled = false
     @AppStorage(JournalAppearanceStorageKeys.todayMode)
     private var journalTodayAppearanceRaw = JournalAppearanceMode.standard.rawValue
+    @AppStorage(ReviewWeekBoundaryPreference.userDefaultsKey)
+    private var reviewWeekBoundaryRawValue = ReviewWeekBoundaryPreference.defaultValue.rawValue
 
     @State private var gratitudeInput = ""
     @State private var needInput = ""
@@ -280,18 +282,18 @@ struct JournalScreen: View {
             needsCount: viewModel.needs.count,
             peopleCount: viewModel.people.count,
             showsCompletionTitle: stickyCompletionChipLabelExpanded,
-            onCollapseExpandTap: {
-                if stickyCompletionChipLabelExpanded {
-                    collapseStickyCompletionChipLabel()
-                } else {
-                    expandStickyCompletionChipLabel()
-                }
-            },
-            onShowCompletionInfo: {
+            onPrimaryTap: {
                 let badge = CompletionBadgeInfo.matching(viewModel.completionLevel)
                 completionInfoPresentation.completionBadgeTapped(badge, reduceMotion: reduceMotion)
                 if completionInfoPresentation.isInfoCardPresented {
                     completionHeaderScrollPulse &+= 1
+                }
+            },
+            onLongPressToggleLabelExpansion: {
+                if stickyCompletionChipLabelExpanded {
+                    collapseStickyCompletionChipLabel()
+                } else {
+                    expandStickyCompletionChipLabel()
                 }
             }
         )
@@ -2000,7 +2002,11 @@ private extension JournalScreen {
 
     fileprivate var navigationTitle: String {
         if let date = entryDate {
-            return date.formatted(date: .abbreviated, time: .omitted)
+            return PastSearchDayCaption.journalNavigationTitle(
+                forEntryDate: date,
+                now: Date(),
+                weekBoundaryRawValue: reviewWeekBoundaryRawValue
+            )
         }
         return String(localized: "shell.tab.today")
     }

--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewHistoryDrilldownCalendar.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewHistoryDrilldownCalendar.swift
@@ -1,23 +1,6 @@
 import SwiftUI
 import SwiftData
 
-// Opens ``JournalScreen`` from Past history drill-down calendars (``navigationDestination`` item).
-// swiftlint:disable:next type_name
-struct ReviewHistoryDrilldownJournalNavigationDay: Identifiable, Hashable {
-    let id: String
-    let date: Date
-
-    init(dayStart: Date, calendar: Calendar) {
-        let normalized = calendar.startOfDay(for: dayStart)
-        date = normalized
-        let components = calendar.dateComponents([.year, .month, .day], from: normalized)
-        let year = components.year ?? 0
-        let month = components.month ?? 0
-        let day = components.day ?? 0
-        id = "\(year)-\(month)-\(day)"
-    }
-}
-
 /// One structural row in the continuous drill-down calendar (week rows + month banners).
 enum ReviewHistoryDrilldownCalendarRow: Identifiable, Equatable {
     case monthBanner(id: String, title: String)

--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewHistoryDrilldownSheets.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewHistoryDrilldownSheets.swift
@@ -101,6 +101,7 @@ struct ReviewHistoryDrilldownSheetContainer: View {
     let calendar: Calendar
     let referenceDate: Date
     let pastStatisticsInterval: PastStatisticsIntervalSelection
+    let onOpenJournalDay: (Date) -> Void
 
     var body: some View {
         switch payload {
@@ -110,7 +111,8 @@ struct ReviewHistoryDrilldownSheetContainer: View {
                 entries: entries,
                 calendar: calendar,
                 referenceDate: referenceDate,
-                pastStatisticsInterval: pastStatisticsInterval
+                pastStatisticsInterval: pastStatisticsInterval,
+                onOpenJournalDay: onOpenJournalDay
             )
         case .section(let kind):
             SectionEntriesDrilldownSheet(
@@ -118,14 +120,16 @@ struct ReviewHistoryDrilldownSheetContainer: View {
                 entries: entries,
                 calendar: calendar,
                 referenceDate: referenceDate,
-                pastStatisticsInterval: pastStatisticsInterval
+                pastStatisticsInterval: pastStatisticsInterval,
+                onOpenJournalDay: onOpenJournalDay
             )
         case .journalingDays:
             JournalingDaysDrilldownSheet(
                 entries: entries,
                 calendar: calendar,
                 referenceDate: referenceDate,
-                pastStatisticsInterval: pastStatisticsInterval
+                pastStatisticsInterval: pastStatisticsInterval,
+                onOpenJournalDay: onOpenJournalDay
             )
         }
     }
@@ -135,9 +139,9 @@ struct ReviewHistoryDrilldownSheetContainer: View {
 
 private struct JournalingDaysDrilldownSheet: View {
     @Environment(\.dismiss) private var dismiss
-    @State private var journalNavigationDay: ReviewHistoryDrilldownJournalNavigationDay?
     @State private var abovePeekHeight: CGFloat = 0
 
+    private let onOpenJournalDay: (Date) -> Void
     private let historyJournalDays: Set<Date>
     private let historyDayRange: Range<Date>
     private let displayRange: Range<Date>
@@ -147,8 +151,10 @@ private struct JournalingDaysDrilldownSheet: View {
         entries: [Journal],
         calendar: Calendar,
         referenceDate: Date,
-        pastStatisticsInterval: PastStatisticsIntervalSelection
+        pastStatisticsInterval: PastStatisticsIntervalSelection,
+        onOpenJournalDay: @escaping (Date) -> Void
     ) {
+        self.onOpenJournalDay = onOpenJournalDay
         drilldownCalendar = calendar
         historyDayRange = pastStatisticsInterval.validated.resolvedHistoryRange(
             referenceDate: referenceDate,
@@ -210,10 +216,7 @@ private struct JournalingDaysDrilldownSheet: View {
                                 sectionStripChipCountsByDay: nil,
                                 scrollViewportHeight: peek,
                                 onMatchingDaySelected: { day in
-                                    journalNavigationDay = ReviewHistoryDrilldownJournalNavigationDay(
-                                        dayStart: day,
-                                        calendar: drilldownCalendar
-                                    )
+                                    onOpenJournalDay(drilldownCalendar.startOfDay(for: day))
                                 }
                             )
                             .padding(.vertical, 4)
@@ -238,9 +241,6 @@ private struct JournalingDaysDrilldownSheet: View {
                     )
                 }
             }
-            .navigationDestination(item: $journalNavigationDay) { item in
-                JournalScreen(entryDate: item.date)
-            }
         }
     }
 
@@ -262,9 +262,9 @@ private struct JournalingDaysDrilldownSheet: View {
 private struct GrowthStageDrilldownSheet: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
-    @State private var journalNavigationDay: ReviewHistoryDrilldownJournalNavigationDay?
     @State private var abovePeekHeight: CGFloat = 0
 
+    private let onOpenJournalDay: (Date) -> Void
     let level: JournalCompletionLevel
     private let matchingDayStarts: Set<Date>
     private let historyJournalDays: Set<Date>
@@ -277,8 +277,10 @@ private struct GrowthStageDrilldownSheet: View {
         entries: [Journal],
         calendar: Calendar,
         referenceDate: Date,
-        pastStatisticsInterval: PastStatisticsIntervalSelection
+        pastStatisticsInterval: PastStatisticsIntervalSelection,
+        onOpenJournalDay: @escaping (Date) -> Void
     ) {
+        self.onOpenJournalDay = onOpenJournalDay
         self.level = level
         drilldownCalendar = calendar
         historyDayRange = pastStatisticsInterval.validated.resolvedHistoryRange(
@@ -351,10 +353,7 @@ private struct GrowthStageDrilldownSheet: View {
                                 sectionStripChipCountsByDay: nil,
                                 scrollViewportHeight: peek,
                                 onMatchingDaySelected: { day in
-                                    journalNavigationDay = ReviewHistoryDrilldownJournalNavigationDay(
-                                        dayStart: day,
-                                        calendar: drilldownCalendar
-                                    )
+                                    onOpenJournalDay(drilldownCalendar.startOfDay(for: day))
                                 }
                             )
                             .padding(.vertical, 4)
@@ -381,9 +380,6 @@ private struct GrowthStageDrilldownSheet: View {
                 ToolbarItem(placement: .topBarTrailing) {
                     PastToolbarDoneButton(action: { dismiss() })
                 }
-            }
-            .navigationDestination(item: $journalNavigationDay) { item in
-                JournalScreen(entryDate: item.date)
             }
         }
     }
@@ -436,8 +432,8 @@ private struct GrowthStageDrilldownSheet: View {
 
 private struct SectionEntriesDrilldownSheet: View {
     @Environment(\.dismiss) private var dismiss
-    @State private var journalNavigationDay: ReviewHistoryDrilldownJournalNavigationDay?
 
+    private let onOpenJournalDay: (Date) -> Void
     let section: ReviewStatsSectionKind
     private let contributingEntries: [Journal]
     private let sectionMatchingDayStarts: Set<Date>
@@ -452,8 +448,10 @@ private struct SectionEntriesDrilldownSheet: View {
         entries: [Journal],
         calendar: Calendar,
         referenceDate: Date,
-        pastStatisticsInterval: PastStatisticsIntervalSelection
+        pastStatisticsInterval: PastStatisticsIntervalSelection,
+        onOpenJournalDay: @escaping (Date) -> Void
     ) {
+        self.onOpenJournalDay = onOpenJournalDay
         self.section = section
         drilldownCalendar = calendar
         historyDayRange = pastStatisticsInterval.validated.resolvedHistoryRange(
@@ -527,10 +525,7 @@ private struct SectionEntriesDrilldownSheet: View {
                                 sectionStripChipCountsByDay: sectionStripChipCountsByDay,
                                 scrollViewportHeight: peek,
                                 onMatchingDaySelected: { day in
-                                    journalNavigationDay = ReviewHistoryDrilldownJournalNavigationDay(
-                                        dayStart: day,
-                                        calendar: drilldownCalendar
-                                    )
+                                    onOpenJournalDay(drilldownCalendar.startOfDay(for: day))
                                 }
                             )
                             .padding(.vertical, 4)
@@ -550,9 +545,6 @@ private struct SectionEntriesDrilldownSheet: View {
                 ToolbarItem(placement: .topBarTrailing) {
                     PastToolbarDoneButton(action: { dismiss() })
                 }
-            }
-            .navigationDestination(item: $journalNavigationDay) { item in
-                JournalScreen(entryDate: item.date)
             }
         }
     }

--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewInsightThemeCardSupport.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewInsightThemeCardSupport.swift
@@ -186,11 +186,17 @@ struct MostRecurringBrowseSheetContainer: View {
     let themes: [ReviewMostRecurringTheme]
     let referenceDate: Date
     let calendar: Calendar
+    let onOpenJournalDay: (Date) -> Void
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
         NavigationStack {
-            MostRecurringThemesBrowseView(themes: themes, referenceDate: referenceDate, calendar: calendar)
+            MostRecurringThemesBrowseView(
+                themes: themes,
+                referenceDate: referenceDate,
+                calendar: calendar,
+                onOpenJournalDay: onOpenJournalDay
+            )
                 .toolbar {
                     ToolbarItem(placement: .topBarTrailing) {
                         PastToolbarDoneButton(
@@ -205,10 +211,11 @@ struct MostRecurringBrowseSheetContainer: View {
 
 struct TrendingBrowseSheetContainer: View {
     let buckets: ReviewTrendingBuckets
+    let onOpenJournalDay: (Date) -> Void
 
     var body: some View {
         NavigationStack {
-            TrendingThemesBrowseView(buckets: buckets)
+            TrendingThemesBrowseView(buckets: buckets, onOpenJournalDay: onOpenJournalDay)
         }
     }
 }
@@ -217,6 +224,7 @@ struct MostRecurringThemesBrowseView: View {
     let themes: [ReviewMostRecurringTheme]
     let referenceDate: Date
     let calendar: Calendar
+    let onOpenJournalDay: (Date) -> Void
     @AppStorage(PastStatisticsIntervalPreference.appStorageKey)
     private var pastStatisticsIntervalEncoded = ""
 
@@ -259,7 +267,8 @@ struct MostRecurringThemesBrowseView: View {
                 NavigationLink {
                     ThemeDrilldownView(
                         payload: drilldownPayload(for: row),
-                        includeDoneButton: false
+                        includeDoneButton: false,
+                        onOpenJournalDay: onOpenJournalDay
                     )
                 } label: {
                     HStack(alignment: .center, spacing: 10) {
@@ -374,6 +383,7 @@ struct MostRecurringBrowseRowModel: Identifiable {
 
 struct TrendingThemesBrowseView: View {
     let buckets: ReviewTrendingBuckets
+    let onOpenJournalDay: (Date) -> Void
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
@@ -406,7 +416,11 @@ struct TrendingThemesBrowseView: View {
         Section {
             ForEach(themes) { theme in
                 NavigationLink {
-                    ThemeDrilldownView(payload: drilldownPayload(for: theme), includeDoneButton: false)
+                    ThemeDrilldownView(
+                        payload: drilldownPayload(for: theme),
+                        includeDoneButton: false,
+                        onOpenJournalDay: onOpenJournalDay
+                    )
                 } label: {
                     HStack(alignment: .center, spacing: 10) {
                         Text(theme.label)
@@ -470,15 +484,21 @@ struct TrendingThemesBrowseView: View {
 
 struct ThemeDrilldownSheet: View {
     let payload: ReviewThemeDrilldownPayload
+    let onOpenJournalDay: (Date) -> Void
 
     var body: some View {
-        ThemeDrilldownView(payload: payload, includeDoneButton: true)
+        ThemeDrilldownView(
+            payload: payload,
+            includeDoneButton: true,
+            onOpenJournalDay: onOpenJournalDay
+        )
     }
 }
 
 struct ThemeDrilldownView: View {
     let payload: ReviewThemeDrilldownPayload
     let includeDoneButton: Bool
+    let onOpenJournalDay: (Date) -> Void
     @Environment(\.dismiss) private var dismiss
     @AppStorage(ReviewWeekBoundaryPreference.userDefaultsKey)
     private var reviewWeekBoundaryRawValue = ReviewWeekBoundaryPreference.defaultValue.rawValue
@@ -530,8 +550,8 @@ struct ThemeDrilldownView: View {
                         ForEach(evidenceGroupedByDay, id: \.day) { group in
                             Section {
                                 ForEach(group.rows) { evidence in
-                                    NavigationLink {
-                                        JournalScreen(entryDate: evidence.entryDate)
+                                    Button {
+                                        onOpenJournalDay(groupingCalendar.startOfDay(for: evidence.entryDate))
                                     } label: {
                                         VStack(alignment: .leading, spacing: 8) {
                                             Text(evidence.source.localizedJournalSurfaceTitle)

--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewScreen.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewScreen.swift
@@ -181,10 +181,10 @@ extension ReviewScreen {
             )
         }
         .sheet(item: $mostRecurringThemeDrilldown) { payload in
-            ThemeDrilldownSheet(payload: payload)
+            ThemeDrilldownSheet(payload: payload, onOpenJournalDay: presentJournalDismissingThemeDrilldownSheets)
         }
         .sheet(item: $trendingThemeDrilldown) { payload in
-            ThemeDrilldownSheet(payload: payload)
+            ThemeDrilldownSheet(payload: payload, onOpenJournalDay: presentJournalDismissingThemeDrilldownSheets)
         }
         .sheet(item: $browseSheet, onDismiss: {
             browseSheet = nil
@@ -195,10 +195,14 @@ extension ReviewScreen {
                     MostRecurringBrowseSheetContainer(
                         themes: payload.themes,
                         referenceDate: payload.referenceDate,
-                        calendar: payload.calendar
+                        calendar: payload.calendar,
+                        onOpenJournalDay: presentJournalDismissingBrowseSheet
                     )
                 case .trending(let payload):
-                    TrendingBrowseSheetContainer(buckets: payload.buckets)
+                    TrendingBrowseSheetContainer(
+                        buckets: payload.buckets,
+                        onOpenJournalDay: presentJournalDismissingBrowseSheet
+                    )
                 }
             }
             .id(sheet.id)
@@ -209,7 +213,8 @@ extension ReviewScreen {
                 entries: entries,
                 calendar: calendar,
                 referenceDate: insightsReferenceDate,
-                pastStatisticsInterval: pastStatisticsInterval
+                pastStatisticsInterval: pastStatisticsInterval,
+                onOpenJournalDay: presentJournalDismissingHistoryDrilldown
             )
         }
         .sheet(item: $journalDaySheetItem) { item in
@@ -219,6 +224,31 @@ extension ReviewScreen {
 
     private func presentJournalDaySheet(for day: Date) {
         journalDaySheetItem = ReviewJournalDaySheetItem(dayStart: day, calendar: calendar)
+    }
+
+    private func presentJournalDismissingHistoryDrilldown(for day: Date) {
+        historyDrilldown = nil
+        Task { @MainActor in
+            await Task.yield()
+            presentJournalDaySheet(for: day)
+        }
+    }
+
+    private func presentJournalDismissingThemeDrilldownSheets(for day: Date) {
+        mostRecurringThemeDrilldown = nil
+        trendingThemeDrilldown = nil
+        Task { @MainActor in
+            await Task.yield()
+            presentJournalDaySheet(for: day)
+        }
+    }
+
+    private func presentJournalDismissingBrowseSheet(for day: Date) {
+        browseSheet = nil
+        Task { @MainActor in
+            await Task.yield()
+            presentJournalDaySheet(for: day)
+        }
     }
 
     private var emptyStateWithSearch: some View {

--- a/GraceNotes/GraceNotes/Localizable.xcstrings
+++ b/GraceNotes/GraceNotes/Localizable.xcstrings
@@ -3864,29 +3864,29 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tap to show or hide the status label. Touch and hold for what this status means."
+            "value": "Tap to show what this status means and scroll to the journal header. Touch and hold to show or hide the status label."
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "轻点可显示或隐藏状态标签。按住可了解此状态的含义。"
+            "value": "轻点可了解此状态含义并滚动到日记顶部。按住可显示或隐藏状态标签。"
           }
         }
       }
     },
-    "accessibility.stickyCompletionChipShowDetailsAction": {
+    "accessibility.stickyCompletionChipToggleLabelAction": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Explain status"
+            "value": "Show or hide status label"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "说明状态"
+            "value": "显示或隐藏状态标签"
           }
         }
       }

--- a/GraceNotesTests/Features/Journal/PastSearchDayCaptionTests.swift
+++ b/GraceNotesTests/Features/Journal/PastSearchDayCaptionTests.swift
@@ -59,6 +59,26 @@ final class PastSearchDayCaptionTests: XCTestCase {
         XCTAssertTrue(caption.contains("2024"), "Expected year in caption, got: \(caption)")
     }
 
+    func test_journalNavigationTitle_matchesPastSearchCaption_forSundayStartPreference() {
+        let now = date(year: 2026, month: 7, day: 15, hour: 12)
+        let day = date(year: 2026, month: 3, day: 8, hour: 12)
+        let locale = Locale(identifier: "en_US_POSIX")
+        let preferenceCalendar = ReviewWeekBoundaryPreference.sundayStart.configuredCalendar(base: calendar)
+        let expected = PastSearchDayCaption.string(
+            day: day,
+            now: now,
+            calendar: preferenceCalendar,
+            dateFormattingLocale: locale
+        )
+        let title = PastSearchDayCaption.journalNavigationTitle(
+            forEntryDate: day,
+            now: now,
+            weekBoundaryRawValue: ReviewWeekBoundaryPreference.sundayStart.rawValue,
+            dateFormattingLocale: locale
+        )
+        XCTAssertEqual(title, expected)
+    }
+
     private func date(year: Int, month: Int, day: Int, hour: Int = 12) -> Date {
         var components = DateComponents()
         components.year = year


### PR DESCRIPTION
## Summary

Implements GitHub #257: consistent Past/journal behavior for completion affordances, navigation titles, and opening a day’s journal from insights drill-downs.

## User impact

- **Sticky completion chip** behaves like the inline completion pill: a normal tap shows or toggles the status explanation and scrolls to the completion header; touch-and-hold expands or collapses the label in the toolbar. Accessibility hint and custom action updated.
- **Past journal** navigation titles match **Past** search/list day lines (same calendar year without a redundant year; **Today** / **Yesterday** where applicable), using the same week-boundary calendar as the Past tab.
- **Insights drill-downs** (growth, section mix, reflection rhythm calendar, theme sheets, browse sheets) open the day journal in the same **Done** sheet used from search and the rhythm strip. The drill-down sheet is dismissed first so only one sheet is active at a time.

## Verification

- `swiftlint lint`
- `grace l10n audit`
- `xcodebuild` — `GraceNotesTests` on iOS Simulator

Closes #257