### PR TITLE
Ignore completion highlight in rhythm scroll pin identity

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewRhythmScrollPinIdentity.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewRhythmScrollPinIdentity.swift
@@ -4,7 +4,19 @@ import Foundation
 ///
 /// Used to reset trailing-edge scroll pinning after a real dataset change, without clearing user scroll when
 /// `ReviewInsights` is regenerated for the same week with the same per-day rhythm payload (#131).
+///
+/// Equality ignores ``ReviewDayActivity/strongestCompletionLevel``: it only affects which growth-stage row is
+/// highlighted, not column count or horizontal extent, so recomputing completion staging must not reset pin state.
 struct ReviewRhythmScrollPinIdentity: Equatable {
     let weekStart: Date
     let days: [ReviewDayActivity]
+
+    static func == (lhs: ReviewRhythmScrollPinIdentity, rhs: ReviewRhythmScrollPinIdentity) -> Bool {
+        guard lhs.weekStart == rhs.weekStart, lhs.days.count == rhs.days.count else { return false }
+        return zip(lhs.days, rhs.days).allSatisfy { left, right in
+            left.date == right.date
+                && left.hasReflectiveActivity == right.hasReflectiveActivity
+                && left.hasPersistedEntry == right.hasPersistedEntry
+        }
+    }
 }


### PR DESCRIPTION
## Headline

Weekly review rhythm keeps your horizontal scroll position when only completion highlights refresh.

## User impact

Previously, when the app recomputed which growth-stage row was highlighted for a day, the scroll pin treated that as a layout change and could reset horizontal scroll. That felt jumpy and could pull you away from where you were reading. Pin identity now tracks only what actually changes column count and horizontal extent.

## What changed

The scroll pin identity for the reflection rhythm strip used full struct equality, so any change to per-day completion staging (strongest completion level) looked like a new dataset and cleared trailing-edge scroll pinning. Custom equality now compares week start and, for each day in order, the date plus whether there is reflective activity and a persisted entry—matching what affects visible columns—while ignoring the completion highlight field. Documentation explains why that field is excluded.

## Verification

On a Mac with Xcode and the Grace Notes dev CLI, run `grace ci` (or `grace test` with the project’s default simulator destination) to lint and build; exercise the weekly review rhythm strip: scroll horizontally, trigger a path that recomputes completion highlights without adding/removing columns, and confirm scroll position stays pinned.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
