### PR TITLE
Skip global UIAppearance in hosted unit tests

### DIFF
--- a/GraceNotes/GraceNotes/Application/GraceNotesAppDelegate.swift
+++ b/GraceNotes/GraceNotes/Application/GraceNotesAppDelegate.swift
@@ -1,11 +1,18 @@
 import UIKit
 
 /// Applies global UIKit chrome after `UIApplication` launch (safer on iOS 17 than configuring from `App.init()`).
+@MainActor
 final class GraceNotesAppDelegate: NSObject, UIApplicationDelegate {
     func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
+        // Keep this aligned with `GraceNotesApp.init`: hosted unit tests use a blank root and should not
+        // mutate global `UIAppearance`; UI tests and normal launches still get chrome.
+        let isXCTestSession = ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+        if isXCTestSession, !ProcessInfo.graceNotesIsRunningUITests {
+            return true
+        }
         AppInterfaceAppearance.configure()
         return true
     }


### PR DESCRIPTION
## Headline

Unit tests no longer inherit global UIKit chrome from the app delegate.

## User impact

Hosted unit tests run with a predictable, isolated root without global appearance side effects, so tests are more reliable and less flaky. Real launches and UI tests still apply the normal app chrome, so what users see in the app is unchanged.

## What changed

The app delegate now marks its implementation as main-actor isolated for consistency with UI work. On launch it detects an XCTest session and, when those are hosted unit tests (not UI tests), it skips configuring global UIKit appearance so it stays aligned with the app’s test entry behavior and does not mutate shared UIAppearance state during unit tests. Normal runs and UI tests continue to apply interface appearance as before.

## Verification

On a Mac with Xcode and the project’s grace CLI, run `grace ci` or `grace test` to confirm lint, build, and tests pass with the updated delegate behavior.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
