### PR TITLE
Normalize stored journal appearance preference values

### DIFF
--- a/GraceNotes/GraceNotes/DesignSystem/JournalAppearanceMode.swift
+++ b/GraceNotes/GraceNotes/DesignSystem/JournalAppearanceMode.swift
@@ -8,18 +8,25 @@ enum JournalAppearanceMode: String, CaseIterable, Identifiable {
     var id: String { rawValue }
 
     /// Interprets persisted `@AppStorage` / `UserDefaults` strings, including legacy `"summer"`.
+    /// Trims surrounding whitespace and lowercases before matching so hand-edited or oddly-cased values do not silently fall back to Standard.
     static func resolveStored(rawValue: String) -> JournalAppearanceMode {
-        if rawValue == "summer" {
+        let normalized = normalizedStoredRawValue(rawValue)
+        if normalized == "summer" {
             return .bloom
         }
-        return JournalAppearanceMode(rawValue: rawValue) ?? .standard
+        return JournalAppearanceMode(rawValue: normalized) ?? .standard
     }
 
     /// Rewrites legacy `"summer"` to ``bloom``’s raw value so new exports and debugging stay canonical.
     static func migrateLegacyJournalAppearanceRawValueIfNeeded(defaults: UserDefaults = .standard) {
         let key = JournalAppearanceStorageKeys.todayMode
-        guard defaults.string(forKey: key) == "summer" else { return }
+        guard let stored = defaults.string(forKey: key) else { return }
+        guard normalizedStoredRawValue(stored) == "summer" else { return }
         defaults.set(JournalAppearanceMode.bloom.rawValue, forKey: key)
+    }
+
+    private static func normalizedStoredRawValue(_ rawValue: String) -> String {
+        rawValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     }
 }
 


### PR DESCRIPTION
## Headline

Today’s journal appearance (Standard or Bloom) stays correct even when the saved setting has odd casing or spaces.

## User impact

If the stored preference string was edited or formatted oddly, the app could misread it and quietly show Standard Today styling instead of Bloom. This makes parsing more forgiving so your chosen look persists reliably.

## What changed

Journal appearance mode now normalizes saved strings by trimming surrounding whitespace and lowercasing before resolving the mode or migrating the legacy "summer" value to Bloom. That shared normalization is used both when reading the current value and when rewriting the old key so behavior stays consistent and less fragile to hand-edited defaults.

## Verification

On a Mac with the repo and Xcode installed, run `swiftlint lint` from the repo root, then run `grace ci` (or `grace test` with the project’s default simulator destination) to confirm the app builds and automated checks pass.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
