### PR TITLE
Mark CompletionBadgeInfo as Sendable for concurrency safety

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/CompletionBadgeInfo.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/CompletionBadgeInfo.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-enum CompletionBadgeInfo: Equatable {
+enum CompletionBadgeInfo: Equatable, Sendable {
     case empty
     case started
     case growing


### PR DESCRIPTION
## Headline

Keeps the journal growth-stage badge model aligned with Swift’s strict concurrency rules without changing what people see.

## User impact

There is no change to on-screen copy, colors, or when each growth stage appears. The update is about compile-time safety: the badge state type is explicitly shareable across concurrency boundaries, which helps prevent subtle Swift 6 isolation issues as related UI code evolves.

## What changed

The CompletionBadgeInfo enum already represented a small, fixed set of growth stages with localized titles and guidance. The only behavioral change is declaring Sendable conformance alongside Equatable so the compiler treats this plain enum as safe to pass where Sendable is required or inferred. No strings, palette logic, or mapping between completion levels were modified.

## Verification

On a Mac with Xcode and the iOS Simulator installed, from the repository root run `grace ci` (or `grace test` using the project’s default destination in `gracenotes-dev.toml`) to confirm a clean build and tests.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
