### PR TITLE
Normalize marketing version strings in launch tracking

### DIFF
--- a/GraceNotes/GraceNotes/Application/AppLaunchVersionTracker.swift
+++ b/GraceNotes/GraceNotes/Application/AppLaunchVersionTracker.swift
@@ -17,7 +17,8 @@ enum AppLaunchVersionTracker {
         currentMarketingVersionOverride: String? = nil,
         currentBundleVersionOverride: Int? = nil
     ) {
-        let currentMarketing = currentMarketingVersionOverride ?? bundle.graceNotesMarketingVersion ?? "0"
+        let rawMarketing = currentMarketingVersionOverride ?? bundle.graceNotesMarketingVersion
+        let currentMarketing = Self.normalizedMarketingVersion(rawMarketing)
         let currentBundle = currentBundleVersionOverride ?? bundle.graceNotesBundleVersion
 
         defaults.set(currentMarketing, forKey: GraceNotesLaunchStorageKeys.lastLaunchedMarketingVersion)
@@ -31,5 +32,11 @@ enum AppLaunchVersionTracker {
     static func resetLaunchTracking(in defaults: UserDefaults = .standard) {
         defaults.removeObject(forKey: GraceNotesLaunchStorageKeys.lastLaunchedMarketingVersion)
         defaults.removeObject(forKey: GraceNotesLaunchStorageKeys.lastLaunchedBundleVersion)
+    }
+
+    /// `CFBundleShortVersionString` may be empty or whitespace in a malformed bundle; treat like a missing value.
+    private static func normalizedMarketingVersion(_ raw: String?) -> String {
+        let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? "0" : trimmed
     }
 }


### PR DESCRIPTION
## Headline

Launch tracking now treats blank or whitespace-only version strings as missing, defaulting to a safe fallback.

## User impact

If the app’s marketing version string is empty or only whitespace (for example from a misconfigured bundle), we no longer persist a meaningless blank value for support and continuity. Stored “last launched” version data stays consistent and comparable across launches.

## What changed

App launch version tracking used to take the marketing version from overrides or the bundle and fall back to "0" only when the value was nil. That meant an empty or whitespace-only `CFBundleShortVersionString` could still be saved as-is. The tracker now trims whitespace and newlines and, when nothing meaningful remains, stores "0" instead—matching how we treat a truly missing version.

## Verification

On a Mac with Xcode and the project’s `grace` CLI installed, run `grace ci` (or `grace test` with the usual simulator destination) to confirm the app builds and tests pass. Optionally sanity-check that launch tracking still runs once per process start before guided-journal migration resolution.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
