### PR TITLE
Harden JSON import: empty picker errors and merge-conflict flow

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/ImportExportSettingsScreen.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/ImportExportSettingsScreen.swift
@@ -180,7 +180,11 @@ struct ImportExportSettingsScreen: View {
             JSONImportFileImporterAnchor(isPresented: $showImportPicker) { result in
                 switch result {
                 case .success(let urls):
-                    guard let url = urls.first else { return }
+                    guard let url = urls.first else {
+                        importErrorMessage = String(localized: "settings.dataPrivacy.import.error.readFailed")
+                        showImportError = true
+                        return
+                    }
                     pendingImportURL = url
                     importMode = .merge
                     showImportReview = true
@@ -631,6 +635,7 @@ private extension ImportExportSettingsScreen {
         } catch let error as JournalDataImportError {
             if case .mergeConflicts(let days) = error {
                 mergeConflictDays = days
+                showImportReview = false
                 showMergeConflictResolution = true
             } else {
                 importErrorMessage = importFailureMessage(for: error)


### PR DESCRIPTION
## Headline

Imports now fail visibly when the file picker returns nothing, and merge conflicts no longer hide behind the review sheet.

## User impact

If the document picker reports success but does not supply a file, you now see the same read-failed message as other import errors instead of nothing happening. When a merge hits conflicting days, the import review sheet closes before the conflict-resolution alert so you are not stuck with layered UI or a confusing stack of surfaces.

## What changed

The JSON import completion handler used to return quietly when the success case contained no URL. It now sets the import error copy and shows the standard import error alert, matching the failure path so the flow always gives feedback.

When the importer throws merge conflicts, the code dismisses the import review sheet before presenting the merge-conflict resolution alert. That keeps presentation predictable and avoids the review sheet staying open on top of or alongside the conflict dialog.

## Verification

On a Mac with Xcode and the iOS Simulator, run `grace ci` (or `grace test` with the project’s usual destination). Manually: trigger JSON import with an edge case that yields no URL if reproducible, and run a merge that produces conflicts to confirm the review sheet dismisses and the conflict alert appears alone.

## Risk

Medium

## Touch class

`ui-ux`

## Human

Post `/sentry-approve` from an allowlisted account to merge when review is satisfied.
---
*Automated by `grace sentry`.*
