### PR TITLE
Fix weekly review theme tie-break order for first-seen themes

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregatesBuilder+ThemeSections.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregatesBuilder+ThemeSections.swift
@@ -52,6 +52,7 @@ extension WeeklyReviewAggregatesBuilder {
                     .compactMap { _, candidates in candidates.max(by: { $0.score < $1.score }) }
 
                 for concept in uniqueConcepts {
+                    let isFirstAppearance = map[concept.canonicalConcept] == nil
                     var accumulator = map[concept.canonicalConcept] ?? DistilledThemeAccumulator(
                         canonicalConcept: concept.canonicalConcept,
                         displayLabel: concept.displayLabel,
@@ -80,8 +81,10 @@ extension WeeklyReviewAggregatesBuilder {
                         )
                     )
                     map[concept.canonicalConcept] = accumulator
+                    if isFirstAppearance {
+                        sequence += 1
+                    }
                 }
-                sequence += 1
             }
         }
 


### PR DESCRIPTION
## Headline

Most recurring themes now break ties using each theme’s true first appearance, not per journal surface.

## User impact

When two themes show up equally often in your weekly review, the list order could feel arbitrary or shuffle relative to how you actually wrote them. Ordering is now steadier and matches the sequence themes are first detected across your entries.

## What changed

Theme aggregation used a single “first seen” sequence number for every new theme that appeared on the same section of an entry, then advanced that counter only after the whole section was processed. That meant co-occurring themes could look tied even when the extractor had a clear order, so tie-breaking could lean on label sorting instead of discovery order. The builder now advances the sequence only when a canonical theme is seen for the first time, so each theme gets a distinct first-seen rank that follows the actual scan order.

## Verification

On a Mac with the repo’s dev toolchain, run `grace ci` (or `grace test` with the project’s default simulator destination) to confirm the GraceNotes scheme still builds and tests pass.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
