### PR TITLE
Align guided journal completion reads with migration resolver

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalOnboardingProgress.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalOnboardingProgress.swift
@@ -39,7 +39,7 @@ final class JournalOnboardingProgress {
     }
 
     var hasCompletedGuidedJournal: Bool {
-        get { defaults.bool(forKey: JournalOnboardingStorageKeys.completedGuidedJournal) }
+        get { Self.resolvedHasCompletedGuidedJournal(using: defaults) }
         set { defaults.set(newValue, forKey: JournalOnboardingStorageKeys.completedGuidedJournal) }
     }
 


### PR DESCRIPTION
## Headline

Existing users no longer get misread as never finishing the guided journal when the flag was never stored.

## User impact

If the guided-journal completion flag was missing from settings, the app could treat long-time users like first-time users and surface the wrong onboarding or tutorial prompts. Reading completion through the same resolver used elsewhere restores the intended “already onboarded” behavior for upgrades and edge cases.

## What changed

The `hasCompletedGuidedJournal` getter no longer reads a bare boolean from `UserDefaults`, which defaults to false when the key is absent. It now delegates to the existing `resolvedHasCompletedGuidedJournal` helper so the first read can infer completion from legacy signals, persist a concrete value, and stay consistent with call sites that already used the static API.

The setter is unchanged: it still writes an explicit true or false when the app records completion.

## Verification

On a Mac with Xcode and the project’s `grace` CLI installed, run `grace ci` (or at least `grace test` with the repo’s default simulator destination) to confirm the app builds and automated tests pass.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
