### PR TITLE
Fix settings highlight stealing taps and tighten highlight padding

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/SettingsTargetHighlightModifier.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/SettingsTargetHighlightModifier.swift
@@ -5,18 +5,19 @@ struct SettingsTargetHighlightModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .padding(.horizontal, isHighlighted ? AppTheme.spacingTight : 0)
-            .padding(.vertical, isHighlighted ? AppTheme.spacingTight : 0)
+            .padding(isHighlighted ? AppTheme.spacingTight : 0)
             .background {
                 if isHighlighted {
                     RoundedRectangle(cornerRadius: AppTheme.cornerRadiusMedium)
                         .fill(AppTheme.journalPaper.opacity(0.82))
+                        .allowsHitTesting(false)
                 }
             }
             .overlay {
                 if isHighlighted {
                     RoundedRectangle(cornerRadius: AppTheme.cornerRadiusMedium)
-                        .stroke(AppTheme.accent, lineWidth: 1)
+                        .strokeBorder(AppTheme.accent, lineWidth: 1)
+                        .allowsHitTesting(false)
                 }
             }
     }


### PR DESCRIPTION
## Headline

Settings row highlights no longer block taps, with clearer stroke and simpler padding.

## User impact

When a settings row is visually highlighted (for example during onboarding or focus), taps and gestures should still reach the real controls underneath. Previously, the decorative background and border could intercept touches and make the row feel unresponsive. The highlight should look the same to users while behaving reliably when they tap.

## What changed

The highlight modifier now applies uniform padding in one step instead of separate horizontal and vertical padding, with no intended visual change. The filled background and accent outline are marked so they do not participate in hit testing, so touches pass through the decoration to the interactive content. The outline uses an inside-aligned stroke so the border renders more predictably at the rounded corners.

## Verification

On a Mac with Xcode and the project’s grace CLI, run `grace ci` (or `grace test` if that matches your usual review). In Settings, trigger a highlighted row and confirm you can still tap switches, buttons, and navigation as expected while the highlight appears.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
