### PR TITLE
Clamp insight loading placeholder bars to container width

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewInsightThemeCardSupport+Loading.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewInsightThemeCardSupport+Loading.swift
@@ -10,7 +10,10 @@ struct InsightsPlaceholderBar: View {
     var body: some View {
         GeometryReader { geo in
             let fraction = min(1, max(0, widthFraction))
-            let lineWidth = max(geo.size.width * fraction, height * 2)
+            let availableWidth = max(0, geo.size.width)
+            let desiredWidth = availableWidth * fraction
+            // Keep a minimum visual width when there is room, but never exceed the container (narrow layouts).
+            let lineWidth = min(max(desiredWidth, height * 2), availableWidth)
             RoundedRectangle(cornerRadius: height * 0.42, style: .continuous)
                 .fill(AppTheme.reviewTextMuted.opacity(0.10))
                 .frame(width: lineWidth, height: height, alignment: .leading)


### PR DESCRIPTION
## Headline

Review insight loading skeletons no longer overflow narrow layouts.

## User impact

On small widths or split-screen layouts, skeleton bars for review insights could render wider than the card, causing clipping or awkward overflow. The bars now stay within the available space while still using a sensible minimum width when there is room.

## What changed

The loading placeholder bar width logic was updated so the bar is computed from the geometry’s available width and the requested fraction, then clamped between a minimum size (for visibility) and the container width. Previously the minimum width could exceed the container on narrow layouts. A short comment documents why the bar is capped.

## Verification

On a Mac with Xcode, run `grace ci` (or `grace test` with the project’s default simulator destination) to lint and build; open the review insights flow on a narrow device or split view and confirm loading skeleton bars stay inside the card.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
