### PR TITLE
Default persistence snapshot to local-only when environment is missing

### DIFF
--- a/GraceNotes/GraceNotes/Application/PersistenceRuntimeSnapshotEnvironment.swift
+++ b/GraceNotes/GraceNotes/Application/PersistenceRuntimeSnapshotEnvironment.swift
@@ -1,7 +1,9 @@
 import SwiftUI
 
+/// Fallback when the app root does not inject `PersistenceController.runtimeSnapshot`.
+/// Prefer local-only semantics so privacy and iCloud copy never assume CloudKit from a missing injection.
 private struct PersistenceRuntimeSnapshotKey: EnvironmentKey {
-    static let defaultValue = PersistenceRuntimeSnapshot.previewPlaceholder
+    static let defaultValue = PersistenceRuntimeSnapshot.forInMemory(userRequestedCloudSync: false)
 }
 
 extension EnvironmentValues {


### PR DESCRIPTION
## Headline

Prevents accidental CloudKit assumptions when the runtime snapshot is not injected at the app root.

## User impact

If something ever renders without the proper persistence snapshot, the app now treats storage as local-only instead of mirroring preview or sync assumptions. That reduces the risk of misleading privacy messaging or iCloud-related copy when CloudKit was not actually requested.

## What changed

The SwiftUI environment key’s default value for the persistence runtime snapshot no longer uses the preview placeholder. It now uses an in-memory snapshot with user-requested cloud sync turned off, so the implicit fallback matches local-only behavior. A brief comment documents that this default exists for missing injection at the app root and why local-only semantics matter for privacy and cloud-related UI.

## Verification

On a Mac with Xcode and the project’s grace CLI, run `grace ci` (or `grace test` with the usual simulator destination) to confirm the app still builds and tests pass.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
