### PR TITLE
Fix reminder time updates queued during enable and harden async flow

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/ReminderSettingsFlowModel.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/ReminderSettingsFlowModel.swift
@@ -57,25 +57,23 @@ final class ReminderSettingsFlowModel: ObservableObject {
     }
 
     func enableReminders() async {
-        guard !isWorking else { return }
-        isWorking = true
-        defer { isWorking = false }
-
-        transientErrorMessage = nil
-        let result = await reminderScheduler.enableDailyReminder(at: selectedTime, body: resolvedReminderBody())
-        switch result {
-        case .scheduled:
-            persistSelectedTime()
-            await refreshStatus()
-        case .permissionDenied:
-            liveStatus = .denied
-        case .failed:
-            liveStatus = .unavailable
-            transientErrorMessage = String(
-                localized: "notifications.reminder.scheduleFailed"
-            )
-        case .disabled:
-            await refreshStatus()
+        await runWithWorking {
+            transientErrorMessage = nil
+            let result = await reminderScheduler.enableDailyReminder(at: selectedTime, body: resolvedReminderBody())
+            switch result {
+            case .scheduled:
+                persistSelectedTime()
+                await refreshStatus()
+            case .permissionDenied:
+                liveStatus = .denied
+            case .failed:
+                liveStatus = .unavailable
+                transientErrorMessage = String(
+                    localized: "notifications.reminder.scheduleFailed"
+                )
+            case .disabled:
+                await refreshStatus()
+            }
         }
     }
 
@@ -84,6 +82,7 @@ final class ReminderSettingsFlowModel: ObservableObject {
         isWorking = true
         defer { isWorking = false }
         pendingRescheduleTask?.cancel()
+        pendingRescheduleAfterCurrentSave = false
 
         transientErrorMessage = nil
         _ = await reminderScheduler.disableDailyReminder()
@@ -145,7 +144,7 @@ final class ReminderSettingsFlowModel: ObservableObject {
     func handleSelectedTimeChanged() {
         guard hasLoadedLiveStatus, liveStatus == .enabled else { return }
         pendingRescheduleTask?.cancel()
-        pendingRescheduleTask = Task { [weak self] in
+        pendingRescheduleTask = Task { @MainActor [weak self] in
             do {
                 try await Task.sleep(nanoseconds: 400_000_000)
                 guard !Task.isCancelled else { return }
@@ -154,6 +153,22 @@ final class ReminderSettingsFlowModel: ObservableObject {
                 // Ignore cancellation from rapid picker updates.
             }
         }
+    }
+
+    private func runWithWorking(_ work: () async -> Void) async {
+        guard !isWorking else { return }
+        isWorking = true
+        await work()
+        isWorking = false
+        await drainPendingRescheduleIfNeeded()
+    }
+
+    /// Runs a deferred time save after `isWorking` drops (picker updates coalesced during enable).
+    private func drainPendingRescheduleIfNeeded() async {
+        guard pendingRescheduleAfterCurrentSave else { return }
+        pendingRescheduleAfterCurrentSave = false
+        guard liveStatus == .enabled else { return }
+        await saveEnabledReminderTime()
     }
 
     private func resolvedReminderBody() -> String {


### PR DESCRIPTION
## Headline

Daily reminder scheduling now finishes coalesced time changes after enabling, with clearer main-thread handling.

## User impact

Changing the time while reminders are turning on could leave the scheduled notification out of sync with what you picked. Turning reminders off could also leave a stale “save later” flag around. This update drains deferred saves after the enable finishes, clears that flag on disable, and runs the debounced picker task explicitly on the main actor.

## What changed

Reminder enable used a simple busy flag with defer, which dropped the flag before any work that was intentionally deferred while another operation held “working.” That meant time-picker updates that set “reschedule after save” during enable might never run afterward. Enable now goes through a shared helper that awaits the enable work, clears the busy state, then runs any pending reschedule if reminders ended up enabled.

Disabling reminders now resets the pending-reschedule flag so a later stray save does not reschedule after you turned notifications off.

The debounced time-change task is marked to run on the main actor so follow-up saves stay aligned with UI state updates.

## Verification

On a Mac with Xcode, run `grace ci` (or `grace test` with the project’s default simulator destination). Manually: enable daily reminders, adjust the time while the toggle/enable path is in progress, and confirm the notification time matches the final selection; disable reminders and confirm no unexpected reschedule occurs.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
