### PR TITLE
Fix CompletionInfoCard VoiceOver and replace AnyView card surface

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/CompletionInfoCard.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/CompletionInfoCard.swift
@@ -30,14 +30,30 @@ struct CompletionInfoCard: View {
         )
         .shadow(color: cardTintColor.opacity(reduceTransparency ? 0.18 : 0.24), radius: 8, x: 0, y: 4)
         .accessibilityElement(children: .contain)
-        .accessibilityLabel(Text(badgeInfo.description))
         .onAppear {
             animateEntry()
         }
     }
 
-    private var cardSurface: AnyView {
-        let base = RoundedRectangle(cornerRadius: AppTheme.cornerRadiusMedium)
+    private var cardSurface: some View {
+        Group {
+            if showMorph && !reduceMotion {
+                roundedRectangleSurface
+                    .matchedGeometryEffect(
+                        id: "completionInfoMorphSurface",
+                        in: morphNamespace,
+                        properties: .frame,
+                        anchor: .topLeading,
+                        isSource: false
+                    )
+            } else {
+                roundedRectangleSurface
+            }
+        }
+    }
+
+    private var roundedRectangleSurface: some View {
+        RoundedRectangle(cornerRadius: AppTheme.cornerRadiusMedium)
             .fill(
                 palette.paper.opacity(reduceTransparency ? 1.0 : 0.94 * palette.sectionPaperOpacity)
             )
@@ -46,20 +62,6 @@ struct CompletionInfoCard: View {
                     .stroke(cardTintColor.opacity(0.24 * bloomProgress), lineWidth: 1.4)
                     .scaleEffect(1.0 + (0.02 * (1 - bloomProgress)))
             )
-
-        guard showMorph, !reduceMotion else {
-            return AnyView(base)
-        }
-
-        return AnyView(
-            base.matchedGeometryEffect(
-                id: "completionInfoMorphSurface",
-                in: morphNamespace,
-                properties: .frame,
-                anchor: .topLeading,
-                isSource: false
-            )
-        )
     }
 
     private func animateEntry() {


### PR DESCRIPTION
## Headline

Cleaner accessibility for the journal completion card and more predictable SwiftUI rendering for the morph animation.

## User impact

VoiceOver no longer risks repeating or overriding the card’s description when the text is already exposed as child content, so the completion message is easier to hear correctly. The card’s animated surface is also expressed without type erasure, which helps SwiftUI stay efficient and stable during the completion morph.

## What changed

Removed the container-level accessibility label on the completion info card because the view is already configured to expose its children to assistive technologies, which avoids redundant or conflicting announcements alongside the visible description text.

Rebuilt the card background so the rounded rectangle and bloom styling live in one shared subview, and applied the matched geometry effect only when morphing is enabled and reduced motion is off. That replaces the previous AnyView-based branching with ordinary conditional views, which is easier for the framework to reason about and aligns with typical SwiftUI style.

## Verification

On a Mac with Xcode and the repo’s grace CLI, run `grace ci` (or at least `swiftlint lint` plus a simulator build via your usual grace workflow) and exercise the journal completion flow with VoiceOver on: confirm the card’s message is announced once clearly, and with Reduce Motion off confirm the morph animation still looks correct.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
