### PR TITLE
Trim unlock feedback text and simplify journal unlock card shadows

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/JournalUnlockFeedback.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/JournalUnlockFeedback.swift
@@ -60,7 +60,8 @@ struct JournalUnlockFeedbackSurface: View {
     var milestoneHighlight: JournalUnlockMilestoneHighlight = .none
 
     var body: some View {
-        let text = JournalUnlockFeedbackMessage.message(for: level, milestone: milestoneHighlight)
+        let raw = JournalUnlockFeedbackMessage.message(for: level, milestone: milestoneHighlight)
+        let text = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         if text.isEmpty {
             EmptyView()
         } else {
@@ -109,23 +110,16 @@ struct JournalUnlockFeedbackSurface: View {
         }
     }
 
-    private var shadowTint: Color {
+    private var shadowColor: Color {
         switch level {
         case .soil:
-            return .clear
-        case .sprout:
-            return palette.quickCheckInGlow
-        case .twig, .leaf:
-            return palette.standardGlow
-        case .bloom:
-            return palette.fullGlow
-        }
-    }
-
-    private var shadowColor: Color {
-        if shadowTint == .clear {
             return Color.black.opacity(0.12)
+        case .sprout:
+            return palette.quickCheckInGlow.opacity(0.18)
+        case .twig, .leaf:
+            return palette.standardGlow.opacity(0.18)
+        case .bloom:
+            return palette.fullGlow.opacity(0.18)
         }
-        return shadowTint.opacity(0.18)
     }
 }


### PR DESCRIPTION
## Headline

Journal completion feedback treats whitespace-only copy as empty and uses clearer per-tier shadow colors.

## User impact

If a localized string is only spaces or newlines, the app no longer shows a confusing empty-looking encouragement card. Shadow styling for the unlock card stays predictable across completion tiers without fragile color comparisons.

## What changed

Unlock feedback now trims leading and trailing whitespace and newlines from the message before deciding whether to show the surface, so invisible-only strings behave like empty copy.

Shadow color is computed in one place: the soil tier keeps a subtle black shadow, and sprout through bloom use the matching glow token at a fixed opacity, replacing the old split between a tint color and a second step that special-cased clear.

## Verification

On a Mac with Xcode and the iOS Simulator, run `grace ci` from the repo root (or `grace test` with the project’s default destination) to confirm SwiftLint and the simulator build pass.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
