### PR TITLE
Harden entry-row tap debounce for same-row repeats

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/EntryRowTapDebounce.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/EntryRowTapDebounce.swift
@@ -13,13 +13,22 @@ enum EntryRowTapDebounce {
         lastAcceptedDate: inout Date?,
         interval: TimeInterval
     ) -> Bool {
-        if let priorID = lastAcceptedItemID,
-           let priorDate = lastAcceptedDate,
-           priorID == itemID,
-           date >= priorDate,
-           date.timeIntervalSince(priorDate) < interval {
+        let window = max(0, interval)
+
+        guard let priorID = lastAcceptedItemID,
+              let priorDate = lastAcceptedDate,
+              priorID == itemID,
+              date >= priorDate
+        else {
+            lastAcceptedItemID = itemID
+            lastAcceptedDate = date
+            return true
+        }
+
+        if date.timeIntervalSince(priorDate) < window {
             return false
         }
+
         lastAcceptedItemID = itemID
         lastAcceptedDate = date
         return true


### PR DESCRIPTION
## Headline

Journal sentence rows ignore only true rapid repeats on the same entry, with clearer rules and safer timing.

## User impact

Tapping a sentence row should feel predictable: repeated taps on the same line in a short window are still dropped so focus and editing work do not stack or fight each other. The logic is easier to reason about and misconfigured or edge-case timing values are less likely to behave oddly.

## What changed

The same-row debounce helper was restructured so the code first decides whether this tap continues the same entry with a sane timeline, then applies the ignore window only in that case. When you switch rows, have no prior tap, or the tap time does not match the “same row, forward in time” path, the tap is accepted and the remembered row and time update as before. The debounce window now uses the interval clamped to at least zero, so a negative interval cannot create a confusing window.

## Verification

On a Mac with Xcode and the iOS Simulator, run `grace ci` (or `grace test` with your usual destination) to confirm the project still builds and tests pass.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
