### PR TITLE
Clamp insight placeholder width; stabilize theme IDs with POSIX locale

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewInsightThemeCardSupport+Loading.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewInsightThemeCardSupport+Loading.swift
@@ -9,7 +9,8 @@ struct InsightsPlaceholderBar: View {
 
     var body: some View {
         GeometryReader { geo in
-            let lineWidth = max(geo.size.width * widthFraction, height * 2)
+            let fraction = min(1, max(0, widthFraction))
+            let lineWidth = max(geo.size.width * fraction, height * 2)
             RoundedRectangle(cornerRadius: height * 0.42, style: .continuous)
                 .fill(AppTheme.reviewTextMuted.opacity(0.10))
                 .frame(width: lineWidth, height: height, alignment: .leading)
@@ -41,8 +42,10 @@ struct InsightsCalmLoadingBreath: ViewModifier {
 }
 
 func reviewInsightSanitizedThemeId(_ value: String) -> String {
+    // POSIX keeps accessibility identifiers stable across user locales (e.g. Turkish casing rules).
+    let stableLocale = Locale(identifier: "en_US_POSIX")
     let cleaned = value
-        .folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current)
+        .folding(options: [.diacriticInsensitive, .caseInsensitive], locale: stableLocale)
         .replacingOccurrences(of: "[^a-zA-Z0-9]+", with: "-", options: .regularExpression)
         .trimmingCharacters(in: CharacterSet(charactersIn: "-"))
     if cleaned.isEmpty {


### PR DESCRIPTION
## Headline

Review insight loading bars stay within bounds, and theme accessibility IDs no longer drift with locale-specific casing.

## User impact

Skeleton loading bars no longer stretch past the card when a bad width fraction slips through. Theme-based accessibility identifiers stay the same no matter the device language, so automation and assistive tech see consistent IDs (important where casing rules differ, such as Turkish).

## What changed

The placeholder bar now clamps the width fraction to the 0–1 range before computing bar width, so layout stays predictable even if callers pass an out-of-range value. Theme ID sanitization uses a fixed POSIX English locale for case- and diacritic-insensitive folding instead of the user’s current locale, so the same theme string maps to the same identifier across regions. A short comment documents why POSIX is used.

## Verification

On a Mac with Xcode and the project’s grace CLI: run `swiftlint lint` from the repo root, then `grace ci` (or `grace test` with the default simulator destination) to confirm the GraceNotes scheme still builds and tests pass. In Simulator, open Review insights loading/skeleton UI and spot-check placeholder bar width; switch system language to one with special casing (e.g. Turkish) and confirm theme-related accessibility identifiers remain stable if you inspect them in UI tests or Accessibility Inspector.

## Risk

Medium

## Touch class

`ui-ux`

## Human

Post `/sentry-approve` from an allowlisted account to merge when review is satisfied.
---
*Automated by `grace sentry`.*
