### PR TITLE
Centralize clearing of journal tutorial UserDefaults keys

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalTutorialProgress.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalTutorialProgress.swift
@@ -11,6 +11,14 @@ enum JournalTutorialStorageKeys {
     /// First time all fifteen Entries were filled (Bloom).
     static let celebratedFirstBloom = "journalTutorial.celebratedFirstBloom"
 
+    private static let currentKeys: [String] = [
+        dismissedSproutGuidance,
+        dismissedBloomGuidance,
+        celebratedFirstSprout,
+        celebratedFirstLeaf,
+        celebratedFirstBloom
+    ]
+
     /// Copies legacy keys into the keys above, then removes legacy entries.
     /// Call early at launch before CloudKit continuity checks.
     static func migrateLegacyKeysIfNeeded(using defaults: UserDefaults = .standard) {
@@ -19,6 +27,13 @@ enum JournalTutorialStorageKeys {
         migrateBool(from: Legacy.celebratedFirstSeed, to: celebratedFirstSprout, defaults: defaults)
         migrateBool(from: Legacy.celebratedFirstBalanced, to: celebratedFirstLeaf, defaults: defaults)
         migrateBool(from: Legacy.celebratedFirstHarvest, to: celebratedFirstBloom, defaults: defaults)
+    }
+
+    /// Removes current and legacy tutorial keys (e.g. UI test reset, debug tooling).
+    static func removeAllStoredKeys(in defaults: UserDefaults) {
+        for key in currentKeys + Legacy.allKeyStrings {
+            defaults.removeObject(forKey: key)
+        }
     }
 
     private static func migrateBool(from legacyKey: String, to key: String, defaults: UserDefaults) {
@@ -35,6 +50,14 @@ enum JournalTutorialStorageKeys {
         static let celebratedFirstSeed = "journalTutorial.celebratedFirstSeed"
         static let celebratedFirstBalanced = "journalTutorial.celebratedFirstBalanced"
         static let celebratedFirstHarvest = "journalTutorial.celebratedFirstHarvest"
+
+        static let allKeyStrings: [String] = [
+            dismissedSeedGuidance,
+            dismissedHarvestGuidance,
+            celebratedFirstSeed,
+            celebratedFirstBalanced,
+            celebratedFirstHarvest
+        ]
     }
 }
 
@@ -86,24 +109,6 @@ final class JournalTutorialProgress {
     }
 
     static func resetAll(in defaults: UserDefaults = .standard) {
-        let keys = [
-            JournalTutorialStorageKeys.dismissedSproutGuidance,
-            JournalTutorialStorageKeys.dismissedBloomGuidance,
-            JournalTutorialStorageKeys.celebratedFirstSprout,
-            JournalTutorialStorageKeys.celebratedFirstLeaf,
-            JournalTutorialStorageKeys.celebratedFirstBloom
-        ]
-        for key in keys {
-            defaults.removeObject(forKey: key)
-        }
-        for legacy in [
-            "journalTutorial.dismissedSeedGuidance",
-            "journalTutorial.dismissedHarvestGuidance",
-            "journalTutorial.celebratedFirstSeed",
-            "journalTutorial.celebratedFirstBalanced",
-            "journalTutorial.celebratedFirstHarvest"
-        ] {
-            defaults.removeObject(forKey: legacy)
-        }
+        JournalTutorialStorageKeys.removeAllStoredKeys(in: defaults)
     }
 }


### PR DESCRIPTION
## Headline

Tutorial hints and celebrations reset from one authoritative list of storage keys.

## User impact

Resets and test cleanups now reliably wipe every current and legacy tutorial flag, so hints and milestone celebrations do not reappear because an old key was missed. This keeps first-run guidance predictable after a reset and makes automated UI tests less flaky.

## What changed

Tutorial storage keys were consolidated into two explicit lists: one for the current UserDefaults names and one for the legacy spellings kept for migration. A new helper on the keys type removes all of those entries in one place. The journal tutorial progress reset path now calls that helper instead of maintaining a duplicate list and hard-coded legacy strings inline, so future key changes only need to be updated in one spot.

## Verification

On a Mac with Xcode and the project’s grace CLI installed, run `grace ci` (or `grace test` with the repo’s default simulator destination) to confirm the app still builds and tests pass. Optionally reset tutorial state via the code path that calls reset and confirm Today tutorial hints and celebrations behave as a fresh install.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
