### PR TITLE
Route share-card typography to CJK styles for zh, ja, and ko

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/ShareTypographyScript.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ShareTypographyScript.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Latin vs Chinese typography for share cards.
+/// Latin vs system CJK typography for share cards (`zh` / `ja` / `ko` locale languages).
 /// Figma uses Noto for zh; we approximate CJK with system serif/sans to avoid multi‑MB font bundles.
 enum ShareTypographyScript: Equatable, Sendable {
     case latin
@@ -9,9 +9,11 @@ enum ShareTypographyScript: Equatable, Sendable {
 
 extension ShareTypographyScript {
     static func current() -> ShareTypographyScript {
-        if Locale.current.identifier.hasPrefix("zh") {
+        switch Locale.current.language.languageCode?.identifier {
+        case "zh", "ja", "ko":
             return .chinese
+        default:
+            return .latin
         }
-        return .latin
     }
 }


### PR DESCRIPTION
## Headline

Japanese and Korean share cards now use the same system CJK typography path as Chinese, with a cleaner locale check.

## User impact

Share cards for people using Japanese or Korean now pick the intended CJK-oriented fonts instead of Latin defaults, so shared images read correctly and match the app’s typography intent. The locale logic is also less fragile than matching raw identifier prefixes.

## What changed

Share card typography selection no longer relies on the full locale identifier string starting with “zh.” It now reads the current language code and treats Chinese, Japanese, and Korean as the CJK branch (the existing “chinese” enum case, which maps to system CJK serif/sans). Comments were updated to describe Latin vs system CJK behavior and which language codes are included.

## Verification

On a Mac with Xcode and the project’s grace CLI: run `grace ci` (or at least build and exercise share/export for a journal with the device or app language set to Japanese or Korean and confirm typography; repeat with Chinese and a Latin language for comparison).

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
