### PR TITLE
Canonicalize persisted journal appearance mode and mark Sendable

### DIFF
--- a/GraceNotes/GraceNotes/DesignSystem/JournalAppearanceMode.swift
+++ b/GraceNotes/GraceNotes/DesignSystem/JournalAppearanceMode.swift
@@ -1,14 +1,15 @@
 import Foundation
 
 /// Persisted Today tab journal chrome (`Standard` vs `Bloom`). Scoped to Today-only in the UI.
-enum JournalAppearanceMode: String, CaseIterable, Identifiable {
+enum JournalAppearanceMode: String, CaseIterable, Identifiable, Sendable {
     case standard
     case bloom
 
     var id: String { rawValue }
 
     /// Interprets persisted `@AppStorage` / `UserDefaults` strings, including legacy `"summer"`.
-    /// Trims surrounding whitespace and lowercases before matching so hand-edited or oddly-cased values do not silently fall back to Standard.
+    /// Trims surrounding whitespace and lowercases before matching so hand-edited or oddly-cased values do not
+    /// silently fall back to Standard.
     static func resolveStored(rawValue: String) -> JournalAppearanceMode {
         let normalized = normalizedStoredRawValue(rawValue)
         if normalized == "summer" {
@@ -18,11 +19,15 @@ enum JournalAppearanceMode: String, CaseIterable, Identifiable {
     }
 
     /// Rewrites legacy `"summer"` to ``bloom``’s raw value so new exports and debugging stay canonical.
+    /// Persists the canonical raw value whenever the stored string differs from that form (odd casing,
+    /// surrounding whitespace, unknown values, etc.).
     static func migrateLegacyJournalAppearanceRawValueIfNeeded(defaults: UserDefaults = .standard) {
         let key = JournalAppearanceStorageKeys.todayMode
         guard let stored = defaults.string(forKey: key) else { return }
-        guard normalizedStoredRawValue(stored) == "summer" else { return }
-        defaults.set(JournalAppearanceMode.bloom.rawValue, forKey: key)
+        let resolved = resolveStored(rawValue: stored)
+        let canonical = resolved.rawValue
+        guard stored != canonical else { return }
+        defaults.set(canonical, forKey: key)
     }
 
     private static func normalizedStoredRawValue(_ rawValue: String) -> String {


### PR DESCRIPTION
## Headline

Today tab appearance settings now self-heal in storage and are safe to pass across concurrency boundaries.

## User impact

Odd casing, extra spaces, or legacy “summer” labels no longer linger in UserDefaults once migration runs; the app stores a single predictable value, which reduces confusion in backups, support, and future features. Marking the mode as Sendable improves compile-time safety when the type is used with Swift concurrency.

## What changed

Journal appearance mode now conforms to Sendable alongside its existing string-backed traits. The migration helper no longer rewrites only the legacy “summer” string; it resolves the stored value the same way the rest of the app does, then writes back the canonical raw value whenever the stored string does not already match. Documentation comments were clarified to describe this broader normalization behavior.

## Verification

On a Mac with Xcode and the project’s grace CLI installed, run `grace ci` (or `grace test` per your usual workflow) to confirm lint and simulator build pass.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
