### PR TITLE
Normalize CloudKit snapshot flags on disk launch

### DIFF
--- a/GraceNotes/GraceNotes/Data/Persistence/SwiftData/PersistenceRuntimeSnapshot.swift
+++ b/GraceNotes/GraceNotes/Data/Persistence/SwiftData/PersistenceRuntimeSnapshot.swift
@@ -29,10 +29,14 @@ struct PersistenceRuntimeSnapshot: Equatable, Sendable {
         storeUsesCloudKit: Bool,
         startupUsedCloudKitFallback: Bool
     ) -> PersistenceRuntimeSnapshot {
-        PersistenceRuntimeSnapshot(
+        // A CloudKit-backed store and a startup fallback cannot both be true; callers (or tests) can
+        // accidentally pass both, which would confuse settings copy and `isJournalOnCloudKitStore`.
+        let effectiveStoreUsesCloudKit = startupUsedCloudKitFallback ? false : storeUsesCloudKit
+        let effectiveFallback = effectiveStoreUsesCloudKit ? false : startupUsedCloudKitFallback
+        return PersistenceRuntimeSnapshot(
             userRequestedCloudSync: userRequestedCloudSync,
-            storeUsesCloudKit: storeUsesCloudKit,
-            startupUsedCloudKitFallback: startupUsedCloudKitFallback
+            storeUsesCloudKit: effectiveStoreUsesCloudKit,
+            startupUsedCloudKitFallback: effectiveFallback
         )
     }
 }


### PR DESCRIPTION
## Headline

Settings and cloud status stay consistent when startup flags disagree.

## User impact

Users see accurate sync and storage messaging in Settings instead of contradictory states. Reliability improves because journal-on-CloudKit detection and related copy no longer reflect an impossible combination of flags.

## What changed

Disk launch now builds the runtime snapshot so “using the CloudKit store” and “fell back to local after a cloud open failure” cannot both be true. If a fallback is recorded, the snapshot treats the store as non-CloudKit; if the store is CloudKit, any fallback flag is cleared. A short comment documents why this normalization exists for callers and tests.

## Verification

On a Mac with Xcode and the project’s grace CLI, run `grace ci` (or `grace test` with the usual simulator destination from gracenotes-dev.toml). Optionally spot-check Settings copy and any UI that depends on journal-on-CloudKit state after scenarios that exercise cloud open and fallback.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
