### PR TITLE
Harden Bloom paper fiber canvas against invalid layout sizes

### DIFF
--- a/GraceNotes/GraceNotes/DesignSystem/BloomPaperBackgroundView.swift
+++ b/GraceNotes/GraceNotes/DesignSystem/BloomPaperBackgroundView.swift
@@ -17,7 +17,7 @@ struct BloomPaperBackgroundView: View {
                     endPoint: .bottomTrailing
                 )
                 if !reduceTransparency {
-                    PaperFibersCanvas(size: proxy.size)
+                    PaperFibersCanvas()
                         .opacity(0.14)
                 }
             }
@@ -29,10 +29,12 @@ struct BloomPaperBackgroundView: View {
 }
 
 private struct PaperFibersCanvas: View {
-    let size: CGSize
-
     var body: some View {
         Canvas { context, canvasSize in
+            guard canvasSize.width.isFinite, canvasSize.height.isFinite,
+                  canvasSize.width > 0, canvasSize.height > 0 else {
+                return
+            }
             let grainCount = 90
             var rng = SeededRandom(seed: 42)
             for _ in 0..<grainCount {


### PR DESCRIPTION
## Headline

Bloom’s paper grain now draws only when the canvas has a valid size, using the Canvas’s own dimensions.

## User impact

Reduces risk of glitchy or unstable rendering behind Today in Bloom mode when layout reports odd or zero sizes (e.g. during transitions). The subtle paper texture should look the same in normal use while failing more safely at the edges.

## What changed

PaperFibersCanvas no longer takes an external size from the geometry proxy; it relies on the Canvas closure’s size so grain placement matches what actually gets drawn.

Before stroking fibers, the draw pass now exits early when width or height is non-finite, zero, or negative, so the random stroke math never runs against invalid dimensions.

## Verification

On a Mac with Xcode and the project’s grace CLI: run `grace ci` (or `grace test` if you only need the test subset). In the simulator, open Today in Bloom mode and confirm the warm paper background and light grain still look correct; optionally resize or rotate the device to confirm no visual regressions or crashes.

## Risk

Medium

## Touch class

`ui-ux`

## Human

Post `/sentry-approve` from an allowlisted account to merge when review is satisfied.
---
*Automated by `grace sentry`.*
