### PR TITLE
Harden review week period math for calendar edge cases

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/ReviewInsightsPeriod.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ReviewInsightsPeriod.swift
@@ -12,17 +12,20 @@ enum ReviewInsightsPeriod {
             return rollingSevenDayFallback(containing: referenceDate, calendar: calendar)
         }
         let weekStart = calendar.startOfDay(for: interval.start)
-        guard let periodEndExclusive = calendar.date(byAdding: .day, value: 7, to: weekStart) else {
+        if let exclusiveEnd = calendar.date(byAdding: .day, value: 7, to: weekStart), exclusiveEnd > weekStart {
+            return weekStart..<exclusiveEnd
+        }
+        if interval.end > weekStart {
             return weekStart..<interval.end
         }
-        return weekStart..<periodEndExclusive
+        return rollingSevenDayFallback(containing: referenceDate, calendar: calendar)
     }
 
     /// The calendar week immediately before `current` (the seven local days whose end abuts
     /// `current.lowerBound`).
     static func previousPeriod(before current: Range<Date>, calendar: Calendar) -> Range<Date> {
         let previousStart = calendar.date(byAdding: .day, value: -7, to: current.lowerBound)
-            ?? current.lowerBound
+            ?? current.lowerBound.addingTimeInterval(-604_800)
         return previousStart..<current.lowerBound
     }
 


### PR DESCRIPTION
## Headline

Weekly review insights now pick safer date ranges when the calendar can’t build a clean seven-day window.

## User impact

Review screens that depend on “this week” and “last week” stay consistent and less likely to show empty or skewed ranges around odd calendar boundaries or rare Date arithmetic failures. Navigating prior periods stays meaningful instead of collapsing when subtracting a week returns nil.

## What changed

The code that maps a reference date to the current insights week was tightened: it prefers a full seven-day half-open range when date math succeeds, uses the system week interval end only when it still forms a valid forward range, and otherwise falls back to the existing rolling seven-day window instead of stopping on a weaker partial range. The helper that steps to the previous week no longer falls back to an identical start and end when subtracting seven days fails; it uses a fixed seven-day rewind so the previous period stays a real week-sized span.

## Verification

On a Mac with the project toolchain, run `grace ci` (or `grace test` with the repo’s default simulator destination) so lint and the GraceNotes build succeed; spot-check weekly review UI in the simulator across a week boundary and timezone changes if you want extra confidence.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
