### PR TITLE
Treat negative mention counts as stable in week-over-week trends

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/ReviewWeekTrendPolicy.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ReviewWeekTrendPolicy.swift
@@ -18,6 +18,9 @@ enum ReviewWeekTrendPolicy {
 
     /// Raw week-over-week direction from mention counts (before confidence / floors).
     static func rawTrend(current: Int, previous: Int) -> ReviewThemeTrend {
+        guard current >= 0, previous >= 0 else {
+            return .stable
+        }
         if previous == 0, current > 0 {
             return .new
         }


### PR DESCRIPTION
## Headline

Week trend badges no longer misread bad data as rising or falling.

## User impact

If mention counts ever became negative due to a bug or inconsistent data, the Review week trend could show the wrong direction (for example, “rising”). The app now treats those cases as no change so the weekly review stays trustworthy instead of noisy or misleading.

## What changed

The week-over-week trend helper that turns raw mention counts into a direction now checks that both the current and previous counts are non-negative before comparing them. When either value is negative, the policy returns a stable trend instead of applying the normal new, rising, or down rules. No other surfacing logic was changed; this only tightens the input contract for the raw trend calculation.

## Verification

On a Mac with Xcode and the project’s grace CLI installed, run `grace ci` (or `grace test` with the usual simulator destination from gracenotes-dev.toml) to confirm the app still builds and tests pass.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
