### PR TITLE
Fix Spectral font name for Editorial Mist journal share cards

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/ShareCardStyle+Typography.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ShareCardStyle+Typography.swift
@@ -66,7 +66,7 @@ extension ShareCardStyle {
         case .editorialMist:
             switch script {
             case .latin:
-                Font.custom("Spectral-Regular", size: 15, relativeTo: .body)
+                Font.custom("Spectral", size: 15, relativeTo: .body)
             case .chinese:
                 Font.system(size: 15, weight: .regular, design: .serif)
             }


### PR DESCRIPTION
## Headline

Journal share cards in the Editorial Mist style now render body text with the intended Spectral typeface instead of silently falling back.

## User impact

When you share a journal entry with the Editorial Mist style and Latin script, body copy should look like Spectral as designed. Before this fix, the wrong font postscript name could prevent the custom font from loading, so text might have looked like the system font and less consistent with the rest of the card.

## What changed

Share card typography for Editorial Mist maps Latin body text to the Spectral family using the correct custom font name the app registers (family name "Spectral" instead of a face-specific string that may not match the bundled font). No other share styles or scripts were changed; this is a targeted fix so SwiftUI resolves the same font file customers expect for that look.

## Verification

On a Mac with Xcode and the repo’s grace CLI: run `grace ci` (or at least a simulator build with `grace test`). Manually export or preview a shared journal card using Editorial Mist with Latin body text and confirm Spectral appears for the main body (compare to system serif if unsure).

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
