### PR TITLE
Decode legacy journal chips when fullText is missing

### DIFF
--- a/GraceNotes/GraceNotes/Data/Models/Entry.swift
+++ b/GraceNotes/GraceNotes/Data/Models/Entry.swift
@@ -13,9 +13,14 @@ struct JournalItem: Codable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         id = try container.decodeIfPresent(UUID.self, forKey: .id) ?? UUID()
-        fullText = try container.decode(String.self, forKey: .fullText)
-        _ = try container.decodeIfPresent(String.self, forKey: .entryLabel)
-        _ = try container.decodeIfPresent(String.self, forKey: .chipLabel)
+        let entryLabel = try container.decodeIfPresent(String.self, forKey: .entryLabel)
+        let chipLabel = try container.decodeIfPresent(String.self, forKey: .chipLabel)
+        if let full = try container.decodeIfPresent(String.self, forKey: .fullText) {
+            fullText = full
+        } else {
+            // Legacy rows may omit `fullText` but still carry `entryLabel` / `chipLabel` (see export import).
+            fullText = entryLabel ?? chipLabel ?? ""
+        }
         _ = try container.decodeIfPresent(Bool.self, forKey: .isTruncated)
     }
 


### PR DESCRIPTION
## Headline

Imports and stored data keep your chip text even when older payloads only stored labels.

## User impact

Some older or mixed-format journal rows could omit the main text field while still carrying the display labels. That made decoding fail or show empty chips after import. This change fills in the text from those labels so content survives round-trips more reliably.

## What changed

The persisted journal chip model’s decoder no longer treats the main text as mandatory when reading from JSON. It still prefers the primary field when present, and for legacy rows that only stored the entry or chip label strings, it uses those in order so nothing is dropped.

Encoding is unchanged, so newly saved data continues to write the full structure reviewers expect.

## Verification

On a Mac with Xcode and the repo’s dev tooling, run `grace ci` (or at least `grace test` with the project’s default simulator destination) to confirm the app still builds and tests pass after this Codable change.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
