### PR TITLE
Guard calendar peek height against non-finite geometry

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewHistoryDrilldownPeekMetrics.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewHistoryDrilldownPeekMetrics.swift
@@ -14,7 +14,11 @@ enum ReviewHistoryDrilldownPeekMetrics {
     static let minimumViewportHeight: CGFloat = 200
 
     /// Uses at most the non-negative space remaining; never inflates above `remainingHeight`.
+    ///
+    /// Non-finite values (NaN or infinity) collapse to `0` so invalid geometry math cannot propagate into
+    /// frame sizes for the calendar grid.
     static func clampedViewportHeight(remainingHeight: CGFloat) -> CGFloat {
-        max(0, remainingHeight)
+        guard remainingHeight.isFinite else { return 0 }
+        return max(0, remainingHeight)
     }
 }


### PR DESCRIPTION
## Headline

Prevent bad layout math from breaking the review history calendar peek height.

## User impact

If layout ever produced NaN or infinite heights, those values could flow into the feathered calendar grid’s frame sizing and cause glitches or instability. The peek viewport now treats invalid numbers as zero height, so the calendar stays in a safe, predictable state instead of propagating broken geometry.

## What changed

The helper that clamps remaining height for the review history drilldown peek was updated so it no longer passes through non-finite values from upstream layout math. Documented that NaN and infinity collapse to zero before applying the existing non-negative clamp, keeping the calendar grid from receiving invalid frame dimensions.

## Verification

On a Mac with Xcode and the project’s dev tooling, run `grace ci` (or `grace test` for the usual simulator test pass) to confirm the app still builds and tests pass.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
