### PR TITLE
Identify App Tour path rows by growth stage, not list index

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Tutorial/AppTourView.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Tutorial/AppTourView.swift
@@ -261,17 +261,17 @@ struct AppTourPathStrip: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            ForEach(Array(Self.orderedLevels.enumerated()), id: \.offset) { index, level in
+            ForEach(Array(Self.orderedLevels.enumerated()), id: \.element) { pair in
                 AppTourPathStepRow(
-                    index: index,
+                    index: pair.offset,
                     stepCount: Self.orderedLevels.count,
-                    title: displayName(for: level),
+                    title: displayName(for: pair.element),
                     titleSystemImage: "",
-                    criterionText: criterion(for: level),
-                    isHighlighted: level == highlightedLevel,
-                    dotFill: dotFill(for: level),
-                    dotBorder: dotBorder(for: level),
-                    dotStrokeWidth: level == highlightedLevel ? 2 : 1,
+                    criterionText: criterion(for: pair.element),
+                    isHighlighted: pair.element == highlightedLevel,
+                    dotFill: dotFill(for: pair.element),
+                    dotBorder: dotBorder(for: pair.element),
+                    dotStrokeWidth: pair.element == highlightedLevel ? 2 : 1,
                     pathSpineStroke: pathSpineStroke
                 )
             }


### PR DESCRIPTION
## Headline

The journaling path preview in App Tour now keys each step by its growth stage so SwiftUI tracks the right row.

## User impact

When SwiftUI only used the row’s position as its identity, updates could reuse the wrong row or make highlights and layout feel off as state changed. Keying rows by the actual completion level keeps each step stable and predictable as you move through the tour.

## What changed

In the App Tour path strip, the list of growth stages is still shown in a fixed order, but the ForEach now uses each journal completion level as the row’s identity instead of the enumerated index. Row content still uses the same index for ordering and connectors; only how SwiftUI distinguishes one row from another changed.

## Verification

On a Mac with Xcode and the iOS Simulator, run `grace ci` (or `grace test` with the project’s default destination) and open the App Tour path page to confirm the growth path list renders and highlights correctly.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
