### PR TITLE
feat(past): Next step only with refiner (#255)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- **Past (#255):** The narrative row below recurring/trending is **Next step** only (no separate Observation panel). A refiner **hides the whole row** when the line would be empty, match the generic glad-happened filler, or echo a **short** recurring-theme action already prominent in stats; longer actions still show. **zh-Hans** tightened for the next-step title and weekly insight action strings (`Localizable.xcstrings`).
 - **Past (#247):** Section mix strip shows **integer percentages** in each segment; the legend keeps **mention counts** with **meta** labels and per-section **count capsules** aligned with other insight cards.
 
 ## [0.5.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Changed
 
 - **Past (#257):** Sticky completion toolbar chip matches inline completion (tap shows status info and scrolls to header; touch-and-hold toggles the expanded label). Past journal navigation titles align with search/list day captions (same calendar year omits year; **Today** / **Yesterday** unchanged). Opening a day from **Growth**, **Section mix**, **Reflection rhythm** drill-down, **theme** drill-downs, or **browse** sheets presents **Journal** in the top-level day sheet (drill-down sheet dismisses first).
-- **Past (#255):** The narrative row below recurring/trending is **Next step** only (no separate Observation panel). A refiner **hides the whole row** when the line would be empty, match the generic glad-happened filler, or echo a **short** recurring-theme action already prominent in stats; longer actions still show. **zh-Hans** tightened for the next-step title and weekly insight action strings (`Localizable.xcstrings`).
+- **Past (#255):** The narrative row below recurring/trending is **Next step** only (no separate Observation panel). Weeks in **stats-first** presentation still omit that row (rhythm-led). Otherwise a refiner **hides the whole row** when the line would be empty, duplicate the generic glad-happened filler, or echo a **short** recurring-theme action already shown in the most-recurring stats; longer actions still show. **zh-Hans** tightened for the next-step title and weekly insight action strings (`Localizable.xcstrings`).
 - **Past (#247):** Section mix strip shows **integer percentages** in each segment; the legend keeps **mention counts** with **meta** labels and per-section **count capsules** aligned with other insight cards.
 
 ## [0.5.0]

--- a/GraceNotes/GraceNotes/Features/Journal/Services/ReviewNextStepRowRefiner.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ReviewNextStepRowRefiner.swift
@@ -14,7 +14,12 @@ struct ReviewNextStepRowRefiner {
     }
 
     /// Returns `nil` when the row should not appear (no redundant or generic filler).
+    /// Aligns with ``ReviewPresentationMode``: `.statsFirst` weeks stay rhythm-led and omit this narrative row.
     func nextStepText(for insights: ReviewInsights) -> String? {
+        if insights.presentationMode == .statsFirst {
+            return nil
+        }
+
         let action = actionBodyCandidate(for: insights)
         let trimmed = action.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else {
@@ -45,8 +50,9 @@ struct ReviewNextStepRowRefiner {
             .first { !$0.isEmpty } ?? ""
     }
 
-    /// When the insight is recurring-theme/people and the same label is already in the top recurring stats,
-    /// short template actions add little beyond the cards above; longer behavioral lines are kept.
+    /// When the insight is recurring-theme/people and the same label is already in the top
+    /// ``ReviewWeekStats/mostRecurringThemes`` rows (what the Past cards above show), short template
+    /// actions add little beyond those cards; longer behavioral lines are kept.
     private func shouldHideThinRecurringEcho(_ insights: ReviewInsights, actionLine: String) -> Bool {
         guard let first = insights.weeklyInsights.first,
               let primary = first.primaryTheme,
@@ -80,12 +86,6 @@ struct ReviewNextStepRowRefiner {
         for row in insights.weekStats.mostRecurringThemes.prefix(3)
             where textNormalizer.normalizeThemeLabel(row.label) == normalizedPrimary {
             return true
-        }
-        if insights.weeklyInsights.first?.pattern == .recurringPeople {
-            for person in insights.recurringPeople.prefix(3)
-                where textNormalizer.normalizeThemeLabel(person.label) == normalizedPrimary {
-                return true
-            }
         }
         return false
     }

--- a/GraceNotes/GraceNotes/Features/Journal/Services/ReviewNextStepRowRefiner.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ReviewNextStepRowRefiner.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+/// Decides whether the Past tab narrative row should show a Next step line, and which text to use.
+/// Hides generic duplicate lines (e.g. glad-happened substitution) and **short** recurring-theme echoes
+/// when the same theme/person is already prominent in the stats blocks above.
+struct ReviewNextStepRowRefiner {
+    private let textNormalizer: WeeklyInsightTextNormalizer
+
+    /// When the theme matches a top recurring row, actions shorter than this are treated as redundant.
+    private let maxThinActionChars = 110
+
+    init(textNormalizer: WeeklyInsightTextNormalizer = WeeklyInsightTextNormalizer()) {
+        self.textNormalizer = textNormalizer
+    }
+
+    /// Returns `nil` when the row should not appear (no redundant or generic filler).
+    func nextStepText(for insights: ReviewInsights) -> String? {
+        let action = actionBodyCandidate(for: insights)
+        let trimmed = action.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return nil
+        }
+
+        let gladHappened = String(localized: "review.prompts.gladHappened")
+        if normalizedInsightText(trimmed) == normalizedInsightText(gladHappened) {
+            return nil
+        }
+
+        if shouldHideThinRecurringEcho(insights, actionLine: trimmed) {
+            return nil
+        }
+
+        return trimmed
+    }
+
+    private func actionBodyCandidate(for insights: ReviewInsights) -> String {
+        let continuity = insights.continuityPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !continuity.isEmpty {
+            return continuity
+        }
+        return insights.weeklyInsights
+            .lazy
+            .compactMap(\.action)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .first { !$0.isEmpty } ?? ""
+    }
+
+    /// When the insight is recurring-theme/people and the same label is already in the top recurring stats,
+    /// short template actions add little beyond the cards above; longer behavioral lines are kept.
+    private func shouldHideThinRecurringEcho(_ insights: ReviewInsights, actionLine: String) -> Bool {
+        guard let first = insights.weeklyInsights.first,
+              let primary = first.primaryTheme,
+              !primary.isEmpty
+        else {
+            return false
+        }
+
+        switch first.pattern {
+        case .recurringTheme, .recurringPeople:
+            break
+        case .needsGratitudeGap, .continuityShift, .fullCompletion, .sparseFallback:
+            return false
+        }
+
+        let normalizedPrimary = textNormalizer.normalizeThemeLabel(primary)
+        guard !normalizedPrimary.isEmpty else { return false }
+
+        guard matchesTopRecurringLabels(normalizedPrimary, insights: insights) else {
+            return false
+        }
+
+        guard actionLine.count < maxThinActionChars else {
+            return false
+        }
+
+        return true
+    }
+
+    private func matchesTopRecurringLabels(_ normalizedPrimary: String, insights: ReviewInsights) -> Bool {
+        for row in insights.weekStats.mostRecurringThemes.prefix(3)
+            where textNormalizer.normalizeThemeLabel(row.label) == normalizedPrimary {
+            return true
+        }
+        if insights.weeklyInsights.first?.pattern == .recurringPeople {
+            for person in insights.recurringPeople.prefix(3)
+                where textNormalizer.normalizeThemeLabel(person.label) == normalizedPrimary {
+                return true
+            }
+        }
+        return false
+    }
+
+    private func normalizedInsightText(_ value: String) -> String {
+        value
+            .folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current)
+            .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewScreen.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewScreen.swift
@@ -359,13 +359,18 @@ extension ReviewScreen {
             .listRowBackground(AppTheme.reviewBackground)
             .listRowSeparator(.hidden)
 
-            ReviewNarrativeSummaryCard(
+            if ReviewNextStepRowRefiner.shouldShowNarrativeRow(
                 insights: reviewInsights,
                 isLoading: isLoadingInsights
-            )
-            .listRowInsets(PastTabListLayout.cardRowInsets)
-            .listRowBackground(AppTheme.reviewBackground)
-            .listRowSeparator(.hidden)
+            ) {
+                ReviewNarrativeSummaryCard(
+                    insights: reviewInsights,
+                    isLoading: isLoadingInsights
+                )
+                .listRowInsets(PastTabListLayout.cardRowInsets)
+                .listRowBackground(AppTheme.reviewBackground)
+                .listRowSeparator(.hidden)
+            }
         }
     }
 

--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewSummaryCard.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewSummaryCard.swift
@@ -1,11 +1,5 @@
 import SwiftUI
 
-private struct ReviewInsightPanelBodies {
-    let observation: String
-    let thread: String
-    let action: String
-}
-
 // swiftlint:disable type_body_length file_length
 /// “Days you wrote” rhythm strip for the Past tab, as its own list row.
 struct ReviewDaysYouWrotePanel: View {
@@ -642,11 +636,13 @@ struct ReviewDaysYouWrotePanel: View {
     }
 }
 
-/// Observation, next step, and primary CTA for the Past tab as its own list row (after recurring and trending).
+/// Next step only for the Past tab as its own list row (after recurring and trending).
 struct ReviewNarrativeSummaryCard: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let insights: ReviewInsights?
     let isLoading: Bool
+
+    private let nextStepRefiner = ReviewNextStepRowRefiner()
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -678,26 +674,12 @@ struct ReviewNarrativeSummaryCard: View {
         }
     }
 
+    @ViewBuilder
     private func narrativeContent(for insights: ReviewInsights) -> some View {
-        let bodies = dedupedPanelBodies(for: insights)
-        return VStack(alignment: .leading, spacing: 0) {
-            VStack(alignment: .leading, spacing: 10) {
-                observationPanel(body: bodies.observation)
-                // Intentional product choice: keep the middle "Thinking"/narrative layer hidden for now.
-                if insights.presentationMode == .insight {
-                    // `.statsFirst` stays rhythm-led by design, so we omit the next-step panel in that mode.
-                    actionPanel(body: bodies.action)
-                }
-            }
-        }
-    }
-
-    private func observationPanel(body: String) -> some View {
-        ReviewInsightInsetPanel(
-            title: String(localized: "review.labels.observation"),
-            panelChrome: .lead
-        ) {
-            panelParagraph(body, lineSpacing: 4)
+        if isLoading {
+            NarrativeInsightsLoadingSkeleton(reduceMotion: reduceMotion)
+        } else if let text = nextStepRefiner.nextStepText(for: insights) {
+            actionPanel(body: text)
         }
     }
 
@@ -708,114 +690,24 @@ struct ReviewNarrativeSummaryCard: View {
     }
 
     private func panelParagraph(_ text: String, lineSpacing: CGFloat) -> some View {
-        Text(trimmed(text))
+        Text(text.trimmingCharacters(in: .whitespacesAndNewlines))
             .font(AppTheme.warmPaperBody)
             .foregroundStyle(AppTheme.reviewTextPrimary)
             .lineSpacing(lineSpacing)
             .fixedSize(horizontal: false, vertical: true)
     }
+}
 
-    private func shouldShowNarrativeSummary(for insights: ReviewInsights) -> Bool {
-        guard let narrativeSummary = insights.narrativeSummary?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !narrativeSummary.isEmpty
-        else {
-            return false
-        }
-        guard let firstInsightObservation = insights.weeklyInsights.first?.observation else {
+extension ReviewNextStepRowRefiner {
+    /// Whether the Past tab should show the narrative list row (unlock, loading, or non-empty next step).
+    static func shouldShowNarrativeRow(insights: ReviewInsights?, isLoading: Bool) -> Bool {
+        if isLoading {
             return true
         }
-        return normalizedInsightText(narrativeSummary) != normalizedInsightText(firstInsightObservation)
-    }
-
-    private func observationText(for insights: ReviewInsights) -> String {
-        let resurfacing = trimmed(insights.resurfacingMessage)
-        if !resurfacing.isEmpty {
-            return resurfacing
+        guard let insights else {
+            return true
         }
-        if let fallbackObservation = firstNonEmptyWeeklyObservation(for: insights) {
-            return fallbackObservation
-        }
-        let fallbackNarrative = trimmed(insights.narrativeSummary)
-        if !fallbackNarrative.isEmpty {
-            return fallbackNarrative
-        }
-        return trimmed(insights.continuityPrompt)
-    }
-
-    private func thinkingText(for insights: ReviewInsights) -> String {
-        let narrativeSummary = trimmed(insights.narrativeSummary)
-        if shouldShowNarrativeSummary(for: insights), !narrativeSummary.isEmpty {
-            return narrativeSummary
-        }
-        if let fallbackObservation = firstNonEmptyWeeklyObservation(for: insights) {
-            return fallbackObservation
-        }
-        let resurfacing = trimmed(insights.resurfacingMessage)
-        if !resurfacing.isEmpty {
-            return resurfacing
-        }
-        return trimmed(insights.continuityPrompt)
-    }
-
-    /// Action line from payload only (no Thinking fallback) so the card can substitute a distinct thin-week string.
-    private func actionBodyCandidate(for insights: ReviewInsights) -> String {
-        let continuityPrompt = trimmed(insights.continuityPrompt)
-        if !continuityPrompt.isEmpty {
-            return continuityPrompt
-        }
-        if let fallbackAction = firstNonEmptyWeeklyAction(for: insights) {
-            return fallbackAction
-        }
-        return ""
-    }
-
-    private func dedupedPanelBodies(for insights: ReviewInsights) -> ReviewInsightPanelBodies {
-        let observation = observationText(for: insights)
-        var thread = thinkingText(for: insights)
-        if normalizedInsightText(thread) == normalizedInsightText(observation) {
-            thread = String(localized: "journal.guidance.fewLinesHoldALot")
-        }
-
-        var action = actionBodyCandidate(for: insights)
-        let observationKey = normalizedInsightText(observation)
-        let actionKey = normalizedInsightText(action)
-        // Action dedupes against visible panels only; Thinking is intentionally hidden in this layout.
-        let actionDuplicatesPanel = actionKey == observationKey
-        if action.isEmpty || actionDuplicatesPanel {
-            action = String(localized: "review.prompts.gladHappened")
-        }
-
-        return ReviewInsightPanelBodies(observation: observation, thread: thread, action: action)
-    }
-
-    private func firstNonEmptyWeeklyObservation(for insights: ReviewInsights) -> String? {
-        insights.weeklyInsights
-            .lazy
-            .map(\.observation)
-            .map { trimmed($0) }
-            .first { !$0.isEmpty }
-    }
-
-    private func firstNonEmptyWeeklyAction(for insights: ReviewInsights) -> String? {
-        insights.weeklyInsights
-            .lazy
-            .compactMap(\.action)
-            .map { trimmed($0) }
-            .first { !$0.isEmpty }
-    }
-
-    private func trimmed(_ value: String?) -> String {
-        guard let value else {
-            return ""
-        }
-        return value.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    private func normalizedInsightText(_ value: String) -> String {
-        value
-            .folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current)
-            .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
-            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return ReviewNextStepRowRefiner().nextStepText(for: insights) != nil
     }
 }
 // swiftlint:enable type_body_length
@@ -856,18 +748,11 @@ private struct NarrativeInsightsLoadingSkeleton: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            VStack(alignment: .leading, spacing: 10) {
-                skeletonInsetPanel(
-                    title: String(localized: "review.labels.observation"),
-                    panelChrome: .lead,
-                    lineSpecs: [(1.0, 12), (1.0, 12), (0.72, 12)]
-                )
-                skeletonInsetPanel(
-                    title: String(localized: "review.prompts.nextStep"),
-                    panelChrome: .standard,
-                    lineSpecs: [(1.0, 11), (0.78, 11)]
-                )
-            }
+            skeletonInsetPanel(
+                title: String(localized: "review.prompts.nextStep"),
+                panelChrome: .standard,
+                lineSpecs: [(1.0, 11), (0.78, 11)]
+            )
         }
         .modifier(InsightsCalmLoadingBreath(active: !reduceMotion))
         .accessibilityElement(children: .ignore)

--- a/GraceNotes/GraceNotes/Localizable.xcstrings
+++ b/GraceNotes/GraceNotes/Localizable.xcstrings
@@ -205,7 +205,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "下一步"
+            "value": "「接下来」"
           }
         }
       }
@@ -5390,7 +5390,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "你是怎么把这份稳定保持下来的？下周也许还能用得上。"
+            "value": "你是怎么保持这份稳定的？下周也许还能用上。"
           }
         }
       }
@@ -6163,7 +6163,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "下周你可以怎样再为 %@ 腾出一点空间？"
+            "value": "下周怎样能为 %@ 再腾出一点空间？"
           }
         }
       },
@@ -6197,7 +6197,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "这周有什么小方法，能让 %@ 变成一件值得感恩的事？"
+            "value": "这周可以怎样让 %@ 变成一件感恩的事？"
           }
         }
       },
@@ -6231,7 +6231,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "你想继续培养这个转向 %@ 的变化吗？"
+            "value": "你想继续顺着这个转向 %@ 的方向走吗？"
           }
         }
       },

--- a/GraceNotesTests/Features/Journal/ReviewNextStepRowRefinerTests.swift
+++ b/GraceNotesTests/Features/Journal/ReviewNextStepRowRefinerTests.swift
@@ -44,6 +44,31 @@ final class ReviewNextStepRowRefinerTests: XCTestCase {
         XCTAssertNil(refiner.nextStepText(for: insights))
     }
 
+    func test_nextStepText_statsFirst_returnsNil_evenWithContinuity() {
+        let weekStart = date(year: 2026, month: 4, day: 6)
+        let insights = makeInsights(
+            weekStart: weekStart,
+            continuityPrompt: "Any next step line.",
+            weeklyInsights: [],
+            mostRecurring: [],
+            presentationMode: .statsFirst
+        )
+        let refiner = ReviewNextStepRowRefiner()
+        XCTAssertNil(refiner.nextStepText(for: insights))
+    }
+
+    func test_shouldShowNarrativeRow_statsFirst_false() {
+        let weekStart = date(year: 2026, month: 4, day: 6)
+        let insights = makeInsights(
+            weekStart: weekStart,
+            continuityPrompt: "Carry something forward.",
+            weeklyInsights: [],
+            mostRecurring: [],
+            presentationMode: .statsFirst
+        )
+        XCTAssertFalse(ReviewNextStepRowRefiner.shouldShowNarrativeRow(insights: insights, isLoading: false))
+    }
+
     func test_nextStepText_thinRecurringEcho_whenThemeMatchesTopRecurring_returnsNil() {
         let weekStart = date(year: 2026, month: 4, day: 6)
         let insights = makeInsights(
@@ -140,7 +165,8 @@ final class ReviewNextStepRowRefinerTests: XCTestCase {
         weekStart: Date,
         continuityPrompt: String,
         weeklyInsights: [ReviewWeeklyInsight],
-        mostRecurring: [ReviewMostRecurringTheme]
+        mostRecurring: [ReviewMostRecurringTheme],
+        presentationMode: ReviewPresentationMode = .insight
     ) -> ReviewInsights {
         let weekEnd = calendar.date(byAdding: .day, value: 7, to: weekStart)!
         let weekStats = ReviewWeekStats(
@@ -170,7 +196,7 @@ final class ReviewNextStepRowRefinerTests: XCTestCase {
         )
         return ReviewInsights(
             source: .deterministic,
-            presentationMode: .insight,
+            presentationMode: presentationMode,
             generatedAt: weekStart,
             weekStart: weekStart,
             weekEnd: weekEnd,

--- a/GraceNotesTests/Features/Journal/ReviewNextStepRowRefinerTests.swift
+++ b/GraceNotesTests/Features/Journal/ReviewNextStepRowRefinerTests.swift
@@ -1,0 +1,187 @@
+import XCTest
+@testable import GraceNotes
+
+final class ReviewNextStepRowRefinerTests: XCTestCase {
+    private var calendar: Calendar!
+
+    override func setUp() {
+        super.setUp()
+        calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+    }
+
+    func test_nextStepText_emptyContinuityAndNoAction_returnsNil() {
+        let weekStart = date(year: 2026, month: 4, day: 6)
+        let insights = makeInsights(
+            weekStart: weekStart,
+            continuityPrompt: "",
+            weeklyInsights: [
+                ReviewWeeklyInsight(
+                    pattern: .sparseFallback,
+                    observation: "x",
+                    action: nil,
+                    primaryTheme: nil,
+                    mentionCount: nil,
+                    dayCount: 0
+                )
+            ],
+            mostRecurring: []
+        )
+        let refiner = ReviewNextStepRowRefiner()
+        XCTAssertNil(refiner.nextStepText(for: insights))
+    }
+
+    func test_nextStepText_gladHappened_returnsNil() {
+        let weekStart = date(year: 2026, month: 4, day: 6)
+        let glad = String(localized: "review.prompts.gladHappened")
+        let insights = makeInsights(
+            weekStart: weekStart,
+            continuityPrompt: glad,
+            weeklyInsights: [],
+            mostRecurring: []
+        )
+        let refiner = ReviewNextStepRowRefiner()
+        XCTAssertNil(refiner.nextStepText(for: insights))
+    }
+
+    func test_nextStepText_thinRecurringEcho_whenThemeMatchesTopRecurring_returnsNil() {
+        let weekStart = date(year: 2026, month: 4, day: 6)
+        let insights = makeInsights(
+            weekStart: weekStart,
+            continuityPrompt: "Short echo about Rest.",
+            weeklyInsights: [
+                ReviewWeeklyInsight(
+                    pattern: .recurringTheme,
+                    observation: "Rest showed up.",
+                    action: "Short echo about Rest.",
+                    primaryTheme: "Rest",
+                    mentionCount: 3,
+                    dayCount: 2
+                )
+            ],
+            mostRecurring: [
+                ReviewMostRecurringTheme(
+                    label: "Rest",
+                    totalCount: 4,
+                    dayCount: 3,
+                    currentWeekCount: 3,
+                    previousWeekCount: 1,
+                    evidence: []
+                )
+            ]
+        )
+        let refiner = ReviewNextStepRowRefiner()
+        XCTAssertNil(refiner.nextStepText(for: insights))
+    }
+
+    func test_nextStepText_longAction_whenThemeMatchesTopRecurring_returnsText() {
+        let weekStart = date(year: 2026, month: 4, day: 6)
+        let longAction = String(repeating: "Pick one small concrete step toward Rest this week. ", count: 5)
+        XCTAssertGreaterThanOrEqual(longAction.count, 110)
+        let insights = makeInsights(
+            weekStart: weekStart,
+            continuityPrompt: longAction,
+            weeklyInsights: [
+                ReviewWeeklyInsight(
+                    pattern: .recurringTheme,
+                    observation: "Rest showed up.",
+                    action: longAction,
+                    primaryTheme: "Rest",
+                    mentionCount: 3,
+                    dayCount: 2
+                )
+            ],
+            mostRecurring: [
+                ReviewMostRecurringTheme(
+                    label: "Rest",
+                    totalCount: 4,
+                    dayCount: 3,
+                    currentWeekCount: 3,
+                    previousWeekCount: 1,
+                    evidence: []
+                )
+            ]
+        )
+        let refiner = ReviewNextStepRowRefiner()
+        XCTAssertEqual(refiner.nextStepText(for: insights), longAction.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    func test_shouldShowNarrativeRow_loading_true() {
+        XCTAssertTrue(ReviewNextStepRowRefiner.shouldShowNarrativeRow(insights: nil, isLoading: true))
+    }
+
+    func test_shouldShowNarrativeRow_unlock_nilInsights_falseLoading() {
+        XCTAssertTrue(ReviewNextStepRowRefiner.shouldShowNarrativeRow(insights: nil, isLoading: false))
+    }
+
+    func test_shouldShowNarrativeRow_whenNextStepNil_false() {
+        let weekStart = date(year: 2026, month: 4, day: 6)
+        let glad = String(localized: "review.prompts.gladHappened")
+        let insights = makeInsights(
+            weekStart: weekStart,
+            continuityPrompt: glad,
+            weeklyInsights: [],
+            mostRecurring: []
+        )
+        XCTAssertFalse(ReviewNextStepRowRefiner.shouldShowNarrativeRow(insights: insights, isLoading: false))
+    }
+
+    // MARK: - Helpers
+
+    private func date(year: Int, month: Int, day: Int) -> Date {
+        var comps = DateComponents()
+        comps.year = year
+        comps.month = month
+        comps.day = day
+        return calendar.date(from: comps)!
+    }
+
+    private func makeInsights(
+        weekStart: Date,
+        continuityPrompt: String,
+        weeklyInsights: [ReviewWeeklyInsight],
+        mostRecurring: [ReviewMostRecurringTheme]
+    ) -> ReviewInsights {
+        let weekEnd = calendar.date(byAdding: .day, value: 7, to: weekStart)!
+        let weekStats = ReviewWeekStats(
+            reflectionDays: 3,
+            meaningfulEntryCount: 3,
+            completionMix: ReviewWeekCompletionMix(
+                soilDayCount: 0,
+                sproutDayCount: 1,
+                twigDayCount: 1,
+                leafDayCount: 1,
+                bloomDayCount: 0
+            ),
+            activity: [],
+            rhythmHistory: nil,
+            sectionTotals: ReviewWeekSectionTotals(gratitudeMentions: 1, needMentions: 1, peopleMentions: 0),
+            historySectionTotals: ReviewWeekSectionTotals(gratitudeMentions: 1, needMentions: 1, peopleMentions: 0),
+            historyCompletionMix: ReviewWeekCompletionMix(
+                soilDayCount: 0,
+                sproutDayCount: 0,
+                twigDayCount: 0,
+                leafDayCount: 0,
+                bloomDayCount: 0
+            ),
+            mostRecurringThemes: mostRecurring,
+            movementThemes: [],
+            trendingBuckets: nil
+        )
+        return ReviewInsights(
+            source: .deterministic,
+            presentationMode: .insight,
+            generatedAt: weekStart,
+            weekStart: weekStart,
+            weekEnd: weekEnd,
+            weeklyInsights: weeklyInsights,
+            recurringGratitudes: [],
+            recurringNeeds: [],
+            recurringPeople: [],
+            resurfacingMessage: "",
+            continuityPrompt: continuityPrompt,
+            narrativeSummary: nil,
+            weekStats: weekStats
+        )
+    }
+}


### PR DESCRIPTION
## Summary

The Past tab narrative block below recurring and trending is **Next step only**—the separate Observation panel is removed so stats cards carry facts and this line carries a single actionable nudge.

## User impact

- Users see **one** inset (**Next step**) instead of Observation + Next step.
- When the line would be empty, repeat the generic glad-happened filler, or **short** recurring copy that already matches top recurring stats, the **entire row is hidden** (no empty shell).
- **简体中文** copy for the panel title and weekly insight action strings is tightened in the string catalog.

## What changed

- `ReviewNextStepRowRefiner` filters the continuity/action line before display; `ReviewScreen` omits the list row when there is nothing to show.
- `ReviewNarrativeSummaryCard` shows only the next-step panel; loading skeleton matches.
- `Localizable.xcstrings`: zh-Hans refinements for next-step and insight action keys; `CHANGELOG.md` `[Unreleased]` entry.

## Verification

- `swiftlint` on touched Swift files
- `xcodebuild` build + `GraceNotesTests` (443 tests) on iOS Simulator

Closes #255