### PR TITLE
Prevent duplicate share taps in the journal share composer

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/JournalShareComposerView.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/JournalShareComposerView.swift
@@ -11,6 +11,7 @@ struct JournalShareComposerView: View {
     private var journalTodayAppearanceRaw = JournalAppearanceMode.standard.rawValue
     @State private var draft: ShareCardDraft
     @State private var showRenderError = false
+    @State private var isShareCommitInProgress = false
 
     /// Bloom matches main tab chrome (forced light); otherwise inherit system light/dark like the rest of the app.
     private var appPreferredColorScheme: ColorScheme? {
@@ -57,6 +58,7 @@ struct JournalShareComposerView: View {
                         commitShare()
                     }
                     .fontWeight(.semibold)
+                    .disabled(isShareCommitInProgress)
                     .accessibilityIdentifier("ShareComposerConfirm")
                 }
             }
@@ -198,6 +200,10 @@ struct JournalShareComposerView: View {
     }
 
     private func commitShare() {
+        guard !isShareCommitInProgress else { return }
+        isShareCommitInProgress = true
+        defer { isShareCommitInProgress = false }
+
         let built = ShareRenderPayloadBuilder.build(
             full: basePayload,
             draft: draft,


### PR DESCRIPTION
## Headline

Share waits for the export image to finish so impatient double taps cannot pile up work.

## User impact

Tapping Share more than once while the card image is rendering could queue overlapping export work, waste CPU and memory, and confuse the share flow. The composer now treats Share as a single in-flight action so users get predictable behavior when they tap repeatedly.

## What changed

The share composer tracks whether a share is already being committed. While that work runs, the Share button is disabled so the UI does not accept another tap. The commit path also returns immediately if a share is already in progress, so the renderer cannot be invoked reentrantly from rapid taps. The in-progress flag is cleared when the commit finishes, including when rendering fails and the error alert is shown.

## Verification

On a Mac with Xcode, run `grace ci` (or `grace test` with the project’s default simulator destination). In the app, open the journal share composer and tap Share several times in quick succession; only one share/export cycle should run and the button should stay inactive until rendering completes.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
