### PR TITLE
chore: test Copilot/Cursor review comments (manual verification)

### DIFF
--- a/GraceNotes/GraceNotes/Application/GraceNotesApp.swift
+++ b/GraceNotes/GraceNotes/Application/GraceNotesApp.swift
@@ -9,6 +9,8 @@ import SwiftUI
 import SwiftData
 import UIKit
 
+// Test PR only: touch Swift so Copilot/Cursor review hooks run; revert before merge if undesired.
+
 @main
 struct GraceNotesApp: App {
     @UIApplicationDelegateAdaptor(GraceNotesAppDelegate.self) private var appDelegate


### PR DESCRIPTION
## Purpose

Temporary PR to verify **GitHub Copilot** and **Cursor** post review comments on a normal code change (Swift touch).

## What to check

- Copilot review threads appear (merge gate uses `copilot_login` in `gracenotes-dev.toml`).
- Cursor posts on the PR (issue comments and/or PR reviews) if the Cursor GitHub App is enabled for this repo.

## Cleanup

Close without merging or revert the single comment in `GraceNotesApp.swift` after verification.

**Do not merge** unless you intend to keep the comment line (unlikely).

Made with [Cursor](https://cursor.com)