### PR TITLE
VoiceOver: announce loading for Most Recurring insights skeleton

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewMostRecurringCard.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewMostRecurringCard.swift
@@ -163,8 +163,9 @@ struct ReviewMostRecurringCard: View {
                 }
             }
             .modifier(InsightsCalmLoadingBreath(active: !reduceMotion))
-            // Keep the panel title in the accessibility tree (and visible to UI tests) while hiding inert bars.
-            .accessibilityHidden(true)
+            // Match ReviewTrendingCard: one “loading” node under the title instead of silent placeholder chrome.
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(String(localized: "review.insights.loading"))
         }
     }
 }


### PR DESCRIPTION
## Headline

The Review “Most recurring” loading placeholder now tells assistive tech it is loading, like Trending.

## User impact

VoiceOver and other assistive technologies no longer land on a silent, hidden block while insights load. Users hear a clear “loading” label instead of placeholder bars that were fully removed from the accessibility tree.

## What changed

The loading skeleton for the Most recurring card used to hide its animated placeholder bars from accessibility, which could make the section feel empty or stuck while data was still fetching.

That behavior is now aligned with the Trending insights card: the placeholder group is exposed as a single accessibility element with the standard loading label, so the panel title stays meaningful and the content area has an explicit loading state rather than disappearing from the tree.

## Verification

On a Mac with Xcode, run `grace ci` (or `grace test` with the project’s usual simulator destination). In the Review flow, trigger the Most recurring card’s loading state and confirm with VoiceOver that the skeleton area speaks the localized loading label and does not expose individual placeholder bars.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
