### PR TITLE
Harden journal theme locale resolver thresholds and Latin tie-break

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/ReviewJournalThemeLanguageResolver.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ReviewJournalThemeLanguageResolver.swift
@@ -14,8 +14,12 @@ struct ReviewJournalThemeLanguageResolver: ReviewJournalThemeLanguageResolving {
     private let confidenceThreshold: Double
 
     init(minimumMeaningfulGraphemes: Int = 24, confidenceThreshold: Double = 0.55) {
-        self.minimumMeaningfulGraphemes = minimumMeaningfulGraphemes
-        self.confidenceThreshold = confidenceThreshold
+        self.minimumMeaningfulGraphemes = max(0, minimumMeaningfulGraphemes)
+        if confidenceThreshold.isNaN {
+            self.confidenceThreshold = 0.55
+        } else {
+            self.confidenceThreshold = min(max(confidenceThreshold, 0), 1)
+        }
     }
 
     func resolvedDisplayLocale(forJournalCorpus corpus: String) -> Locale {
@@ -55,6 +59,7 @@ struct ReviewJournalThemeLanguageResolver: ReviewJournalThemeLanguageResolving {
     }
 
     /// When hypotheses are ambiguous, count Han vs Latin letters and pick a side. Equal counts → English.
+    /// Latin includes common accented letters (Latin-1 + Extended-A) so tie-break matches mixed European text.
     private static func scriptTieBreakLocale(trimmed: String) -> Locale {
         var han = 0
         var latin = 0
@@ -70,7 +75,9 @@ struct ReviewJournalThemeLanguageResolver: ReviewJournalThemeLanguageResolving {
                  0x2CEB0...0x2EBEF,
                  0x2F800...0x2FA1F:
                 han += 1
-            case 0x41...0x5A, 0x61...0x7A:
+            case 0x41...0x5A, 0x61...0x7A,
+                 0x00C0...0x00D6, 0x00D8...0x00F6, 0x00F8...0x00FF,
+                 0x0100...0x017F:
                 latin += 1
             default:
                 break


### PR DESCRIPTION
## Headline

Past tab theme chips pick English vs Chinese more reliably for real-world writing and bad inputs.

## User impact

Theme chip wording on the Past tab follows your journal’s language more consistently when detection is uncertain. Accented European letters now count as Latin in the fallback, so mixed European text is less likely to skew toward Chinese. Invalid tuning values no longer produce surprising behavior.

## What changed

The resolver now sanitizes initializer inputs: the minimum meaningful grapheme count cannot go negative, and the confidence threshold is clamped to a sensible probability range, with NaN falling back to the default. When the language recognizer is not confident enough and the code falls back to comparing Han versus Latin letters, the Latin side includes common accented letters from Latin-1 and Latin Extended-A, matching how people actually write in many European languages.

## Verification

On a Mac with Xcode and the project’s grace CLI installed, run `grace ci` (or `grace test` with the project’s usual simulator destination) to confirm the GraceNotes scheme still builds and tests pass.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
