### PR TITLE
Fix month banners when a week spans two months

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewHistoryDrilldownCalendar.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewHistoryDrilldownCalendar.swift
@@ -144,6 +144,25 @@ enum ReviewHistoryDrilldownCalendarLayout {
         return weeks
     }
 
+    /// Month keys in cell order (year-month). Weeks spanning two months yield two specs.
+    private static func orderedMonthBannerSpecs(
+        for week: [Date?],
+        calendar: Calendar
+    ) -> [(key: String, monthDate: Date)] {
+        var seen = Set<String>()
+        var specs: [(String, Date)] = []
+        for cell in week {
+            guard let date = cell else { continue }
+            let year = calendar.component(.year, from: date)
+            let month = calendar.component(.month, from: date)
+            let key = "\(year)-\(month)"
+            if seen.insert(key).inserted {
+                specs.append((key, date))
+            }
+        }
+        return specs
+    }
+
     private static func rowsWithBannersFromWeeks(
         _ weeks: [[Date?]],
         calendar: Calendar
@@ -151,18 +170,15 @@ enum ReviewHistoryDrilldownCalendarLayout {
         var rows: [ReviewHistoryDrilldownCalendarRow] = []
         var lastBannerMonthKey: String?
         for (weekIndex, week) in weeks.enumerated() {
-            if let firstDate = week.compactMap({ $0 }).first {
-                let year = calendar.component(.year, from: firstDate)
-                let month = calendar.component(.month, from: firstDate)
-                let key = "\(year)-\(month)"
-                if lastBannerMonthKey != key {
-                    let title = firstDate.formatted(.dateTime.month(.wide).year())
-                    rows.append(.monthBanner(id: "banner-\(key)", title: title))
-                    lastBannerMonthKey = key
-                }
+            let monthSpecs = orderedMonthBannerSpecs(for: week, calendar: calendar)
+            for spec in monthSpecs where lastBannerMonthKey != spec.key {
+                let title = spec.monthDate.formatted(.dateTime.month(.wide).year())
+                rows.append(.monthBanner(id: "banner-\(spec.key)", title: title))
+                lastBannerMonthKey = spec.key
             }
+            let weekDays = week.compactMap { $0 }
             let weekId: String
-            if let first = week.compactMap({ $0 }).first {
+            if let first = weekDays.first {
                 weekId = "week-\(Int(first.timeIntervalSince1970))-\(weekIndex)"
             } else {
                 weekId = "week-pad-\(weekIndex)"


### PR DESCRIPTION
## Headline

The review history drill-down calendar now labels both months when a single week row crosses a month boundary.

## User impact

Week rows that include days from two months used to pick only the first dated cell for the month banner, so the calendar could skip or misrepresent the transition between months. Users scanning review history now see the correct month heading(s) for that week, which improves clarity and supports VoiceOver and scrolling that rely on those structural rows.

## What changed

Month banner rows are no longer derived from only the first non-empty day in each week. The layout walks week cells in order, collects each distinct year-month in that order, and inserts a banner for each new month key that has not already been shown, so a week that straddles two months can produce two banners before the week row. Week row identity still uses the first real day in the row, with a small refactor to avoid repeating the compact-map pass.

## Verification

On a Mac with Xcode and the iOS Simulator, run `grace ci` (or `grace test` with the project’s usual destination) and manually open the review history drill-down calendar around a month boundary to confirm both month labels appear when a week spans two months.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
