### PR TITLE
Defer reminder disable until after in-flight reminder operations

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/ReminderSettingsFlowModel.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/ReminderSettingsFlowModel.swift
@@ -15,6 +15,8 @@ final class ReminderSettingsFlowModel: ObservableObject {
     private let userDefaults: UserDefaults
     private var pendingRescheduleTask: Task<Void, Never>?
     private var pendingRescheduleAfterCurrentSave = false
+    /// User turned reminders off while another reminder operation held `isWorking`.
+    private var pendingDisableAfterCurrentWork = false
     private var hasLoadedLiveStatus = false
 
     init(
@@ -78,12 +80,16 @@ final class ReminderSettingsFlowModel: ObservableObject {
     }
 
     func disableReminders() async {
-        guard !isWorking else { return }
-        isWorking = true
-        defer { isWorking = false }
         pendingRescheduleTask?.cancel()
         pendingRescheduleAfterCurrentSave = false
 
+        if isWorking {
+            pendingDisableAfterCurrentWork = true
+            return
+        }
+
+        isWorking = true
+        defer { isWorking = false }
         transientErrorMessage = nil
         _ = await reminderScheduler.disableDailyReminder()
         await refreshStatus()
@@ -99,6 +105,7 @@ final class ReminderSettingsFlowModel: ObservableObject {
         isWorking = true
         await runRescheduleLoopWhileEnabled()
         isWorking = false
+        await drainPendingDisableIfNeeded()
         await drainPendingRescheduleIfNeeded()
     }
 
@@ -165,7 +172,22 @@ final class ReminderSettingsFlowModel: ObservableObject {
         isWorking = true
         await work()
         isWorking = false
+        await drainPendingDisableIfNeeded()
         await drainPendingRescheduleIfNeeded()
+    }
+
+    /// Runs a deferred disable after `isWorking` drops (e.g. user turned reminders off during reschedule).
+    private func drainPendingDisableIfNeeded() async {
+        guard pendingDisableAfterCurrentWork else { return }
+        pendingDisableAfterCurrentWork = false
+        pendingRescheduleAfterCurrentSave = false
+
+        isWorking = true
+        defer { isWorking = false }
+        pendingRescheduleTask?.cancel()
+        transientErrorMessage = nil
+        _ = await reminderScheduler.disableDailyReminder()
+        await refreshStatus()
     }
 
     /// Runs a deferred time save after `isWorking` drops (picker updates coalesced during enable or overlapping saves).
@@ -176,6 +198,7 @@ final class ReminderSettingsFlowModel: ObservableObject {
             isWorking = true
             await runRescheduleLoopWhileEnabled()
             isWorking = false
+            await drainPendingDisableIfNeeded()
         }
     }
 


### PR DESCRIPTION
## Headline

Turning reminders off now completes even if you toggle while a schedule change is still running.

## User impact

If someone turned off daily reminders while the app was busy rescheduling or saving the time, the old flow could exit early and leave reminders enabled. That mismatch is confusing and can mean notifications keep firing when the user expects them to stop.

## What changed

Reminder settings used to bail out of disable when another reminder task had already set the working state, so a fast “off” tap during reschedule could be dropped.

The model now cancels any pending debounced reschedule, clears coalesced save flags, and remembers a disable request when work is in flight. After that work finishes, it runs the deferred disable so notifications are actually turned off and the live status refreshes. The same drain runs after enable and after chained reschedule work so the off path stays consistent.

## Verification

On a Mac with Xcode and the iOS Simulator, exercise Settings → reminders: enable, change time rapidly, then toggle off while a save is in progress; confirm reminders end up off and the UI matches. Run `grace ci` (or `grace test` with the project’s usual destination) to confirm the app still builds and tests pass.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
