### PR TITLE
Simplify iCloud account status fetch and log failures

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/Services/ICloudAccountStatusService.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/Services/ICloudAccountStatusService.swift
@@ -1,7 +1,13 @@
 import CloudKit
 import Foundation
+import os
 
-/// Live `CKContainer.accountStatus()` bridge; work runs off the main actor.
+private let iCloudAccountStatusLogger = Logger(
+    subsystem: "com.gracenotes.GraceNotes",
+    category: "ICloudAccountStatus"
+)
+
+/// Live `CKContainer.accountStatus()` bridge; `accountStatus()` suspends without blocking the caller.
 final class ICloudAccountStatusService: ICloudAccountStatusProviding {
     private let containerIdentifier: String
 
@@ -10,15 +16,19 @@ final class ICloudAccountStatusService: ICloudAccountStatusProviding {
     }
 
     func fetchAccountBucket() async -> ICloudAccountBucket {
-        await Task.detached(priority: .utility) { [containerIdentifier] in
-            let container = CKContainer(identifier: containerIdentifier)
-            do {
-                let status = try await container.accountStatus()
-                return ICloudAccountBucket(status)
-            } catch {
-                return .couldNotDetermine
+        let container = CKContainer(identifier: containerIdentifier)
+        do {
+            let status = try await container.accountStatus()
+            return ICloudAccountBucket(status)
+        } catch {
+            if !(error is CancellationError) {
+                let detail = error.localizedDescription
+                iCloudAccountStatusLogger.error(
+                    "Failed to fetch iCloud account status. \(detail, privacy: .public)"
+                )
             }
-        }.value
+            return .couldNotDetermine
+        }
     }
 }
 


### PR DESCRIPTION
## Headline

Faster, clearer iCloud status checks with actionable diagnostics when something goes wrong.

## User impact

Settings that depend on iCloud account state stay accurate without extra background hop. When CloudKit cannot report status, developers get a clear log line instead of a silent fallback, which makes real issues easier to find.

## What changed

The service no longer wraps the CloudKit call in a detached task. The API already suspends cooperatively, so the previous pattern added complexity without a user-facing benefit. Errors are now logged with the unified logging system, except for normal task cancellation, so noise stays low. The doc comment now describes the actual behavior instead of implying work always leaves the main actor.

## Verification

On a Mac with Xcode and the project’s grace CLI: run `grace ci` (or `grace test` with the default simulator destination from gracenotes-dev.toml). Optionally open Settings and confirm iCloud-related messaging still matches account state; if you simulate a failure, check Console for the new log under the ICloudAccountStatus category.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
