### PR TITLE
Harden scheduled backup folder access and failure messages

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/Services/ScheduledBackupRunner.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/Services/ScheduledBackupRunner.swift
@@ -8,20 +8,11 @@ enum ScheduledBackupRunner {
         guard interval != .off else { return }
         guard ScheduledBackupPreferences.isDue() else { return }
 
-        let folderURL: URL
         do {
-            folderURL = try ScheduledBackupPreferences.resolveFolderURL()
+            _ = try ScheduledBackupPreferences.resolveFolderURL()
         } catch {
             await recordScheduledFailure(detail: String(localized: "settings.dataPrivacy.scheduledBackup.folderError"))
             return
-        }
-
-        guard folderURL.startAccessingSecurityScopedResource() else {
-            await recordScheduledFailure(detail: String(localized: "settings.dataPrivacy.scheduledBackup.folderError"))
-            return
-        }
-        defer {
-            folderURL.stopAccessingSecurityScopedResource()
         }
 
         let exportResult = await Task.detached(priority: .utility) {
@@ -43,7 +34,9 @@ enum ScheduledBackupRunner {
         }
 
         do {
-            let fileName = try copyTempExport(at: tempFile, to: folderURL)
+            let fileName = try await Task.detached(priority: .utility) {
+                try Self.copyScheduledExportToFolder(tempFile: tempFile)
+            }.value
             await MainActor.run {
                 ScheduledBackupPreferences.lastRunAt = Date()
                 ScheduledBackupPreferences.lastFailedAttemptAt = nil
@@ -54,9 +47,14 @@ enum ScheduledBackupRunner {
                 )
             }
         } catch {
-            await recordScheduledFailure(
-                detail: String(localized: "settings.dataPrivacy.scheduledBackup.failureDetail")
-            )
+            let detail = failureDetail(for: error)
+            await recordScheduledFailure(detail: detail)
+        }
+    }
+
+    private static func copyScheduledExportToFolder(tempFile: URL) throws -> String {
+        try ScheduledBackupPreferences.withFolderSecurityScopedAccess { folderURL in
+            try copyTempExport(at: tempFile, to: folderURL)
         }
     }
 
@@ -73,6 +71,18 @@ enum ScheduledBackupRunner {
             destinationFileName: name,
             fileManager: .default
         )
+    }
+
+    private static func failureDetail(for error: Error) -> String {
+        if let scheduled = error as? ScheduledBackupError {
+            switch scheduled {
+            case .noFolderBookmark, .securityScopeDenied:
+                return String(localized: "settings.dataPrivacy.scheduledBackup.folderError")
+            case .staleBookmark, .exportFailed:
+                return String(localized: "settings.dataPrivacy.scheduledBackup.failureDetail")
+            }
+        }
+        return String(localized: "settings.dataPrivacy.scheduledBackup.failureDetail")
     }
 
     private enum ExportToTempResult {


### PR DESCRIPTION
## Headline

Scheduled backups now open the backup folder only while copying the export, with clearer error text when something goes wrong.

## User impact

Scheduled folder backups are more reliable because security-scoped access to the chosen folder is taken only for the copy step, matching how bookmarks are meant to be used. When a run fails, the history detail better matches what went wrong (folder access vs other errors).

## What changed

Previously the runner resolved the folder, started security-scoped access once at the beginning, and kept it open through the whole flow—including the background export—before copying into the folder. That could leave access timing and threading misaligned with real file work.

The runner now validates the folder early but performs the copy inside a small helper that uses the shared `withFolderSecurityScopedAccess` wrapper so scope is held only around copying the temp export into the destination. The copy runs on a utility-priority detached task, consistent with the export work. Failure recording maps `ScheduledBackupError` cases to the existing folder vs generic localized messages instead of always showing the generic backup failure string.

## Verification

On a Mac with Xcode, run `grace ci` (or `grace test` with the project’s default simulator destination) to lint and build; exercise Settings → scheduled backup to a user-chosen folder and confirm a due run succeeds and history shows sensible detail on forced failures.

## Risk

Medium

## Touch class

`business-logic`

## Human

Post `/sentry-approve` from an allowlisted account to merge when review is satisfied.
---
*Automated by `grace sentry`.*
