### PR TITLE
fix: Past statistics 'all' window no longer traps on future-only entries

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/PastStatisticsIntervalPreference.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/PastStatisticsIntervalPreference.swift
@@ -53,7 +53,10 @@ struct PastStatisticsIntervalSelection: Codable, Equatable, Hashable, Sendable {
         switch mode {
         case .all:
             let days = allEntries.map { calendar.startOfDay(for: $0.entryDate) }
-            let lower = days.min() ?? refStart
+            let earliest = days.min() ?? refStart
+            // Cap at `refStart` so `lower < endExclusive` when every entry is dated after the reference day
+            // (import/clock skew); otherwise `Range` construction traps.
+            let lower = min(earliest, refStart)
             return lower..<endExclusive
         case .custom:
             let quantityValue = min(max(quantity, 1), 999)

--- a/GraceNotesTests/Features/Journal/PastStatisticsIntervalPreferenceTests.swift
+++ b/GraceNotesTests/Features/Journal/PastStatisticsIntervalPreferenceTests.swift
@@ -36,4 +36,20 @@ final class PastStatisticsIntervalPreferenceTests: XCTestCase {
         PastStatisticsIntervalSelection(mode: .custom, quantity: quantity, unit: unit)
             .statisticsIntervalSubtitlePhrase()
     }
+
+    func test_resolvedHistoryRange_allMode_futureOnlyEntries_doesNotTrapAndCapsLowerToReferenceDay() {
+        var calendar = Calendar(identifier: .gregorian)
+        guard let utc = TimeZone(identifier: "UTC") else {
+            XCTFail("Missing UTC timezone")
+            return
+        }
+        calendar.timeZone = utc
+        let refStart = calendar.startOfDay(for: Date(timeIntervalSince1970: 1_700_000_000))
+        let futureDay = calendar.date(byAdding: .day, value: 10, to: refStart)!
+        let entries = [Journal(entryDate: futureDay, gratitudes: [Entry(fullText: "x")], needs: [], people: [])]
+        let range = PastStatisticsIntervalSelection(mode: .all, quantity: 4, unit: .week)
+            .resolvedHistoryRange(referenceDate: refStart, calendar: calendar, allEntries: entries)
+        XCTAssertEqual(range.lowerBound, refStart)
+        XCTAssertEqual(range.upperBound, calendar.date(byAdding: .day, value: 1, to: refStart))
+    }
 }


### PR DESCRIPTION
## Headline
Past statistics no longer crashes when “All journal” is selected but every on-device day is **after** “today” (e.g. future-dated import or clock skew).

## User impact
Opening Past stats / review flows that resolve the history window could **terminate the app** in that edge case. After the fix, the range stays valid and the window is capped to the reference day as the lower bound.

## What changed
- In `PastStatisticsIntervalSelection.resolvedHistoryRange` (`.all` mode), the lower bound is `min(earliestEntryDay, referenceStartOfDay)` so `lower` is always `<=` the start of the reference day and strictly before `endExclusive`.
- Regression test covers future-only journal entries.

## Verification
- `swiftlint lint` on touched files
- `xcodebuild test` — `GraceNotesTests/PastStatisticsIntervalPreferenceTests` — destination `iPhone 17 Pro @ latest` — **TEST SUCCEEDED**

Made with [Cursor](https://cursor.com)