### PR TITLE
Clarify journal unlock feedback logic and simplify the surface view

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/JournalUnlockFeedback.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/JournalUnlockFeedback.swift
@@ -35,19 +35,18 @@ enum JournalUnlockFeedbackMessage {
         case .firstFull:
             return String(localized: "journal.guidance.firstBloomDay")
         case .none:
-            break
-        }
-        switch level {
-        case .soil:
-            return ""
-        case .sprout:
-            return String(localized: "journal.guidance.reachedSproutToday")
-        case .twig:
-            return String(localized: "journal.guidance.towardLeafShort")
-        case .leaf:
-            return String(localized: "journal.guidance.reachedLeafToday")
-        case .bloom:
-            return String(localized: "journal.guidance.reachedBloomToday")
+            switch level {
+            case .soil:
+                return ""
+            case .sprout:
+                return String(localized: "journal.guidance.reachedSproutToday")
+            case .twig:
+                return String(localized: "journal.guidance.towardLeafShort")
+            case .leaf:
+                return String(localized: "journal.guidance.reachedLeafToday")
+            case .bloom:
+                return String(localized: "journal.guidance.reachedBloomToday")
+            }
         }
     }
 }
@@ -60,22 +59,17 @@ struct JournalUnlockFeedbackSurface: View {
     let level: JournalCompletionLevel
     var milestoneHighlight: JournalUnlockMilestoneHighlight = .none
 
-    private var message: String {
-        JournalUnlockFeedbackMessage.message(for: level, milestone: milestoneHighlight)
-    }
-
     var body: some View {
-        Group {
-            if message.isEmpty {
-                EmptyView()
-            } else {
-                content
-            }
+        let text = JournalUnlockFeedbackMessage.message(for: level, milestone: milestoneHighlight)
+        if text.isEmpty {
+            EmptyView()
+        } else {
+            content(text: text)
         }
     }
 
-    private var content: some View {
-        Text(message)
+    private func content(text: String) -> some View {
+        Text(text)
             .font(AppTheme.warmPaperBody)
             .foregroundStyle(palette.textPrimary)
             .multilineTextAlignment(.leading)
@@ -108,9 +102,7 @@ struct JournalUnlockFeedbackSurface: View {
             return palette.border
         case .sprout:
             return palette.quickCheckInBorder
-        case .twig:
-            return palette.standardBorder
-        case .leaf:
+        case .twig, .leaf:
             return palette.standardBorder
         case .bloom:
             return palette.fullBorder
@@ -123,9 +115,7 @@ struct JournalUnlockFeedbackSurface: View {
             return .clear
         case .sprout:
             return palette.quickCheckInGlow
-        case .twig:
-            return palette.standardGlow
-        case .leaf:
+        case .twig, .leaf:
             return palette.standardGlow
         case .bloom:
             return palette.fullGlow


### PR DESCRIPTION
## Headline

Clearer milestone-vs-tier messaging and a leaner unlock banner implementation.

## User impact

Journal unlock encouragement should read the same in the UI, with logic that is easier to reason about and maintain. Computing the banner text once per update avoids redundant work when SwiftUI rebuilds the surface.

## What changed

The milestone message switch now nests the completion-level guidance under the “no special milestone” case, so tier-based copy is clearly tied to that path instead of relying on a break followed by a second switch.

The unlock feedback surface drops the extra computed property and `Group` wrapper: it resolves the message once in `body`, shows nothing when the string is empty, and passes the text into a small `content` helper for the styled card.

Border and shadow color switches combine twig and leaf into single cases where the colors already matched, reducing duplication without changing appearance.

## Verification

On a Mac with Xcode 26+, run `grace ci` (or `grace test`) from the repo root to lint and build against the project’s configured simulator destinations; exercise the journal screen with unlock feedback visible to confirm the banner still appears and reads correctly for milestone and non-milestone states.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
