### PR TITLE
Normalize export history detail for single-line display

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/ImportExportTechnicalDetailFormatting.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/ImportExportTechnicalDetailFormatting.swift
@@ -3,7 +3,7 @@ import Foundation
 struct ExportHistoryLineParts {
     let kindLabel: String
     let statusLabel: String
-    /// Non-nil when `entry.detail` is non-empty (same rule as on-screen history).
+    /// Non-nil when `entry.detail` has visible content after normalization (trim; line breaks flattened).
     let detail: String?
 }
 
@@ -34,12 +34,7 @@ enum ImportExportTechnicalDetailFormatting {
         } else {
             statusLabel = String(localized: "settings.dataPrivacy.importExport.history.status.failed")
         }
-        let detail: String?
-        if let raw = entry.detail, !raw.isEmpty {
-            detail = raw
-        } else {
-            detail = nil
-        }
+        let detail = entry.detail.flatMap { Self.normalizedExportHistoryDetail($0) }
         return ExportHistoryLineParts(kindLabel: kindLabel, statusLabel: statusLabel, detail: detail)
     }
 
@@ -50,5 +45,13 @@ enum ImportExportTechnicalDetailFormatting {
             return "\(parts.kindLabel) · \(parts.statusLabel) · \(detail)"
         }
         return "\(parts.kindLabel) · \(parts.statusLabel)"
+    }
+
+    /// Trims surrounding whitespace, treats whitespace-only as absent, and flattens line breaks so
+    /// history rows and accessibility labels stay single-line.
+    private static func normalizedExportHistoryDetail(_ raw: String) -> String? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        return trimmed.split { $0.isNewline }.joined(separator: " ")
     }
 }


### PR DESCRIPTION
## Headline

Export history and VoiceOver now show trimmed, one-line detail instead of raw multi-line or whitespace-only strings.

## User impact

History rows and the plain accessibility label stay on a single line and read cleanly. Whitespace-only stored detail no longer appears as a confusing empty fragment, and embedded line breaks no longer break the layout or speech flow.

## What changed

Export history previously treated any non-empty stored detail as visible, which could surface padding-only text or multi-line blobs in Settings and in the shared plain label used for VoiceOver.

Detail is now normalized: leading and trailing whitespace are stripped, runs of line breaks become spaces so the string fits one line, and if nothing meaningful remains the detail is omitted entirely. Documentation on the detail field was updated to match this rule.

## Verification

On a Mac with the repo and `grace` installed, run `grace ci`. Optionally open Settings → Data & Privacy, find import/export export history, and confirm entries with messy stored detail read as a single line with sensible spacing.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
