### PR TITLE
Treat CloudKit and URL cancellations as non-errors in iCloud status fetch

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/Services/ICloudAccountStatusService.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/Services/ICloudAccountStatusService.swift
@@ -21,7 +21,7 @@ final class ICloudAccountStatusService: ICloudAccountStatusProviding {
             let status = try await container.accountStatus()
             return ICloudAccountBucket(status)
         } catch {
-            if !(error is CancellationError) {
+            if !isCancellationLike(error) {
                 let detail = error.localizedDescription
                 iCloudAccountStatusLogger.error(
                     "Failed to fetch iCloud account status. \(detail, privacy: .public)"
@@ -30,6 +30,15 @@ final class ICloudAccountStatusService: ICloudAccountStatusProviding {
             return .couldNotDetermine
         }
     }
+}
+
+/// CloudKit may report cancellation as `CKError.operationCancelled`; URL loading as `URLError.cancelled`, not only
+/// `CancellationError`.
+private func isCancellationLike(_ error: Error) -> Bool {
+    if error is CancellationError { return true }
+    if let ckError = error as? CKError, ckError.code == .operationCancelled { return true }
+    let nsError = error as NSError
+    return nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled
 }
 
 extension ICloudAccountBucket {


### PR DESCRIPTION
## Headline

Stop logging benign cancellations when checking iCloud account status so diagnostics stay trustworthy.

## User impact

When the app cancels or CloudKit reports a normal cancellation, you should not see misleading “failed to fetch” error noise in logs. Real failures still surface clearly, which makes support and debugging more reliable.

## What changed

The iCloud account status helper only skipped logging for Swift’s `CancellationError`. CloudKit and the networking stack often surface cancellation differently (for example operation cancelled or URL cancelled), so those were incorrectly treated as failures and logged as errors.

The change adds a small helper that treats those cancellation-shaped errors the same as `CancellationError`: we still return “could not determine” for the UI path, but we no longer log an error for ordinary cancellation.

## Verification

On a Mac with the repo and Xcode, run `grace ci` (or `grace test` with your usual simulator destination) to confirm the project still builds and tests pass. Optionally exercise Settings flows that touch iCloud status and confirm logs stay quiet when work is cancelled.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
