### PR TITLE
Honor Dynamic Type caps when Outfit is unavailable for UI chrome

### DIFF
--- a/GraceNotes/GraceNotes/DesignSystem/AppInterfaceAppearance.swift
+++ b/GraceNotes/GraceNotes/DesignSystem/AppInterfaceAppearance.swift
@@ -16,16 +16,14 @@ enum AppInterfaceAppearance {
         textStyle: UIFont.TextStyle,
         maximumForContentSizeCategory limit: UIContentSizeCategory? = nil
     ) -> UIFont {
-        guard let font = UIFont(name: name, size: baseSize) else {
-            return UIFont.preferredFont(forTextStyle: textStyle)
-        }
+        let baseFont = UIFont(name: name, size: baseSize) ?? UIFont.preferredFont(forTextStyle: textStyle)
         let metrics = UIFontMetrics(forTextStyle: textStyle)
         guard let limit else {
-            return metrics.scaledFont(for: font)
+            return metrics.scaledFont(for: baseFont)
         }
         let limitTraits = UITraitCollection(preferredContentSizeCategory: limit)
-        let maxPointSize = metrics.scaledFont(for: font, compatibleWith: limitTraits).pointSize
-        return metrics.scaledFont(for: font, maximumPointSize: maxPointSize)
+        let maxPointSize = metrics.scaledFont(for: baseFont, compatibleWith: limitTraits).pointSize
+        return metrics.scaledFont(for: baseFont, maximumPointSize: maxPointSize)
     }
 
     private static func configureNavigationBar() {


### PR DESCRIPTION
## Headline

System UI fonts now use the same scaling and size limits whether Outfit loads or not.

## User impact

If the Outfit font failed to load, navigation bar, tab bar, and bar button text skipped the app’s Dynamic Type scaling and maximum size rules. That could make labels too large or inconsistent at accessibility sizes. Fallback text now follows the same scaling and content size caps as the Outfit path.

## What changed

The helper that picks the Outfit font for UIKit chrome was refactored so the custom font and the system fallback share one code path. Instead of returning early with a plain preferred system font when Outfit is missing, the code always runs through UIFontMetrics, including optional caps tied to content size category. Behavior for the normal case (Outfit present) stays the same; the fix matters when the bundled font does not resolve.

## Verification

On a Mac with Xcode, run `grace ci` (or `grace test` per your usual workflow). Manually, build the app and, with Dynamic Type at very large sizes, confirm navigation titles, tab labels, and bar button titles remain readable and do not overflow stacked tab items; optionally simulate missing Outfit only in a dev build if you use font substitution.

## Risk

Medium

## Touch class

`business-logic`

## Human

Post `/sentry-approve` from an allowlisted account to merge when review is satisfied.
---
*Automated by `grace sentry`.*
