### PR TITLE
Harden journal import size checks and merge conflict date comparison

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/Services/JournalDataImportService.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/Services/JournalDataImportService.swift
@@ -57,7 +57,12 @@ struct JournalDataImportService {
         }
         if let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
            let num = attrs[.size] as? NSNumber {
-            return num.intValue
+            // Use 64-bit magnitude: `intValue` truncates past 32-bit signed range and can mis-report huge files.
+            let v = num.uint64Value
+            if v > UInt64(Int.max) {
+                return Int.max
+            }
+            return Int(v)
         }
         return nil
     }
@@ -283,6 +288,25 @@ struct JournalDataImportService {
         let readingNotes: String
         let reflections: String
         let completedAt: Date?
+
+        static func == (lhs: ImportComparisonPayload, rhs: ImportComparisonPayload) -> Bool {
+            lhs.gratitudeTexts == rhs.gratitudeTexts &&
+                lhs.needTexts == rhs.needTexts &&
+                lhs.peopleTexts == rhs.peopleTexts &&
+                lhs.readingNotes == rhs.readingNotes &&
+                lhs.reflections == rhs.reflections &&
+                completedAtEqualForMerge(lhs.completedAt, rhs.completedAt)
+        }
+    }
+
+    /// ISO8601 decode vs persisted `Date` can differ slightly in sub-second precision; treat as same for merge detection.
+    private static func completedAtEqualForMerge(_ a: Date?, _ b: Date?) -> Bool {
+        switch (a, b) {
+        case (nil, nil): return true
+        case (nil, _), (_, nil): return false
+        case let (a?, b?):
+            return abs(a.timeIntervalSince(b)) < 1.0
+        }
     }
 
     private struct SanitizedExport {


### PR DESCRIPTION
## Headline

Imports now size huge files correctly and stop false merge conflicts from completion timestamps.

## User impact

Merge imports are less likely to ask you to resolve conflicts when the backup and device only disagree by tiny timestamp differences. Very large backup files are measured accurately before loading, so size limits behave as intended instead of mis-reporting huge files.

## What changed

File size from filesystem attributes now uses the full 64-bit value and clamps to the largest representable integer when needed, replacing a path that could truncate past 32-bit range and mis-state size.

Merge conflict detection compares imported payloads with a custom equality for completion time: two completion dates count as the same if they are within one second, covering ISO8601 decoding versus dates already stored on disk, which can differ slightly below a second.

## Verification

On a Mac with Xcode, run `grace ci` (or `grace test` with the project’s default simulator destination) to lint and build; exercise Settings import in merge mode with a backup whose days match the device except for sub-second completion time if you want a manual check.

## Risk

Medium

## Touch class

`business-logic`

## Human

Post `/sentry-approve` from an allowlisted account to merge when review is satisfied.
---
*Automated by `grace sentry`.*
