### PR TITLE
Harden share card default theme and simplify redaction toggles

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/ShareCardDraft.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ShareCardDraft.swift
@@ -60,10 +60,14 @@ struct ShareCardDraft: Equatable, Sendable {
     }
 
     /// Bloom forces light app chrome; otherwise use the system interface style (matches share composer sheet).
+    /// `UITraitCollection.current` is main-thread-only; off the main thread we default to the light card.
     private static func defaultShareCardUsesDarkThemeForCurrentAppAppearance() -> Bool {
         let raw = UserDefaults.standard.string(forKey: JournalAppearanceStorageKeys.todayMode)
             ?? JournalAppearanceMode.standard.rawValue
         if JournalAppearanceMode.resolveStored(rawValue: raw) == .bloom {
+            return false
+        }
+        guard Thread.isMainThread else {
             return false
         }
         return UITraitCollection.current.userInterfaceStyle == .dark
@@ -107,35 +111,15 @@ struct ShareCardDraft: Equatable, Sendable {
     mutating func toggleRedaction(for identity: ShareLineIdentity) {
         switch identity {
         case .gratitude(let index):
-            if redactedGratitudeIndices.contains(index) {
-                redactedGratitudeIndices.remove(index)
-            } else {
-                redactedGratitudeIndices.insert(index)
-            }
+            redactedGratitudeIndices.formSymmetricDifference([index])
         case .need(let index):
-            if redactedNeedIndices.contains(index) {
-                redactedNeedIndices.remove(index)
-            } else {
-                redactedNeedIndices.insert(index)
-            }
+            redactedNeedIndices.formSymmetricDifference([index])
         case .person(let index):
-            if redactedPersonIndices.contains(index) {
-                redactedPersonIndices.remove(index)
-            } else {
-                redactedPersonIndices.insert(index)
-            }
+            redactedPersonIndices.formSymmetricDifference([index])
         case .readingLine(let index):
-            if redactedReadingLineIndices.contains(index) {
-                redactedReadingLineIndices.remove(index)
-            } else {
-                redactedReadingLineIndices.insert(index)
-            }
+            redactedReadingLineIndices.formSymmetricDifference([index])
         case .reflectionLine(let index):
-            if redactedReflectionLineIndices.contains(index) {
-                redactedReflectionLineIndices.remove(index)
-            } else {
-                redactedReflectionLineIndices.insert(index)
-            }
+            redactedReflectionLineIndices.formSymmetricDifference([index])
         }
     }
 }


### PR DESCRIPTION
## Headline

Share cards pick a safe default light theme when appearance cannot be read on the main thread, and line redaction toggles stay clearer.

## User impact

Reading the system interface style off the main thread is not reliable and can cause subtle crashes or inconsistent defaults when the share draft is created in the background. Defaulting to the light card in that case keeps sharing stable and predictable. The redaction toggle behavior is unchanged; it is just expressed in a simpler way that is easier to maintain.

## What changed

The code that chooses whether a new share card starts in dark mode now documents that the current trait collection is main-thread-only. If the initializer runs off the main thread, it skips that read and defaults to the light card palette instead of consulting the current interface style.

Toggling redaction for gratitudes, needs, people, reading lines, and reflection lines now flips membership with a single set operation per section instead of separate insert and remove branches, without changing which lines end up redacted.

## Verification

On a Mac with Xcode, run `grace ci` from the repo root (or `grace test` with the project’s default simulator destination) to lint and build the GraceNotes scheme. Optionally open the journal share flow in the simulator and confirm the default card theme still matches the app appearance on the main thread, including Bloom as light.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
