### PR TITLE
Improve Open Settings button tap target and label layout

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/SettingsOpenSystemSettingsButton.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/SettingsOpenSystemSettingsButton.swift
@@ -15,9 +15,11 @@ struct SettingsOpenSystemSettingsButton: View {
     var body: some View {
         Button(action: action) {
             Text(String(localized: "settings.openSettings"))
+                .font(AppTheme.warmPaperBody)
+                .multilineTextAlignment(.center)
                 .frame(maxWidth: .infinity, minHeight: 44)
+                .contentShape(Rectangle())
         }
-        .font(AppTheme.warmPaperBody)
         .accessibilityHint(accessibilityHint)
         .modifier(OpenSystemSettingsButtonStyle(emphasis: emphasis))
     }


### PR DESCRIPTION
## Headline

The Open System Settings control now fills its row for taps and handles wrapped label text cleanly.

## User impact

Taps on the Open Settings row register across the full width and height of the control, not only on the letters, which is easier for everyone and especially for motor accessibility. If the label wraps (long copy or larger text), it stays centered and keeps the intended warm paper body style.

## What changed

Typography for the localized label was applied on the text itself so the button’s title consistently uses the warm paper body font. Multiline labels are center-aligned when they wrap. A rectangular content shape was added so the interactive hit area matches the full framed button (including empty space beside or above wrapped lines), instead of a narrow strip around the glyphs. The Open System Settings style modifier and accessibility hint behavior are unchanged.

## Verification

On a Mac with Xcode and the iOS Simulator, run `grace ci` (or `grace test` with your usual destination). In the app, open Settings and use the Open System Settings control: confirm it still opens Settings, try tapping near the edges and empty areas of the row, and optionally increase Dynamic Type or use a long localization to confirm wrapped text stays centered.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
