### PR TITLE
Include legacy onboarding keys in iCloud sync continuity checks

### DIFF
--- a/GraceNotes/GraceNotes/Data/Persistence/SwiftData/ICloudSyncPreferenceResolver.swift
+++ b/GraceNotes/GraceNotes/Data/Persistence/SwiftData/ICloudSyncPreferenceResolver.swift
@@ -20,6 +20,20 @@ enum ICloudSyncPreferenceResolver {
         JournalOnboardingStorageKeys.openedICloudSuggestion
     ]
 
+    /// Keys that ``JournalOnboardingProgress`` migrations copy into `onboardingKeys` / `completedGuidedJournal`
+    /// after launch. `GraceNotesApp` resolves iCloud sync first; without these, upgrades from older builds can
+    /// miss continuity and default CloudKit off incorrectly.
+    private static let legacyOnboardingKeysPendingMigration = [
+        JournalOnboardingStorageKeys.legacyHasSeenPostSeedJourney,
+        LegacyJournalOnboardingContinuityKeys.pending051UpgradeOrientation
+    ]
+
+    private enum LegacyJournalOnboardingContinuityKeys {
+        /// Matches ``LegacyJournalOnboardingStorageKeys.pending051UpgradeOrientation`` in
+        /// ``JournalOnboardingProgress``.
+        static let pending051UpgradeOrientation = "journalOnboarding.pending051UpgradeOrientation"
+    }
+
     static func resolvedCloudSyncEnabled(using defaults: UserDefaults = .standard) -> Bool {
         if let storedPreference = defaults.object(forKey: PersistenceController.iCloudSyncEnabledKey) as? Bool {
             return storedPreference
@@ -43,7 +57,7 @@ enum ICloudSyncPreferenceResolver {
             return true
         }
 
-        let continuityKeys = tutorialContinuityKeys + onboardingKeys
+        let continuityKeys = tutorialContinuityKeys + onboardingKeys + legacyOnboardingKeysPendingMigration
         return continuityKeys.contains { defaults.object(forKey: $0) != nil }
     }
 }


### PR DESCRIPTION
## Headline

Upgrades from older builds keep iCloud sync on when migration-only keys prove you are an existing user.

## User impact

Some people who updated the app could have had iCloud sync turned off by mistake on first launch after upgrade, even though they had already used Grace Notes before. That could break syncing until they turned it back on. This change treats the same signals the onboarding migration uses so the default matches a real existing install.

## What changed

The resolver that picks the first-run default for iCloud when no explicit preference is stored now also looks at two legacy UserDefaults keys that onboarding migration copies in after launch. Because the app resolves iCloud before those migrations run, those keys were easy to miss when deciding whether to preserve sync for an existing user. They are now folded into the same continuity list as tutorial and onboarding keys, with a short note tying them to JournalOnboardingProgress behavior.

## Verification

On a Mac with Xcode and the project’s grace CLI installed, run `grace ci` (or `grace test` with the usual simulator destination from gracenotes-dev.toml). Manually, install an older build, exercise flows that set the legacy keys, upgrade to this build, and confirm iCloud stays enabled when expected.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
