### PR TITLE
Fix Simplified Chinese locale detection for LLM instructions

### DIFF
--- a/GraceNotes/GraceNotes/Application/AppInstructionLocale.swift
+++ b/GraceNotes/GraceNotes/Application/AppInstructionLocale.swift
@@ -11,9 +11,16 @@ enum AppInstructionLocale: Equatable, Sendable {
         guard let preferred = bundle.preferredLocalizations.first else {
             return .english
         }
-        if preferred == "zh-Hans" || preferred.hasPrefix("zh-Hans") {
+        if isSimplifiedChineseUIIdentifier(preferred) {
             return .simplifiedChinese
         }
         return .english
+    }
+
+    /// BCP 47 tags are case-insensitive; `Bundle` may return `zh-Hans` or `zh-hans`.
+    /// Require `zh-Hans` as a full tag or as the language-script prefix before the next subtag (`zh-Hans-CN`, …), not `zh-Hant`.
+    private static func isSimplifiedChineseUIIdentifier(_ identifier: String) -> Bool {
+        let tag = identifier.lowercased()
+        return tag == "zh-hans" || tag.hasPrefix("zh-hans-")
     }
 }


### PR DESCRIPTION
## Headline

Review insights and other cloud LLM prompts follow the UI language reliably for Simplified Chinese.

## User impact

When the system or bundle reports the Chinese UI locale with different capitalization (for example lowercase script subtags), the app can wrongly pick English for instruction prompts. After this change, Simplified Chinese is chosen consistently, so insights and instructions match the language you use in the rest of the interface.

## What changed

Locale detection for which language to use for cloud LLM instructions (not on-screen strings) no longer depends on exact capitalization. The logic now treats BCP 47 tags as case-insensitive and only treats the locale as Simplified Chinese when the tag is exactly Simplified Chinese or clearly continues as Simplified Chinese (for example region variants), so it does not rely on fragile string prefix rules that could disagree with how the system reports locales.

## Verification

On a Mac with Xcode and the project’s grace CLI installed, run `grace ci` from the repo root (or `grace test` with the usual simulator destination) to confirm the project still builds and tests pass.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
