### PR TITLE
Harden review insights cache pruning and legacy key removal

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/ReviewInsightsCache.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ReviewInsightsCache.swift
@@ -85,7 +85,9 @@ actor ReviewInsightsCache {
 
     private func loadPayload() -> Payload? {
         // v1 entries did not record boundary preference; never merge them into v2 reads.
-        userDefaults.removeObject(forKey: Self.legacyPayloadKey)
+        if userDefaults.object(forKey: Self.legacyPayloadKey) != nil {
+            userDefaults.removeObject(forKey: Self.legacyPayloadKey)
+        }
         guard let data = userDefaults.data(forKey: Self.payloadKey) else {
             return nil
         }
@@ -118,13 +120,6 @@ actor ReviewInsightsCache {
         return "\(interval)#\(weekBoundaryPreferenceRawValue)#\(pastStatisticsIntervalToken)"
     }
 
-    private static func weekInterval(fromCompositeCacheKey key: String) -> Double {
-        guard let sep = key.firstIndex(of: "#") else {
-            return 0
-        }
-        return Double(key[..<sep]) ?? 0
-    }
-
     private static func prune(
         weeks: [String: ReviewInsights],
         keepingMostRecent: Int
@@ -132,9 +127,17 @@ actor ReviewInsightsCache {
         guard weeks.count > keepingMostRecent else {
             return weeks
         }
+        // Evict by the decoded `weekStart` in each entry, not by re-parsing the composite key string.
+        // That avoids mis-ordering when a key prefix is malformed (e.g. `Double` parse → 0) or the key
+        // format diverges from the payload.
         let sortedKeys = weeks.keys
-            .sorted {
-                weekInterval(fromCompositeCacheKey: $0) > weekInterval(fromCompositeCacheKey: $1)
+            .sorted { key1, key2 in
+                let lhsWeekStart = weeks[key1]!.weekStart
+                let rhsWeekStart = weeks[key2]!.weekStart
+                if lhsWeekStart != rhsWeekStart {
+                    return lhsWeekStart > rhsWeekStart
+                }
+                return key1 < key2
             }
             .prefix(keepingMostRecent)
         let keysToKeep = Set(sortedKeys)


### PR DESCRIPTION
## Headline

Weekly review cache eviction now follows real week dates, not fragile key parsing.

## User impact

Users are less likely to see the wrong weeks dropped from the on-device review insights cache when the stored key string and payload disagree or the key cannot be parsed reliably. Avoiding unconditional legacy key removal reduces unnecessary UserDefaults churn on every load when nothing was stored.

## What changed

Loading the v2 cache now removes the obsolete v1 UserDefaults entry only when that legacy key is present, instead of calling remove on every read.

When trimming the cache to the most recent weeks, eviction order uses each entry’s decoded week start date (with a stable tie-break on the key string) instead of re-parsing the numeric prefix of the composite key. That removes dependence on string parsing that could mis-order or collapse to zero when the format is unexpected, so the cache keeps the intended recent weeks more reliably.

## Verification

On macOS with Xcode, run `grace ci` (or `grace test` with the project’s default destinations) to lint and build; exercise weekly review flows if you want to spot-check cache behavior after boundary or settings changes.

## Risk

Medium

## Touch class

`business-logic`

## Human

Post `/sentry-approve` from an allowlisted account to merge when review is satisfied.
---
*Automated by `grace sentry`.*
