### PR TITLE
Skip streak work when building lapse reminder notification bodies

### DIFF
--- a/GraceNotes/GraceNotes/Services/Reminders/ReminderNotificationBodyBuilder.swift
+++ b/GraceNotes/GraceNotes/Services/Reminders/ReminderNotificationBodyBuilder.swift
@@ -10,7 +10,6 @@ enum ReminderNotificationBodyBuilder {
         calendar: Calendar = .current
     ) throws -> String {
         let repository = JournalRepository(calendar: calendar)
-        let calculator = StreakCalculator(calendar: calendar)
         let todayStart = calendar.startOfDay(for: now)
         let entries = try repository.fetchAllEntries(context: modelContext)
         let gapDays = ReminderNotificationBodySelector.calendarDayGapSinceLastMeaningfulEntry(
@@ -20,6 +19,23 @@ enum ReminderNotificationBodyBuilder {
         )
         let isLapse = ReminderNotificationBodySelector.isLapse(gapDays: gapDays)
 
+        let timeBucket = ReminderNotificationBodySelector.timeBucket(
+            forReminderTime: reminderTime,
+            calendar: calendar
+        )
+
+        if isLapse {
+            // `completion` / `streakBucket` are unused when `isLapse` is true (`localizationKey` returns early).
+            let key = ReminderNotificationBodySelector.localizationKey(
+                isLapse: true,
+                completion: .empty,
+                timeBucket: timeBucket,
+                streakBucket: .none
+            )
+            return String(localized: String.LocalizationValue(key))
+        }
+
+        let calculator = StreakCalculator(calendar: calendar)
         let todayEntry = try repository.fetchEntry(for: now, context: modelContext)
         let completion = ReminderNotificationBodySelector.completionFamily(for: todayEntry)
 
@@ -40,12 +56,8 @@ enum ReminderNotificationBodyBuilder {
             )
         }
 
-        let timeBucket = ReminderNotificationBodySelector.timeBucket(
-            forReminderTime: reminderTime,
-            calendar: calendar
-        )
         let key = ReminderNotificationBodySelector.localizationKey(
-            isLapse: isLapse,
+            isLapse: false,
             completion: completion,
             timeBucket: timeBucket,
             streakBucket: streakBucket


### PR DESCRIPTION
## Headline

Daily reminder copy for a journaling lapse no longer loads today’s entry or streak math.

## User impact

When you have fallen behind on journaling, the app only needs lapse-focused reminder text. Before, it still read today’s journal and computed streak summaries, which was wasted work and could surface avoidable failures when today’s entry was missing or harder to load. Now the lapse path is direct and lighter.

## What changed

Reminder notification body building checks for a lapse first. If the user is in a lapse, it picks the time-of-day bucket and resolves the localization key with fixed placeholder completion and streak values (the selector ignores those when the lapse flag is set), then returns. Streak calculation, today’s entry fetch, and streak bucket selection run only on the non-lapse path, with the localization call using an explicit non-lapse flag.

## Verification

On a Mac with Xcode and the project’s grace CLI installed, run `grace ci` (or `grace test` with the default simulator destination from gracenotes-dev.toml) to lint and build; optionally exercise reminder scheduling in the simulator to confirm lapse vs active copy still matches expectations.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
