### PR TITLE
Trim weekly insight headlines and continuity prompts before display

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyInsightRuleEngine.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyInsightRuleEngine.swift
@@ -47,9 +47,18 @@ struct WeeklyInsightRuleEngine {
         )
 
         let narrativeSummary = candidateBuilder.narrativeSummary(from: selectedInsights)
-        let resurfacingMessage = selectedInsights.first?.observation
-            ?? String(localized: "review.insights.starterReflection")
-        let continuityPrompt = selectedInsights.compactMap(\.action).first
+        let trimmedHeadline = selectedInsights.first?.observation
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let resurfacingMessage: String
+        if let trimmedHeadline, !trimmedHeadline.isEmpty {
+            resurfacingMessage = trimmedHeadline
+        } else {
+            resurfacingMessage = String(localized: "review.insights.starterReflection")
+        }
+
+        let continuityPrompt = selectedInsights.compactMap(\.action).map {
+            $0.trimmingCharacters(in: .whitespacesAndNewlines)
+        }.first(where: { !$0.isEmpty })
             ?? candidateBuilder.defaultContinuityPrompt
 
         return WeeklyInsightAnalysis(


### PR DESCRIPTION
## Headline

Weekly review shows sensible fallback copy when insight text is only whitespace.

## User impact

Insight headlines and follow-up prompts could look empty or wrong when stored text was only spaces or line breaks. This change trims that text and uses the usual starter reflection and default continuity prompt when nothing meaningful remains, so the weekly review stays clear and reliable.

## What changed

The weekly insight rule engine now trims leading and trailing whitespace from the primary insight headline before it is shown. If trimming leaves an empty string, the localized starter reflection is used instead of a blank line. For the continuity prompt, each candidate action is trimmed and the first non-empty result wins; if none qualify, the existing default continuity prompt is used.

## Verification

On macOS with Xcode and the project CLI installed, run `grace ci` from the repo root for lint plus simulator build (or `grace test` with the default destination from `gracenotes-dev.toml`). Optionally open weekly review with data that previously produced whitespace-only insight fields and confirm fallback copy appears.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
