### PR TITLE
Initialize past-statistics interval state from saved Advanced Settings

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/AdvancedSettingsScreen.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/AdvancedSettingsScreen.swift
@@ -16,9 +16,17 @@ struct AdvancedSettingsScreen: View {
     @AppStorage(JournalAppearanceStorageKeys.todayMode)
     private var journalTodayAppearanceRaw = JournalAppearanceMode.standard.rawValue
 
-    @State private var intervalMode: PastStatisticsIntervalPickerMode = .all
-    @State private var customQuantity: Int = 4
-    @State private var customUnit: PastStatisticsIntervalUnit = .week
+    @State private var intervalMode: PastStatisticsIntervalPickerMode
+    @State private var customQuantity: Int
+    @State private var customUnit: PastStatisticsIntervalUnit
+
+    init() {
+        let encoded = UserDefaults.standard.string(forKey: PastStatisticsIntervalPreference.appStorageKey) ?? ""
+        let selection = PastStatisticsIntervalPreference.selection(fromAppStorage: encoded).validated
+        _intervalMode = State(initialValue: selection.mode == .all ? .all : .custom)
+        _customQuantity = State(initialValue: selection.quantity)
+        _customUnit = State(initialValue: selection.unit)
+    }
 
     var body: some View {
         List {


### PR DESCRIPTION
## Headline

Opening Advanced Settings now shows your saved past-statistics window immediately, not placeholder defaults.

## User impact

If you customized how far back past statistics look, the interval controls should match that choice the moment the screen appears. That avoids a confusing flash or moment where the UI looked like a different range or mode before it caught up.

## What changed

The past-statistics interval pickers used fixed default state until the view finished appearing and could reload from storage. An initializer was added so the same saved preference read from UserDefaults seeds the picker mode, quantity, and unit up front, aligned with the existing validation path used elsewhere on this screen.

## Verification

On a Mac with Xcode and the iOS Simulator, run `grace ci` (or `grace test` with the project’s usual destination). Open Settings → Advanced and confirm the Past statistics interval reflects your saved choice on first load without a visible mismatch.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
