### PR TITLE
Sentry: refine GraceNotesApp.swift

### DIFF
--- a/GraceNotes/GraceNotes/Application/GraceNotesApp.swift
+++ b/GraceNotes/GraceNotes/Application/GraceNotesApp.swift
@@ -248,7 +248,7 @@ private struct DailyReminderRefreshOnActiveModifier: ViewModifier {
     func body(content: Content) -> some View {
         content.onChange(of: scenePhase) { _, phase in
             guard phase == .active else { return }
-            Task {
+            Task { @MainActor in
                 await DailyReminderNotificationSync.rescheduleEnabledReminderIfNeeded(modelContext: modelContext)
             }
         }


### PR DESCRIPTION
## Headline

Automated refinement from `grace sentry`.

## User impact

Maintainers get a small scoped change with CI preflight before review.

## What changed

Updates `GraceNotes/GraceNotes/Application/GraceNotesApp.swift` in a single automated pass (see diff on the PR).

## Verification

`grace ci` on macOS using the configured sentry CI profile.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
