### PR TITLE
Log review insight generator failures and tighten sparse fallback

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/ReviewInsightsProvider.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ReviewInsightsProvider.swift
@@ -1,7 +1,14 @@
 import Foundation
+import os
+
+private let reviewInsightsProviderLogger = Logger(
+    subsystem: Bundle(for: PersistenceController.self).bundleIdentifier ?? "GraceNotes",
+    category: "ReviewInsightsProvider"
+)
 
 struct ReviewInsightsProvider: Sendable {
-    /// Legacy key from cloud-insight builds; still consulted for install-continuity heuristics.
+    /// Legacy UserDefaults key from cloud-enabled builds;
+    /// ``migrateLegacyAIFeaturesToggleIfNeeded`` removes it for a clean slate.
     static let legacyAIFeaturesUserDefaultsKey = "useAIReviewInsights"
 
     private let deterministicGenerator: any ReviewInsightsGenerating
@@ -38,21 +45,27 @@ struct ReviewInsightsProvider: Sendable {
         calendar: Calendar,
         pastStatisticsInterval: PastStatisticsIntervalSelection
     ) async -> ReviewInsights {
-        if let deterministicInsights = try? await deterministicGenerator.generateInsights(
-            from: entries,
-            referenceDate: referenceDate,
-            calendar: calendar,
-            pastStatisticsInterval: pastStatisticsInterval
-        ) {
-            return deterministicInsights
+        do {
+            return try await deterministicGenerator.generateInsights(
+                from: entries,
+                referenceDate: referenceDate,
+                calendar: calendar,
+                pastStatisticsInterval: pastStatisticsInterval
+            )
+        } catch {
+            if !(error is CancellationError) {
+                let detail = error.localizedDescription
+                reviewInsightsProviderLogger.error(
+                    "Sparse fallback after generator failure. \(detail, privacy: .public)"
+                )
+            }
+            return sparseFallbackInsights(
+                from: entries,
+                referenceDate: referenceDate,
+                calendar: calendar,
+                pastStatisticsInterval: pastStatisticsInterval
+            )
         }
-
-        return sparseFallbackInsights(
-            from: entries,
-            referenceDate: referenceDate,
-            calendar: calendar,
-            pastStatisticsInterval: pastStatisticsInterval
-        )
     }
 
     private func sparseFallbackInsights(
@@ -74,14 +87,13 @@ struct ReviewInsightsProvider: Sendable {
             referenceDate: referenceDate,
             pastStatisticsInterval: pastStatisticsInterval
         )
+        let carryIntoNextWeek = String(localized: "review.prompts.carryIntoNextWeek")
         let fallbackInsight = ReviewWeeklyInsight(
             pattern: .sparseFallback,
             observation: String(
                 localized: "review.insights.starterReflection"
             ),
-            action: String(
-                localized: "review.prompts.carryIntoNextWeek"
-            ),
+            action: carryIntoNextWeek,
             primaryTheme: nil,
             mentionCount: nil,
             dayCount: 0
@@ -97,9 +109,7 @@ struct ReviewInsightsProvider: Sendable {
             recurringNeeds: [],
             recurringPeople: [],
             resurfacingMessage: fallbackInsight.observation,
-            continuityPrompt: fallbackInsight.action ?? String(
-                localized: "review.prompts.carryIntoNextWeek"
-            ),
+            continuityPrompt: carryIntoNextWeek,
             narrativeSummary: nil,
             weekStats: aggregates.stats
         )


### PR DESCRIPTION
## Headline

Weekly review insights still fall back gracefully when generation fails, while failures are now visible to developers and cancellation stays quiet.

## User impact

If deterministic insight generation throws, you still get the familiar sparse weekly review instead of a blank or broken screen. Engineers gain a clear log when something went wrong (other than normal task cancellation), which makes rare production issues easier to trace without changing what you see in the journal.

## What changed

The provider no longer uses silent error swallowing for the deterministic generator. It now catches errors explicitly, logs a structured message when the failure is not a cancellation, and then builds the same sparse fallback insights as before. A shared localized string for the “carry into next week” prompt is computed once and reused for both the fallback insight action and the continuity prompt, so those strings stay aligned. The legacy UserDefaults key comment was updated to describe migration and cleanup accurately.

## Verification

On a Mac with Xcode and the project’s grace CLI installed, run `grace ci` (or `grace test` per your usual profile) to lint and build against the configured simulator; optionally open Console and trigger a path where the generator fails to confirm the new log line appears and the weekly review still shows the sparse fallback.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* If Copilot review threads block merge, post `/sentry-approve` from an allowlisted account.
