### PR TITLE
fix(sentry): avoid ValueError when merge sweep budget elapses during poll

### DIFF
--- a/Scripts/gracenotes-dev/src/gracenotes_dev/sentry/runner.py
+++ b/Scripts/gracenotes-dev/src/gracenotes_dev/sentry/runner.py
@@ -757,7 +757,8 @@ def reconcile_open_sentry_prs(
 
             if not queue:
                 break
-            time.sleep(min(poll_interval, pr_end - time.monotonic()))
+            remaining = pr_end - time.monotonic()
+            time.sleep(max(0.0, min(poll_interval, remaining)))
 
         if finished:
             continue


### PR DESCRIPTION
## Summary

`grace sentry start --tui` could crash with `ValueError: sleep length must be non-negative` while reconciling open sentry PRs during a merge sweep.

## User impact

The sentry TUI (and any path that calls `reconcile_open_sentry_prs`) no longer dies when the per-PR sweep window expires *after* `merge_poll_once` and `git fetch` run, so the remaining sleep duration becomes negative.

## What changed

The poll sleep now uses `max(0.0, min(poll_interval, remaining))` so we never pass a negative value to `time.sleep`.

## Verification

- `uv run --project Scripts/gracenotes-dev python -m unittest discover -s tests` (165 tests, OK)