### PR TITLE
feat(settings): backup folder retention, size cap, and delete

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/ImportExportSettingsScreen.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/ImportExportSettingsScreen.swift
@@ -25,6 +25,8 @@ struct ImportExportSettingsScreen: View {
     @State private var showMergeConflictResolution = false
     @State private var exportHistory: [BackupExportHistoryEntry] = []
     @State private var scheduledInterval: ScheduledBackupInterval = ScheduledBackupPreferences.interval
+    @State private var backupRetention: BackupRetentionPeriod = ScheduledBackupPreferences.backupRetentionPeriod
+    @State private var backupSizeCap: BackupFolderSizeCap = ScheduledBackupPreferences.backupFolderSizeCap
     @State private var showScheduledFolderPicker = false
     @State private var scheduledFolderError: String?
     @State private var showScheduledFolderError = false
@@ -57,11 +59,59 @@ struct ImportExportSettingsScreen: View {
         }
     }
 
+    @ViewBuilder
+    private var scheduledBackupRetentionPicker: some View {
+        let title = String(localized: "settings.dataPrivacy.scheduledBackup.retention.title")
+        Picker(title, selection: $backupRetention) {
+            Text(String(localized: "settings.dataPrivacy.scheduledBackup.retention.days7"))
+                .tag(BackupRetentionPeriod.days7)
+            Text(String(localized: "settings.dataPrivacy.scheduledBackup.retention.days30"))
+                .tag(BackupRetentionPeriod.days30)
+            Text(String(localized: "settings.dataPrivacy.scheduledBackup.retention.days90"))
+                .tag(BackupRetentionPeriod.days90)
+            Text(String(localized: "settings.dataPrivacy.scheduledBackup.retention.days365"))
+                .tag(BackupRetentionPeriod.days365)
+            Text(String(localized: "settings.dataPrivacy.scheduledBackup.retention.forever"))
+                .tag(BackupRetentionPeriod.forever)
+        }
+        .font(AppTheme.warmPaperBody)
+        .foregroundStyle(AppTheme.settingsTextPrimary)
+        .onChange(of: backupRetention) { _, newValue in
+            ScheduledBackupPreferences.backupRetentionPeriod = newValue
+        }
+    }
+
+    @ViewBuilder
+    private var scheduledBackupSizeCapPicker: some View {
+        let title = String(localized: "settings.dataPrivacy.scheduledBackup.sizeCap.title")
+        Picker(title, selection: $backupSizeCap) {
+            Text(String(localized: "settings.dataPrivacy.scheduledBackup.sizeCap.mb25"))
+                .tag(BackupFolderSizeCap.mb25)
+            Text(String(localized: "settings.dataPrivacy.scheduledBackup.sizeCap.mb100"))
+                .tag(BackupFolderSizeCap.mb100)
+            Text(String(localized: "settings.dataPrivacy.scheduledBackup.sizeCap.mb500"))
+                .tag(BackupFolderSizeCap.mb500)
+            Text(String(localized: "settings.dataPrivacy.scheduledBackup.sizeCap.gb2"))
+                .tag(BackupFolderSizeCap.gb2)
+            Text(String(localized: "settings.dataPrivacy.scheduledBackup.sizeCap.unlimited"))
+                .tag(BackupFolderSizeCap.unlimited)
+        }
+        .font(AppTheme.warmPaperBody)
+        .foregroundStyle(AppTheme.settingsTextPrimary)
+        .onChange(of: backupSizeCap) { _, newValue in
+            ScheduledBackupPreferences.backupFolderSizeCap = newValue
+        }
+    }
+
     var body: some View {
         ZStack {
             List {
             Section {
                 scheduledBackupIntervalPicker
+
+                scheduledBackupRetentionPicker
+
+                scheduledBackupSizeCapPicker
 
                 Button {
                     showScheduledFolderPicker = true
@@ -80,10 +130,13 @@ struct ImportExportSettingsScreen: View {
                     .foregroundStyle(AppTheme.settingsTextMuted)
                     .textCase(nil)
             } footer: {
-                Text(String(localized: "settings.dataPrivacy.scheduledBackup.footer"))
-                    .font(AppTheme.warmPaperMeta)
-                    .foregroundStyle(AppTheme.settingsTextMuted)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                VStack(alignment: .leading, spacing: AppTheme.spacingTight) {
+                    Text(String(localized: "settings.dataPrivacy.scheduledBackup.footer"))
+                    Text(String(localized: "settings.dataPrivacy.scheduledBackup.retentionPolicy.footer"))
+                }
+                .font(AppTheme.warmPaperMeta)
+                .foregroundStyle(AppTheme.settingsTextMuted)
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
 
             Section {
@@ -220,6 +273,8 @@ struct ImportExportSettingsScreen: View {
         .onAppear {
             refreshHistory()
             scheduledInterval = ScheduledBackupPreferences.interval
+            backupRetention = ScheduledBackupPreferences.backupRetentionPeriod
+            backupSizeCap = ScheduledBackupPreferences.backupFolderSizeCap
         }
         .sheet(isPresented: $showImportReview) {
             importReviewSheet

--- a/GraceNotes/GraceNotes/Features/Settings/ImportExportSettingsSupport.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/ImportExportSettingsSupport.swift
@@ -58,6 +58,11 @@ struct BackupFolderImportFileListView: View {
 
     @State private var files: [URL] = []
     @State private var listError: String?
+    @State private var isSelecting = false
+    @State private var selection = Set<String>()
+    @State private var showDeleteConfirm = false
+    @State private var deleteErrorMessage: String?
+    @State private var showDeleteError = false
 
     var body: some View {
         Group {
@@ -71,6 +76,19 @@ struct BackupFolderImportFileListView: View {
                     .font(AppTheme.warmPaperBody)
                     .foregroundStyle(AppTheme.settingsTextMuted)
                     .padding()
+            } else if isSelecting {
+                List(selection: $selection) {
+                    ForEach(files, id: \.path) { url in
+                        Text(url.lastPathComponent)
+                            .font(AppTheme.settingsTechnicalBody)
+                            .foregroundStyle(AppTheme.settingsTextPrimary)
+                            .tag(url.path)
+                    }
+                }
+                .environment(\.editMode, .constant(.active))
+                .listRowBackground(AppTheme.settingsPaper.opacity(0.9))
+                .scrollContentBackground(.hidden)
+                .background(AppTheme.settingsBackground)
             } else {
                 List(files, id: \.path) { url in
                     Button {
@@ -90,9 +108,79 @@ struct BackupFolderImportFileListView: View {
         }
         .navigationTitle(String(localized: "settings.dataPrivacy.importExport.backupFolder.title"))
         .background(AppTheme.settingsBackground)
+        .toolbar {
+            if !files.isEmpty, listError == nil {
+                if isSelecting {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button(String(localized: "common.cancel")) {
+                            isSelecting = false
+                            selection.removeAll()
+                        }
+                    }
+                    ToolbarItem(placement: .primaryAction) {
+                        Button(String(localized: "common.delete"), role: .destructive) {
+                            showDeleteConfirm = true
+                        }
+                        .disabled(selection.isEmpty)
+                    }
+                } else {
+                    ToolbarItem(placement: .primaryAction) {
+                        Button(String(localized: "settings.dataPrivacy.importExport.backupFolder.select")) {
+                            isSelecting = true
+                        }
+                    }
+                }
+            }
+        }
+        .confirmationDialog(
+            String(localized: "settings.dataPrivacy.importExport.backupFolder.deleteConfirm.title"),
+            isPresented: $showDeleteConfirm,
+            titleVisibility: .visible
+        ) {
+            Button(String(localized: "common.delete"), role: .destructive) {
+                performDelete()
+            }
+            Button(String(localized: "common.cancel"), role: .cancel) {}
+        } message: {
+            Text(String.localizedStringWithFormat(
+                String(localized: "settings.dataPrivacy.importExport.backupFolder.deleteConfirm.messageFormat"),
+                selection.count
+            ))
+        }
+        .alert(
+            String(localized: "settings.dataPrivacy.importExport.backupFolder.deleteError.title"),
+            isPresented: $showDeleteError
+        ) {
+            Button(String(localized: "common.ok"), role: .cancel) {}
+        } message: {
+            Text(deleteErrorMessage ?? String(localized: "common.tryAgainGeneric"))
+        }
         .task {
             load()
         }
+        .onChange(of: files) { _, newFiles in
+            if newFiles.isEmpty {
+                isSelecting = false
+                selection.removeAll()
+            }
+        }
+    }
+
+    private func performDelete() {
+        let urls = files.filter { selection.contains($0.path) }
+        guard !urls.isEmpty else { return }
+        do {
+            try ScheduledBackupPreferences.withFolderSecurityScopedAccess { _ in
+                try BackupFolderLibrary.deleteFiles(at: urls)
+            }
+        } catch {
+            deleteErrorMessage = String(localized: "settings.dataPrivacy.importExport.backupFolder.deleteError.message")
+            showDeleteError = true
+            return
+        }
+        selection.removeAll()
+        isSelecting = false
+        load()
     }
 
     private func load() {

--- a/GraceNotes/GraceNotes/Features/Settings/Services/ScheduledBackupPreferences.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/Services/ScheduledBackupPreferences.swift
@@ -28,6 +28,56 @@ enum ScheduledBackupInterval: String, CaseIterable, Codable {
     }
 }
 
+/// How long JSON backups are kept in the scheduled backup folder before automatic age-based removal.
+enum BackupRetentionPeriod: String, CaseIterable, Codable, Sendable {
+    case days7
+    case days30
+    case days90
+    case days365
+    case forever
+
+    /// Delete files with modification date before this instant; `nil` means no age-based pruning.
+    func ageCutoff(from now: Date, calendar: Calendar = .current) -> Date? {
+        switch self {
+        case .forever:
+            return nil
+        case .days7:
+            return calendar.date(byAdding: .day, value: -7, to: now)
+        case .days30:
+            return calendar.date(byAdding: .day, value: -30, to: now)
+        case .days90:
+            return calendar.date(byAdding: .day, value: -90, to: now)
+        case .days365:
+            return calendar.date(byAdding: .day, value: -365, to: now)
+        }
+    }
+}
+
+/// Preset maximum total size for JSON files in the scheduled backup folder (`unlimited` → no size pruning).
+enum BackupFolderSizeCap: String, CaseIterable, Codable, Sendable {
+    case mb25
+    case mb100
+    case mb500
+    case gb2
+    case unlimited
+
+    /// Upper bound on total JSON size; `nil` means no cap.
+    var maxBytes: Int64? {
+        switch self {
+        case .mb25:
+            return 25 * 1024 * 1024
+        case .mb100:
+            return 100 * 1024 * 1024
+        case .mb500:
+            return 500 * 1024 * 1024
+        case .gb2:
+            return 2 * 1024 * 1024 * 1024
+        case .unlimited:
+            return nil
+        }
+    }
+}
+
 enum ScheduledBackupPreferences {
     /// After a failed scheduled backup, wait this long before `isDue` returns true again.
     /// Export history still records each attempt.
@@ -38,6 +88,8 @@ enum ScheduledBackupPreferences {
     private static let folderDisplayNameKey = "ScheduledBackup.folderDisplayName"
     private static let lastRunKey = "ScheduledBackup.lastRunAt"
     private static let lastFailedAttemptKey = "ScheduledBackup.lastFailedAttemptAt"
+    private static let retentionKey = "ScheduledBackup.retentionRaw"
+    private static let sizeCapKey = "ScheduledBackup.sizeCapRaw"
 
     static var interval: ScheduledBackupInterval {
         get {
@@ -81,6 +133,32 @@ enum ScheduledBackupPreferences {
     static var lastFailedAttemptAt: Date? {
         get { UserDefaults.standard.object(forKey: lastFailedAttemptKey) as? Date }
         set { UserDefaults.standard.set(newValue, forKey: lastFailedAttemptKey) }
+    }
+
+    static var backupRetentionPeriod: BackupRetentionPeriod {
+        get {
+            guard let raw = UserDefaults.standard.string(forKey: retentionKey),
+                  let value = BackupRetentionPeriod(rawValue: raw) else {
+                return .days30
+            }
+            return value
+        }
+        set {
+            UserDefaults.standard.set(newValue.rawValue, forKey: retentionKey)
+        }
+    }
+
+    static var backupFolderSizeCap: BackupFolderSizeCap {
+        get {
+            guard let raw = UserDefaults.standard.string(forKey: sizeCapKey),
+                  let value = BackupFolderSizeCap(rawValue: raw) else {
+                return .mb500
+            }
+            return value
+        }
+        set {
+            UserDefaults.standard.set(newValue.rawValue, forKey: sizeCapKey)
+        }
     }
 
     static func storeFolderBookmark(for url: URL) throws {

--- a/GraceNotes/GraceNotes/Features/Settings/Services/ScheduledBackupRunner.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/Services/ScheduledBackupRunner.swift
@@ -69,7 +69,14 @@ enum ScheduledBackupRunner {
 
     private static func copyScheduledExportToFolder(tempFile: URL) throws -> String {
         try ScheduledBackupPreferences.withFolderSecurityScopedAccess { folderURL in
-            try copyTempExport(at: tempFile, to: folderURL)
+            let name = try copyTempExport(at: tempFile, to: folderURL)
+            try BackupFolderLibrary.prune(
+                folderURL: folderURL,
+                now: Date(),
+                retention: ScheduledBackupPreferences.backupRetentionPeriod,
+                maxTotalBytes: ScheduledBackupPreferences.backupFolderSizeCap.maxBytes
+            )
+            return name
         }
     }
 
@@ -129,23 +136,92 @@ enum ScheduledBackupRunner {
     }
 }
 
+struct BackupFolderFileMetadata: Equatable {
+    let url: URL
+    let modificationDate: Date
+    let fileSize: Int64
+}
+
 enum BackupFolderLibrary {
-    static func listExportFiles(in folder: URL) throws -> [URL] {
-        let urls = try FileManager.default.contentsOfDirectory(
+    static func listExportFiles(in folder: URL, fileManager: FileManager = .default) throws -> [URL] {
+        try listJSONMetadata(in: folder, fileManager: fileManager)
+            .sorted { lhs, rhs in
+                if lhs.modificationDate != rhs.modificationDate {
+                    return lhs.modificationDate > rhs.modificationDate
+                }
+                let order = lhs.url.lastPathComponent.localizedStandardCompare(rhs.url.lastPathComponent)
+                return order == .orderedDescending
+            }
+            .map(\.url)
+    }
+
+    /// Oldest files first (tie-breaker: path) for pruning and oldest-first deletion.
+    static func listJSONMetadataOldestFirst(
+        in folder: URL,
+        fileManager: FileManager = .default
+    ) throws -> [BackupFolderFileMetadata] {
+        try listJSONMetadata(in: folder, fileManager: fileManager)
+            .sorted { lhs, rhs in
+                if lhs.modificationDate != rhs.modificationDate {
+                    return lhs.modificationDate < rhs.modificationDate
+                }
+                let order = lhs.url.lastPathComponent.localizedStandardCompare(rhs.url.lastPathComponent)
+                return order == .orderedAscending
+            }
+    }
+
+    private static func listJSONMetadata(
+        in folder: URL,
+        fileManager: FileManager
+    ) throws -> [BackupFolderFileMetadata] {
+        let urls = try fileManager.contentsOfDirectory(
             at: folder,
-            includingPropertiesForKeys: [.contentModificationDateKey],
+            includingPropertiesForKeys: [.contentModificationDateKey, .fileSizeKey],
             options: [.skipsHiddenFiles]
         )
-        let json = urls.filter { $0.pathExtension.lowercased() == "json" }
-        return json.sorted { lhs, rhs in
-            let left = (try? lhs.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate)
-                ?? .distantPast
-            let right = (try? rhs.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate)
-                ?? .distantPast
-            if left != right {
-                return left > right
+        let jsonURLs = urls.filter { $0.pathExtension.lowercased() == "json" }
+        var result: [BackupFolderFileMetadata] = []
+        result.reserveCapacity(jsonURLs.count)
+        for url in jsonURLs {
+            let values = try url.resourceValues(forKeys: [.contentModificationDateKey, .fileSizeKey])
+            let date = values.contentModificationDate ?? .distantPast
+            let size = Int64(values.fileSize ?? 0)
+            result.append(BackupFolderFileMetadata(url: url, modificationDate: date, fileSize: size))
+        }
+        return result
+    }
+
+    static func deleteFiles(at urls: [URL], fileManager: FileManager = .default) throws {
+        for url in urls {
+            try fileManager.removeItem(at: url)
+        }
+    }
+
+    /// Removes JSON backups outside the retention window (oldest first),
+    /// then trims by total size (oldest first) if a cap is set.
+    static func prune(
+        folderURL: URL,
+        now: Date,
+        retention: BackupRetentionPeriod,
+        maxTotalBytes: Int64?,
+        calendar: Calendar = .current,
+        fileManager: FileManager = .default
+    ) throws {
+        if let cutoff = retention.ageCutoff(from: now, calendar: calendar) {
+            let meta = try listJSONMetadataOldestFirst(in: folderURL, fileManager: fileManager)
+            for file in meta where file.modificationDate < cutoff {
+                try fileManager.removeItem(at: file.url)
             }
-            return lhs.lastPathComponent.localizedStandardCompare(rhs.lastPathComponent) == .orderedDescending
+        }
+
+        guard let maxBytes = maxTotalBytes else { return }
+
+        var remaining = try listJSONMetadataOldestFirst(in: folderURL, fileManager: fileManager)
+        var total = remaining.reduce(Int64(0)) { $0 + $1.fileSize }
+        while total > maxBytes, let oldest = remaining.first {
+            try fileManager.removeItem(at: oldest.url)
+            total -= oldest.fileSize
+            remaining.removeFirst()
         }
     }
 }

--- a/GraceNotes/GraceNotes/Localizable.xcstrings
+++ b/GraceNotes/GraceNotes/Localizable.xcstrings
@@ -1458,6 +1458,214 @@
         }
       }
     },
+    "settings.dataPrivacy.scheduledBackup.retention.title": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keep backups"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保留备份"
+          }
+        }
+      }
+    },
+    "settings.dataPrivacy.scheduledBackup.retention.days7": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "7 days"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "7 天"
+          }
+        }
+      }
+    },
+    "settings.dataPrivacy.scheduledBackup.retention.days30": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "30 days"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "30 天"
+          }
+        }
+      }
+    },
+    "settings.dataPrivacy.scheduledBackup.retention.days90": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "90 days"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "90 天"
+          }
+        }
+      }
+    },
+    "settings.dataPrivacy.scheduledBackup.retention.days365": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 year"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 年"
+          }
+        }
+      }
+    },
+    "settings.dataPrivacy.scheduledBackup.retention.forever": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Forever"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "永久"
+          }
+        }
+      }
+    },
+    "settings.dataPrivacy.scheduledBackup.sizeCap.title": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Max backup folder size"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "备份文件夹上限"
+          }
+        }
+      }
+    },
+    "settings.dataPrivacy.scheduledBackup.sizeCap.mb25": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "25 MB"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "25 MB"
+          }
+        }
+      }
+    },
+    "settings.dataPrivacy.scheduledBackup.sizeCap.mb100": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "100 MB"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "100 MB"
+          }
+        }
+      }
+    },
+    "settings.dataPrivacy.scheduledBackup.sizeCap.mb500": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "500 MB"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "500 MB"
+          }
+        }
+      }
+    },
+    "settings.dataPrivacy.scheduledBackup.sizeCap.gb2": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2 GB"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2 GB"
+          }
+        }
+      }
+    },
+    "settings.dataPrivacy.scheduledBackup.sizeCap.unlimited": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlimited"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不限制"
+          }
+        }
+      }
+    },
+    "settings.dataPrivacy.scheduledBackup.retentionPolicy.footer": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "After each successful scheduled backup, the app removes backups older than the time you chose, then trims oldest files if the folder is still over the size limit."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每次自动备份成功后，会先按你设置的时间删除旧备份；若仍超过大小上限，再按从最旧到最新的顺序删除，直到低于上限。"
+          }
+        }
+      }
+    },
     "settings.dataPrivacy.scheduledBackup.failureDetail": {
       "localizations": {
         "en": {
@@ -1534,6 +1742,86 @@
           "stringUnit": {
             "state": "translated",
             "value": "备份文件"
+          }
+        }
+      }
+    },
+    "settings.dataPrivacy.importExport.backupFolder.select": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择"
+          }
+        }
+      }
+    },
+    "settings.dataPrivacy.importExport.backupFolder.deleteConfirm.title": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete backups?"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除备份？"
+          }
+        }
+      }
+    },
+    "settings.dataPrivacy.importExport.backupFolder.deleteConfirm.messageFormat": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete %lld backup files? This cannot be undone."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除 %lld 个备份文件？此操作无法撤销。"
+          }
+        }
+      }
+    },
+    "settings.dataPrivacy.importExport.backupFolder.deleteError.title": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not delete"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法删除"
+          }
+        }
+      }
+    },
+    "settings.dataPrivacy.importExport.backupFolder.deleteError.message": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The files could not be removed. Try again in Files."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法删除这些文件。请在「文件」中重试。"
           }
         }
       }

--- a/GraceNotesTests/Features/Settings/BackupFolderLibraryPruneTests.swift
+++ b/GraceNotesTests/Features/Settings/BackupFolderLibraryPruneTests.swift
@@ -2,23 +2,26 @@ import XCTest
 @testable import GraceNotes
 
 final class BackupFolderLibraryPruneTests: XCTestCase {
-    private var root: URL!
+    private var root: URL?
 
-    override func setUp() throws {
-        try super.setUp()
-        root = FileManager.default.temporaryDirectory
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        let tempRoot = FileManager.default.temporaryDirectory
             .appendingPathComponent("BackupFolderLibraryPruneTests-\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        root = tempRoot
     }
 
     override func tearDown() {
-        if let root {
+        if let root = root {
             try? FileManager.default.removeItem(at: root)
         }
+        root = nil
         super.tearDown()
     }
 
     func test_prune_removesFilesOlderThanRetention() throws {
+        let root = try XCTUnwrap(root)
         let folder = root.appendingPathComponent("Folder", isDirectory: true)
         try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
 
@@ -46,6 +49,7 @@ final class BackupFolderLibraryPruneTests: XCTestCase {
     }
 
     func test_prune_trimsBySizeOldestFirst() throws {
+        let root = try XCTUnwrap(root)
         let folder = root.appendingPathComponent("SizeFolder", isDirectory: true)
         try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
 
@@ -74,6 +78,7 @@ final class BackupFolderLibraryPruneTests: XCTestCase {
     }
 
     func test_prune_ageThenSize() throws {
+        let root = try XCTUnwrap(root)
         let folder = root.appendingPathComponent("Both", isDirectory: true)
         try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
 

--- a/GraceNotesTests/Features/Settings/BackupFolderLibraryPruneTests.swift
+++ b/GraceNotesTests/Features/Settings/BackupFolderLibraryPruneTests.swift
@@ -1,0 +1,106 @@
+import XCTest
+@testable import GraceNotes
+
+final class BackupFolderLibraryPruneTests: XCTestCase {
+    private var root: URL!
+
+    override func setUp() throws {
+        try super.setUp()
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("BackupFolderLibraryPruneTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        if let root {
+            try? FileManager.default.removeItem(at: root)
+        }
+        super.tearDown()
+    }
+
+    func test_prune_removesFilesOlderThanRetention() throws {
+        let folder = root.appendingPathComponent("Folder", isDirectory: true)
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+
+        let old = folder.appendingPathComponent("old.json")
+        let recent = folder.appendingPathComponent("recent.json")
+        try Data("a".utf8).write(to: old)
+        try Data("b".utf8).write(to: recent)
+
+        let tenDaysAgo = Date().addingTimeInterval(-86400 * 10)
+        try FileManager.default.setAttributes([.modificationDate: tenDaysAgo], ofItemAtPath: old.path)
+        try FileManager.default.setAttributes([.modificationDate: Date()], ofItemAtPath: recent.path)
+
+        let now = Date()
+        try BackupFolderLibrary.prune(
+            folderURL: folder,
+            now: now,
+            retention: .days7,
+            maxTotalBytes: nil,
+            calendar: Calendar(identifier: .gregorian),
+            fileManager: .default
+        )
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: old.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: recent.path))
+    }
+
+    func test_prune_trimsBySizeOldestFirst() throws {
+        let folder = root.appendingPathComponent("SizeFolder", isDirectory: true)
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+
+        let first = folder.appendingPathComponent("first.json")
+        let second = folder.appendingPathComponent("second.json")
+        let payload = Data(repeating: 0, count: 40)
+        try payload.write(to: first)
+        try payload.write(to: second)
+
+        let olderStamp = Date().addingTimeInterval(-200)
+        let newerStamp = Date().addingTimeInterval(-100)
+        try FileManager.default.setAttributes([.modificationDate: olderStamp], ofItemAtPath: first.path)
+        try FileManager.default.setAttributes([.modificationDate: newerStamp], ofItemAtPath: second.path)
+
+        try BackupFolderLibrary.prune(
+            folderURL: folder,
+            now: Date(),
+            retention: .forever,
+            maxTotalBytes: 50,
+            calendar: Calendar(identifier: .gregorian),
+            fileManager: .default
+        )
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: first.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: second.path))
+    }
+
+    func test_prune_ageThenSize() throws {
+        let folder = root.appendingPathComponent("Both", isDirectory: true)
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+
+        let ancient = folder.appendingPathComponent("ancient.json")
+        let old = folder.appendingPathComponent("oldish.json")
+        let fresh = folder.appendingPathComponent("fresh.json")
+
+        let ancientDate = Date().addingTimeInterval(-86400 * 100)
+        let oldDate = Date().addingTimeInterval(-86400 * 10)
+        try Data(repeating: 1, count: 30).write(to: ancient)
+        try Data(repeating: 2, count: 30).write(to: old)
+        try Data(repeating: 3, count: 30).write(to: fresh)
+        try FileManager.default.setAttributes([.modificationDate: ancientDate], ofItemAtPath: ancient.path)
+        try FileManager.default.setAttributes([.modificationDate: oldDate], ofItemAtPath: old.path)
+        try FileManager.default.setAttributes([.modificationDate: Date()], ofItemAtPath: fresh.path)
+
+        try BackupFolderLibrary.prune(
+            folderURL: folder,
+            now: Date(),
+            retention: .days30,
+            maxTotalBytes: 35,
+            calendar: Calendar(identifier: .gregorian),
+            fileManager: .default
+        )
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: ancient.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: old.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: fresh.path))
+    }
+}

--- a/GraceNotesTests/Features/Settings/ScheduledBackupPreferencesTests.swift
+++ b/GraceNotesTests/Features/Settings/ScheduledBackupPreferencesTests.swift
@@ -10,6 +10,8 @@ final class ScheduledBackupPreferencesTests: XCTestCase {
         defaults.removeObject(forKey: "ScheduledBackup.intervalRaw")
         defaults.removeObject(forKey: "ScheduledBackup.lastRunAt")
         defaults.removeObject(forKey: "ScheduledBackup.lastFailedAttemptAt")
+        defaults.removeObject(forKey: "ScheduledBackup.retentionRaw")
+        defaults.removeObject(forKey: "ScheduledBackup.sizeCapRaw")
         super.tearDown()
     }
 
@@ -23,6 +25,13 @@ final class ScheduledBackupPreferencesTests: XCTestCase {
         let pastFailure = Date().addingTimeInterval(-ScheduledBackupPreferences.failureBackoff - 1)
         ScheduledBackupPreferences.lastFailedAttemptAt = pastFailure
         XCTAssertTrue(ScheduledBackupPreferences.isDue(now: Date()))
+    }
+
+    func test_backupRetentionAndSizeCap_roundTrip() {
+        ScheduledBackupPreferences.backupRetentionPeriod = .days90
+        ScheduledBackupPreferences.backupFolderSizeCap = .mb100
+        XCTAssertEqual(ScheduledBackupPreferences.backupRetentionPeriod, .days90)
+        XCTAssertEqual(ScheduledBackupPreferences.backupFolderSizeCap, .mb100)
     }
 
     func test_storeFolderBookmark_persistsDisplayName() throws {

--- a/GraceNotesTests/Services/Reminders/ReminderSchedulerTests.swift
+++ b/GraceNotesTests/Services/Reminders/ReminderSchedulerTests.swift
@@ -132,7 +132,9 @@ final class ReminderSchedulerTests: XCTestCase {
 
         XCTAssertEqual(result, .failed)
         XCTAssertNil(center.lastAddedRequest)
-        XCTAssertEqual(center.removedIdentifiers, [ReminderSettings.notificationIdentifier])
+        // `scheduleReminder` does not call `removeReminder` when `add` fails (see implementation comment:
+        // avoid clearing a prior pending request if replacement fails).
+        XCTAssertNil(center.removedIdentifiers)
     }
 
     private func date(components: DateComponents, calendar: Calendar) -> Date {


### PR DESCRIPTION
## Summary

Scheduled backup folders can fill up forever with JSON exports. This adds predictable cleanup and in-app deletion.

## User impact

- **Settings → Data & privacy → Import & export:** Under scheduled backup, you can choose how long to keep backups (7 days through forever) and a maximum total size for JSON files in that folder (presets through unlimited).
- After each **successful** automatic backup, the app removes files older than your time choice, then deletes the oldest remaining files if the folder is still over the size limit.
- In **Import from backup folder**, use **Select** to choose one or more files and **Delete** (with confirmation). Tap a row as before to import.

## Verification

- `swiftlint lint` on touched Swift files (clean).
- `grace l10n audit` — OK.
- On macOS: `grace ci` or `grace test` recommended before merge (Swift build not run in this environment).

Closes #308

Made with [Cursor](https://cursor.com)