### PR TITLE
Use subsecond timestamps in review theme evidence IDs

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/ReviewInsights.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ReviewInsights.swift
@@ -70,7 +70,7 @@ struct ReviewThemeSurfaceEvidence: Equatable, Hashable, Sendable, Codable, Ident
     let content: String
 
     var id: String {
-        "\(Int(entryDate.timeIntervalSince1970))|\(source.rawValue)|\(content)"
+        "\(entryDate.timeIntervalSince1970)|\(source.rawValue)|\(content)"
     }
 }
 


### PR DESCRIPTION
## Headline

Review theme evidence rows get more precise stable identities so lists and updates stay correct.

## User impact

Evidence chips and rows tied to recurring or trending themes rely on a stable string ID. Truncating the entry time to whole seconds could make two different pieces of evidence look identical to SwiftUI or deduplication, which can cause wrong rows, flicker, or merged items when entries land in the same second. The ID now reflects the full time value, which lowers that collision risk.

## What changed

The change is limited to how `ReviewThemeSurfaceEvidence` builds its `id` string for `Identifiable`. Previously the journal entry time was converted to integer seconds before joining it with the source and content. That conversion is removed so the timestamp portion keeps subsecond precision from `timeIntervalSince1970`, making the composite ID more discriminating without changing the rest of the review models or decoding.

## Verification

On a Mac with the repo and `grace` installed, run `swiftlint lint` from the repo root, then `grace ci` (or `grace test` with the project’s default simulator destination) to confirm the GraceNotes scheme still builds and tests pass. Manually spot-check the review screen if theme evidence lists are easy to open: multiple items in the same second should still appear as distinct rows when content differs.

## Risk

Medium

## Touch class

`business-logic`

## Human

Post `/sentry-approve` from an allowlisted account to merge when review is satisfied.
---
*Automated by `grace sentry`.*
