### PR TITLE
Scale Sunrise share card date tracking with Dynamic Type

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/ShareCardStyle+Typography.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ShareCardStyle+Typography.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 extension ShareCardStyle {
     func dateFont(for script: ShareTypographyScript) -> Font {
@@ -116,6 +117,6 @@ extension ShareCardStyle {
 
     func dateTracking(for script: ShareTypographyScript) -> CGFloat? {
         guard self == .sunriseGradient, script == .latin else { return nil }
-        return 3.2
+        return UIFontMetrics(forTextStyle: .largeTitle).scaledValue(for: 3.2)
     }
 }


### PR DESCRIPTION
## Headline

Share cards keep letter spacing proportional when text size changes.

## User impact

On the Sunrise Gradient style, the Latin date used a fixed tracking value that did not grow or shrink with Larger Text settings, so spacing could look too tight or too loose compared to the scaled headline font. Matching tracking to the large-title metrics keeps the date readable and visually balanced for everyone, including users who rely on accessibility text sizing.

## What changed

The change adds UIKit so we can use UIFontMetrics for the same text style the date uses (large title). The Sunrise Gradient Latin-only date tracking value is no longer a constant; it is scaled through the metrics API so it follows the user’s preferred content size. Other share typography definitions are unchanged in intent; the behavioral fix is isolated to that tracking path.

## Verification

On a Mac with Xcode, run `grace ci` (or `grace test`) from the repo root. In the Simulator, open a journal share preview with the Sunrise Gradient style, set Display & Text Size to larger and smaller values, and confirm the Latin date’s letter spacing stays proportional to the headline rather than looking stuck at one spacing.

## Risk

Medium

## Touch class

`business-logic`

## Human

Post `/sentry-approve` from an allowlisted account to merge when review is satisfied.
---
*Automated by `grace sentry`.*
