### PR TITLE
Fix demo seed collision between anchored history and rolling week

### DIFF
--- a/GraceNotes/GraceNotes/Data/Persistence/DemoDataSeeder.swift
+++ b/GraceNotes/GraceNotes/Data/Persistence/DemoDataSeeder.swift
@@ -4,17 +4,17 @@ import SwiftData
 
 @MainActor
 enum DemoDataSeeder {
-    private static let seedVersion = 5
+    private static let seedVersion = 6
     private static let seedVersionKey = "demoDataSeedVersion"
 
     static func seedIfNeeded(context: ModelContext, calendar: Calendar = .current) {
         let seedTrace = PerformanceTrace.begin("DemoDataSeeder.seedIfNeeded")
-        guard shouldSeed(context: context, calendar: calendar) else {
+        let now = Date.now
+        guard shouldSeed(context: context, calendar: calendar, now: now) else {
             PerformanceTrace.end("DemoDataSeeder.seedIfNeeded.skipped", startedAt: seedTrace)
             return
         }
 
-        let now = Date.now
         let today = calendar.startOfDay(for: now)
         let entries = makeSeedEntries(today: today, now: now, calendar: calendar)
 
@@ -32,11 +32,11 @@ enum DemoDataSeeder {
         }
     }
 
-    private static func shouldSeed(context: ModelContext, calendar: Calendar) -> Bool {
+    private static func shouldSeed(context: ModelContext, calendar: Calendar, now: Date) -> Bool {
         let savedVersion = UserDefaults.standard.integer(forKey: seedVersionKey)
         if savedVersion != seedVersion { return true }
 
-        let today = calendar.startOfDay(for: .now)
+        let today = calendar.startOfDay(for: now)
         return fetchEntry(for: today, context: context, calendar: calendar) == nil
     }
 
@@ -90,16 +90,25 @@ enum DemoDataSeeder {
         let fiveDaysAgo = calendar.date(byAdding: .day, value: -5, to: today) ?? today
         let sixDaysAgo = calendar.date(byAdding: .day, value: -6, to: today) ?? today
 
-        return [
+        let week = [
             makeTodayPayload(entryDate: today, completedAt: now),
             makeYesterdayPayload(entryDate: yesterday),
             makeBlankPayload(entryDate: twoDaysAgo),
             makeThreeDaysAgoPayload(entryDate: threeDaysAgo, completedAt: now),
             makeFourDaysAgoPayload(entryDate: fourDaysAgo),
             makeFiveDaysAgoPayload(entryDate: fiveDaysAgo),
-            makeSixDaysAgoPayload(entryDate: sixDaysAgo),
-            demoDecember2025Entry(calendar: calendar, now: now)
+            makeSixDaysAgoPayload(entryDate: sixDaysAgo)
         ]
+
+        // The anchored December row must not share a calendar day with the rolling week, or the
+        // later upsert would overwrite the intended demo for that day.
+        let anchored = demoDecember2025Entry(calendar: calendar, now: now)
+        let anchoredDay = calendar.startOfDay(for: anchored.entryDate)
+        let weekDays = Set(week.map { calendar.startOfDay(for: $0.entryDate) })
+        if weekDays.contains(anchoredDay) {
+            return week
+        }
+        return week + [anchored]
     }
 
     private static func makeTodayPayload(entryDate: Date, completedAt: Date) -> DemoEntryPayload {


### PR DESCRIPTION
## Headline

Demo journal seeding no longer overwrites a week row when a fixed history date lands on the same day.

## User impact

In the Demo build, two seed rows that share the same calendar day could fight during upsert, so the last write could replace the intended “this week” sample with the anchored history sample (or the other way around). The seeder now also uses one captured “now” for the skip check and for building rows so “today” does not shift mid-run.

## What changed

The demo seed version was bumped so existing Demo installs pick up the new behavior. Seeding captures a single current time up front and passes it into the “should we seed?” check, and that path uses the same instant for the start-of-day “today” test instead of reading the clock again.

When assembling demo rows, the code builds the rolling seven-day set first, then adds the fixed December 2025 history row only if that anchored day is not already represented in the week. If the calendar would collide, the anchored row is skipped so upserts cannot clobber the week’s intended story for that day.

## Verification

On a Mac with Xcode and simulators installed, run `grace ci` from the repo root. For a manual spot-check, launch the GraceNotes (Demo) scheme and confirm the demo journal still looks coherent around the current week and, when the anchored day does not overlap the week, that the separate past-year sample still appears.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
