### PR TITLE
Fix journal add freeze after bouncing add morph and chips

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/JournalEntryInteractionCoordinator.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/JournalEntryInteractionCoordinator.swift
@@ -11,19 +11,15 @@ enum JournalEntryInteractionCoordinator {
         let operations: EntrySectionOperations
     }
 
-    static func addNewTapped(
-        context: SectionContext,
-        restoreInputFocus: (FocusState<Bool>.Binding) -> Void
-    ) {
-        let handled = JournalScreenEntryHandling.handleAddEntryTap(
+    /// Returns whether `handleAddEntryTap` applied. Callers that reveal the add morph should run
+    /// `restoreInputFocus` **after** `isAddMorphComposerVisible` becomes true (next run loop).
+    static func addNewTapped(context: SectionContext) -> Bool {
+        JournalScreenEntryHandling.handleAddEntryTap(
             input: context.input,
             editingIndex: context.editingIndex,
             operations: context.operations,
             isTransitioning: context.isTransitioning
         )
-        if handled {
-            restoreInputFocus(context.inputFocus)
-        }
     }
 
     static func entryTapped(

--- a/GraceNotes/GraceNotes/Features/Journal/Views/JournalScreen.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/JournalScreen.swift
@@ -1117,6 +1117,7 @@ private extension JournalScreen {
             onMoveItem: { from, toOffset in moveChip(section: .gratitude, from: from, toOffset: toOffset) },
             onDeleteItem: { index in deleteChip(section: .gratitude, index: index) },
             onAddNew: { addNewTapped(section: .gratitude) },
+            onAfterAddMorphRevealed: { restoreFocusAfterAddMorph(section: .gratitude) },
             isAddMorphComposerVisible: $isGratitudeAddMorphComposerVisible,
             ambientInlineEditingActive: isAnyInlineChipEditing,
             sectionHostsInlineFocus: editingGratitudeIndex != nil || isGratitudeAddMorphComposerVisible,
@@ -1154,6 +1155,7 @@ private extension JournalScreen {
             onMoveItem: { from, toOffset in moveChip(section: .need, from: from, toOffset: toOffset) },
             onDeleteItem: { index in deleteChip(section: .need, index: index) },
             onAddNew: { addNewTapped(section: .need) },
+            onAfterAddMorphRevealed: { restoreFocusAfterAddMorph(section: .need) },
             isAddMorphComposerVisible: $isNeedAddMorphComposerVisible,
             ambientInlineEditingActive: isAnyInlineChipEditing,
             sectionHostsInlineFocus: editingNeedIndex != nil || isNeedAddMorphComposerVisible,
@@ -1192,6 +1194,7 @@ private extension JournalScreen {
             onMoveItem: { from, toOffset in moveChip(section: .person, from: from, toOffset: toOffset) },
             onDeleteItem: { index in deleteChip(section: .person, index: index) },
             onAddNew: { addNewTapped(section: .person) },
+            onAfterAddMorphRevealed: { restoreFocusAfterAddMorph(section: .person) },
             isAddMorphComposerVisible: $isPersonAddMorphComposerVisible,
             ambientInlineEditingActive: isAnyInlineChipEditing,
             sectionHostsInlineFocus: editingPersonIndex != nil || isPersonAddMorphComposerVisible,
@@ -1796,12 +1799,16 @@ private extension JournalScreen {
             )
         )
     }
-    func addNewTapped(section: EntryListSection) {
+    func addNewTapped(section: EntryListSection) -> Bool {
         let adapter = entryListSectionAdapter(for: section)
-        JournalEntryInteractionCoordinator.addNewTapped(
-            context: adapter.entryInteractionContext,
-            restoreInputFocus: restoreInputFocus
+        return JournalEntryInteractionCoordinator.addNewTapped(
+            context: adapter.entryInteractionContext
         )
+    }
+
+    private func restoreFocusAfterAddMorph(section: EntryListSection) {
+        let adapter = entryListSectionAdapter(for: section)
+        restoreInputFocus(adapter.inputFocus)
     }
 
     func deleteChip(section: EntryListSection, index: Int) {

--- a/GraceNotes/GraceNotes/Features/Journal/Views/SequentialSectionEntryScroller.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/SequentialSectionEntryScroller.swift
@@ -17,7 +17,7 @@ struct SequentialSectionEntryScroller<ChipRow: View>: View {
     let isInteractionEnabled: Bool
     let canScrollChipsLeft: Bool
     let canScrollChipsRight: Bool
-    let onAddNew: (() -> Void)?
+    let onAddNew: (() -> Bool)?
 
     @Binding var entryScrollSnapshot: SequentialSectionEntryRow.EntryRowScrollSnapshot
 
@@ -33,7 +33,7 @@ struct SequentialSectionEntryScroller<ChipRow: View>: View {
                         accessibilityHint: addButtonAccessibilityHint,
                         accessibilityIdentifier: addChipAccessibilityIdentifier,
                         showsTrailingChevron: showsTrailingChevronOnAddChip,
-                        onTap: addNew
+                        onTap: { _ = addNew() }
                     )
                 }
             }

--- a/GraceNotes/GraceNotes/Features/Journal/Views/SequentialSectionPrimaryColumn.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/SequentialSectionPrimaryColumn.swift
@@ -32,7 +32,8 @@ struct SequentialSectionPrimaryColumn<ProgressDots: View>: View {
     let onItemTap: (Int) -> Void
     let onMoveItem: ((Int, Int) -> Void)?
     let onDeleteItem: ((Int) -> Void)?
-    let onAddNew: (() -> Void)?
+    let onAddNew: (() -> Bool)?
+    let onAfterAddMorphRevealed: (() -> Void)?
     let ambientInlineEditingActive: Bool
     let sectionHostsInlineFocus: Bool
     let onRequestDismissInlineEditing: (() -> Void)?
@@ -362,11 +363,19 @@ extension SequentialSectionPrimaryColumn {
         }
     }
 
-    private func handleAddTap(_ addNew: () -> Void) {
+    /// Issue #275: Commit prior editor state (`onAddNew` / `handleAddEntryTap`) before revealing the morph so we
+    /// never show the composer when the handler fails or `isTransitioning` blocks interaction.
+    private func handleAddTap(_ addNew: () -> Bool) {
+        guard addNew() else { return }
         withAnimation(reduceMotion ? nil : .snappy(duration: 0.24)) {
             isAddMorphComposerVisible = true
         }
-        addNew()
+        if let onAfterAddMorphRevealed {
+            Task { @MainActor in
+                await Task.yield()
+                onAfterAddMorphRevealed()
+            }
+        }
     }
 
     private func commitAddMorphFromHeaderTap() {

--- a/GraceNotes/GraceNotes/Features/Journal/Views/SequentialSectionView.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/SequentialSectionView.swift
@@ -40,7 +40,9 @@ struct SequentialSectionView: View {
     let onItemTap: (Int) -> Void
     let onMoveItem: ((Int, Int) -> Void)?
     let onDeleteItem: ((Int) -> Void)?
-    let onAddNew: (() -> Void)?
+    let onAddNew: (() -> Bool)?
+    /// After a successful add tap, run once the add morph is visible (e.g. keyboard focus on the composer).
+    let onAfterAddMorphRevealed: (() -> Void)?
     /// When true, another entry row or add morph in this journal is focused; fades non-focused rows.
     let ambientInlineEditingActive: Bool
     /// This section contains the focused inline editor or add morph composer.
@@ -81,7 +83,8 @@ struct SequentialSectionView: View {
         onItemTap: @escaping (Int) -> Void,
         onMoveItem: ((Int, Int) -> Void)? = nil,
         onDeleteItem: ((Int) -> Void)? = nil,
-        onAddNew: (() -> Void)? = nil,
+        onAddNew: (() -> Bool)? = nil,
+        onAfterAddMorphRevealed: (() -> Void)? = nil,
         isAddMorphComposerVisible: Binding<Bool> = .constant(false),
         ambientInlineEditingActive: Bool = false,
         sectionHostsInlineFocus: Bool = false,
@@ -112,6 +115,7 @@ struct SequentialSectionView: View {
         self.onMoveItem = onMoveItem
         self.onDeleteItem = onDeleteItem
         self.onAddNew = onAddNew
+        self.onAfterAddMorphRevealed = onAfterAddMorphRevealed
         self._isAddMorphComposerVisible = isAddMorphComposerVisible
         self.ambientInlineEditingActive = ambientInlineEditingActive
         self.sectionHostsInlineFocus = sectionHostsInlineFocus
@@ -182,6 +186,7 @@ struct SequentialSectionView: View {
             onMoveItem: onMoveItem,
             onDeleteItem: onDeleteItem,
             onAddNew: onAddNew,
+            onAfterAddMorphRevealed: onAfterAddMorphRevealed,
             ambientInlineEditingActive: ambientInlineEditingActive,
             sectionHostsInlineFocus: sectionHostsInlineFocus,
             onRequestDismissInlineEditing: onRequestDismissInlineEditing,

--- a/GraceNotesTests/Features/Journal/JournalScreenEntryHandlingEdgeCaseTests.swift
+++ b/GraceNotesTests/Features/Journal/JournalScreenEntryHandlingEdgeCaseTests.swift
@@ -181,6 +181,8 @@ final class JournalScreenEntryHandlingEdgeCaseTests: XCTestCase {
         XCTAssertNil(editingIndex)
     }
 
+    /// Regression (issue #275): UI reveals the add morph only after this handler succeeds so the morph
+    /// cannot appear while `isTransitioning` still blocks hit testing on the section.
     func test_handleAddEntryTap_whileTransitioning_returnsFalseWithoutMutating() {
         var input = "Draft"
         var editingIndex: Int?


### PR DESCRIPTION
## Summary

Opening a past day (or any journal that uses the sentence add control), starting a new line with **Add**, switching back to an existing chip, then tapping **Add** again could leave the UI stuck—taps on the section stopped working.

## What changed

The add-morph composer is only revealed **after** `handleAddEntryTap` succeeds, so we never show the composer while the section is still in a transition that disables hit testing. Keyboard focus runs after the morph is on screen (next run loop).

## Verification

- `swiftlint lint`
- `grace ci`
- `xcodebuild test` (JournalScreenEntryHandlingEdgeCaseTests)
- `grace run` on a physical device

Fixes #275

Made with [Cursor](https://cursor.com)