### PR TITLE
Keep prior daily reminder if rescheduling fails

### DIFF
--- a/GraceNotes/GraceNotes/Services/Reminders/ReminderScheduler.swift
+++ b/GraceNotes/GraceNotes/Services/Reminders/ReminderScheduler.swift
@@ -137,8 +137,8 @@ struct ReminderScheduler {
     }
 
     private func scheduleReminder(at time: Date, body: String) async -> Bool {
-        removeReminder()
-
+        // Do not remove the existing pending request first. Adding a request with the same
+        // identifier replaces it; removing first would orphan the user if `add` throws.
         let content = UNMutableNotificationContent()
         content.title = String(localized: "app.name")
         content.body = body


### PR DESCRIPTION
## Headline

Rescheduling a daily reminder no longer clears the old notification before the new one is saved.

## User impact

If adding the updated reminder failed, the app used to remove the existing pending notification first, which could leave journaling reminders turned off without the user intending it. Users are less likely to silently lose their daily reminder when the system cannot complete an update.

## What changed

Scheduling a daily reminder used to delete the current pending notification and then add a new one. That sequence meant a failed add could wipe the previous schedule. The scheduler now relies on the fact that registering a notification with the same identifier replaces the prior request, so the existing reminder stays in place until a new one is successfully added. A short comment documents this behavior for future changes.

## Verification

On a Mac with Xcode and the iOS Simulator, run `grace ci` (or `grace test` with the project’s default destination) to confirm the GraceNotes scheme builds and tests pass.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
