### PR TITLE
Fix journal history month grouping when month keys cannot be built

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/HistoryEntryGrouping.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/HistoryEntryGrouping.swift
@@ -7,12 +7,29 @@ enum HistoryEntryGrouping {
         calendar: Calendar
     ) -> [(key: Date, entries: [Journal])] {
         let grouped = Dictionary(grouping: entries) { entry -> Date in
-            let components = calendar.dateComponents([.year, .month], from: entry.entryDate)
-            return calendar.date(from: components) ?? entry.entryDate
+            monthKey(for: entry.entryDate, calendar: calendar)
         }
         return grouped.keys.sorted(by: >).map { month in
             let groupedEntries = grouped[month] ?? []
             return (month, groupedEntries)
         }
+    }
+
+    /// Start of the calendar month containing `date`. Used so a failed `date(from:)`
+    /// does not fall back to the raw entry timestamp (which would split one month into many buckets).
+    private static func monthKey(for date: Date, calendar: Calendar) -> Date {
+        if let intervalStart = calendar.dateInterval(of: .month, for: date)?.start {
+            return intervalStart
+        }
+        var components = calendar.dateComponents([.year, .month], from: date)
+        components.day = 1
+        components.hour = 0
+        components.minute = 0
+        components.second = 0
+        components.nanosecond = 0
+        if let normalized = calendar.date(from: components) {
+            return normalized
+        }
+        return calendar.startOfDay(for: date)
     }
 }


### PR DESCRIPTION
## Headline

Journal history now keeps all entries in the correct month section instead of splitting one month into many.

## User impact

Entries were sometimes shown under lots of tiny “month” rows instead of a single month, which made history hard to scan and felt broken. Grouping now uses a stable start-of-month key so months stay together reliably.

## What changed

Month grouping no longer falls back to each entry’s exact timestamp when building the month bucket key. A small helper picks the start of the calendar month when possible, normalizes year/month to the first day with time cleared if needed, and only then uses a last-resort day-level anchor—so failed date construction cannot scatter same-month entries across many groups.

## Verification

On a Mac with the repo’s dev tooling, run `grace ci` (or `grace test` with your usual simulator destination from `gracenotes-dev.toml`) and spot-check Journal history: entries for a given calendar month should appear under one month heading, including around calendar or data edge cases.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
