### PR TITLE
Fix VoiceOver labels for Data & Privacy storage and status blocks

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/DataPrivacySettingsSection.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/DataPrivacySettingsSection.swift
@@ -150,7 +150,6 @@ private extension DataPrivacySettingsSection {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel(String(localized: "settings.dataPrivacy.a11y.storage"))
     }
 
     func attentionBlock(message: String) -> some View {
@@ -172,7 +171,6 @@ private extension DataPrivacySettingsSection {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel(String(localized: "settings.dataPrivacy.a11y.nextSteps"))
     }
 
     var importExportRow: some View {


### PR DESCRIPTION
## Headline

VoiceOver now reads the full storage and status copy instead of short generic labels.

## User impact

A combined accessibility element with a custom label could override the real on-screen text, so listeners heard a brief category name instead of where journal data lives or what to do next. This change restores natural announcements from the visible copy, which improves clarity and trust for people who rely on VoiceOver in Settings.

## What changed

In the Data & Privacy settings section, custom accessibility labels were removed from the storage summary block (local-only / fallback description) and from the attention block that can include guidance and an Open Settings action. Those views still use combined accessibility elements so children are grouped, but without a separate label VoiceOver derives speech from the actual text and controls inside each block.

## Verification

On a Mac with Xcode and the iOS Simulator, run `grace ci` (or `grace test` with the project’s default destination). In the app, open Settings → Data & Privacy, enable VoiceOver, and move through the storage summary and any attention message; confirm VoiceOver speaks the full visible strings rather than only a short heading-style label.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* If Copilot review threads block merge, post `/sentry-approve` from an allowlisted account.
