### PR TITLE
fix(past): section-mix percentages sum to 100

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewHistoryInsightsPanels.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewHistoryInsightsPanels.swift
@@ -233,8 +233,9 @@ enum ReviewSectionDistributionStripLayout {
         return widths
     }
 
-    /// Display percentages for the section-mix strip (issue #247). Whole numbers only; rounded shares may not sum
-    /// to 100. When all counts are zero, returns `[0, 0, 0]` so each segment can show `0%` with equal thirds widths.
+    /// Display percentages for the section-mix strip (issue #247). Whole numbers only; uses the largest-remainder
+    /// method so the three values always sum to **100** when `total > 0` (plain rounding can yield 99).
+    /// When all counts are zero, returns `[0, 0, 0]` so each segment can show `0%` with equal thirds widths.
     static func integerDisplayPercents(
         gratitudeMentions: Int,
         needMentions: Int,
@@ -243,7 +244,23 @@ enum ReviewSectionDistributionStripLayout {
         let counts = [gratitudeMentions, needMentions, peopleMentions]
         let total = counts.reduce(0, +)
         guard total > 0 else { return [0, 0, 0] }
-        return counts.map { Int((Double($0) / Double(total) * 100).rounded()) }
+
+        let totalDouble = Double(total)
+        let exactShares = counts.map { Double($0) / totalDouble * 100 }
+        var floors = exactShares.map { Int($0.rounded(.down)) }
+        var remainder = 100 - floors.reduce(0, +)
+        guard remainder > 0 else { return floors }
+
+        let indicesByLargestFraction = (0..<counts.count).sorted { lhs, rhs in
+            let leftFraction = exactShares[lhs] - Double(floors[lhs])
+            let rightFraction = exactShares[rhs] - Double(floors[rhs])
+            if leftFraction != rightFraction { return leftFraction > rightFraction }
+            return lhs < rhs
+        }
+        for offset in 0..<remainder {
+            floors[indicesByLargestFraction[offset]] += 1
+        }
+        return floors
     }
 }
 

--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewHistoryInsightsPanels.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewHistoryInsightsPanels.swift
@@ -248,7 +248,7 @@ enum ReviewSectionDistributionStripLayout {
         let totalDouble = Double(total)
         let exactShares = counts.map { Double($0) / totalDouble * 100 }
         var floors = exactShares.map { Int($0.rounded(.down)) }
-        var remainder = 100 - floors.reduce(0, +)
+        let remainder = 100 - floors.reduce(0, +)
         guard remainder > 0 else { return floors }
 
         let indicesByLargestFraction = (0..<counts.count).sorted { lhs, rhs in

--- a/GraceNotesTests/Features/Journal/SectionDistributionStripLayoutTests.swift
+++ b/GraceNotesTests/Features/Journal/SectionDistributionStripLayoutTests.swift
@@ -95,4 +95,15 @@ final class SectionDistributionStripLayoutTests: XCTestCase {
         )
         XCTAssertEqual(percents, [100, 0, 0])
     }
+
+    /// Plain rounding yields 33+33+33=99; largest remainder assigns the spare point (first index wins ties).
+    func test_integerDisplayPercents_equalCounts_sumTo100() {
+        let percents = ReviewSectionDistributionStripLayout.integerDisplayPercents(
+            gratitudeMentions: 1,
+            needMentions: 1,
+            peopleMentions: 1
+        )
+        XCTAssertEqual(percents, [34, 33, 33])
+        XCTAssertEqual(percents.reduce(0, +), 100)
+    }
 }


### PR DESCRIPTION
## Summary

The Past tab section-distribution strip shows whole-number percentages per segment. Independent rounding of each share meant three equal counts could display **33% + 33% + 33% = 99%**, which is wrong and confusing.

## Change

- Use **largest-remainder** allocation (Hamilton-style) so the three displayed integers always sum to **100** when there is at least one mention.
- Tie-break equal fractional parts by segment order (Gratitudes → Needs → People) so behavior is stable.

## Tests

- Added `test_integerDisplayPercents_equalCounts_sumTo100` for the 1:1:1 case (`[34, 33, 33]`).
- **Not run here** (Linux agent): `xcodebuild test` / `grace test` — please run on macOS: `grace test` or Xcode for `SectionDistributionStripLayoutTests`.

## Verification

- `swiftlint lint` on touched files (clean).

Made with [Cursor](https://cursor.com)