### PR TITLE
Clamp reminder journal-day gap to non-negative values

### DIFF
--- a/GraceNotes/GraceNotes/Services/Reminders/ReminderNotificationBodySelector.swift
+++ b/GraceNotes/GraceNotes/Services/Reminders/ReminderNotificationBodySelector.swift
@@ -73,6 +73,8 @@ enum ReminderNotificationBodySelector {
 
     /// Calendar-day gap from the last meaningful journal day to ``todayStart``.
     /// Returns `nil` when there was never meaningful content.
+    /// The result is always non-negative: future-dated entries (``lastDay`` after ``todayStart``)
+    /// yield `0` instead of a negative component.
     static func calendarDayGapSinceLastMeaningfulEntry(
         entries: [Journal],
         todayStart: Date,
@@ -86,7 +88,8 @@ enum ReminderNotificationBodySelector {
             }
         }
         guard let lastDay = latestMeaningfulDay else { return nil }
-        return calendar.dateComponents([.day], from: lastDay, to: todayStart).day
+        let rawDay = calendar.dateComponents([.day], from: lastDay, to: todayStart).day ?? 0
+        return max(0, rawDay)
     }
 
     /// True when we should use welcoming-back copy (requires a prior meaningful day and


### PR DESCRIPTION
## Headline

Daily journal reminder copy no longer treats future-dated entries as a negative “days since” gap.

## User impact

If your latest meaningful entry was dated after today, the app could compute a negative day gap, which could skew which reminder message variant you get (for example, lapse-style copy). The gap is now treated as zero days in that edge case, so messaging stays aligned with “today.”

## What changed

The calendar-day gap helper that feeds reminder body selection used the raw day count between the last meaningful journal day and the start of today. When the last meaningful day is after today, that difference can be negative or the day component can be missing. The update clamps the result to zero at minimum, treats a missing day as zero, and documents that the returned gap is never negative.

## Verification

On a Mac with Xcode and the iOS Simulator, run `grace ci` (or `grace test` using the project’s configured simulator destination). If there are existing tests around `ReminderNotificationBodySelector`, run those or the full test target to confirm behavior.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
