### PR TITLE
Fix journal share image rendering with bounded layout width

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/JournalShareRenderer.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/JournalShareRenderer.swift
@@ -2,10 +2,25 @@ import SwiftUI
 import UIKit
 
 enum JournalShareRenderer {
+    /// Renders the share card to a bitmap.
+    ///
+    /// `ImageRenderer` proposes a size to the root view. If that size is effectively unbounded,
+    /// flexible-width SwiftUI content can lay out poorly and `uiImage` may be nil or empty.
+    /// A concrete width matches typical phone layout and keeps the export stable across devices.
     @MainActor static func renderImage(from payload: ShareRenderPayload) -> UIImage? {
         let cardView = JournalShareCardView(payload: payload, onLineTap: nil)
         let renderer = ImageRenderer(content: cardView)
-        renderer.scale = UIScreen.main.scale
+        renderer.proposedSize = ProposedViewSize(width: Self.proposedLayoutWidth, height: nil)
+        renderer.scale = Self.pixelScale
         return renderer.uiImage
+    }
+
+    private static let proposedLayoutWidth: CGFloat = 390
+
+    private static var pixelScale: CGFloat {
+        if #available(iOS 17.0, *) {
+            return UITraitCollection.current.displayScale
+        }
+        return UIScreen.main.scale
     }
 }


### PR DESCRIPTION
## Headline

Share exports should reliably produce a crisp, correctly laid-out image instead of failing or looking wrong.

## User impact

Sharing a journal as an image should work more consistently, especially when the system would otherwise give the share card an ambiguous width. Exports should also look sharp on current devices by using the right display scale when available.

## What changed

The share card renderer now gives SwiftUI’s ImageRenderer a concrete proposed width (typical phone width) with flexible height, so flexible layouts don’t break under an effectively unbounded size—avoiding nil or empty bitmaps and keeping the export stable across devices. Pixel scale prefers the current trait collection’s display scale on iOS 17 and newer, with a fallback to the main screen scale on older versions. A short doc comment explains why this sizing exists.

## Verification

On a Mac with Xcode and the project’s grace CLI installed, run `grace ci` (or at least `grace test` with the default simulator destination from gracenotes-dev.toml). Manually: share a journal and confirm the generated image looks correct and is not blank.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
