### PR TITLE
Stack journal onboarding actions at large Dynamic Type sizes

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalOnboardingSuggestionView.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalOnboardingSuggestionView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct JournalOnboardingSuggestionView: View {
     @Environment(\.todayJournalPalette) private var palette
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     let title: String
     let message: String
     let primaryActionTitle: String
@@ -22,24 +23,8 @@ struct JournalOnboardingSuggestionView: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
 
-            HStack(spacing: AppTheme.spacingRegular) {
-                Button(action: onPrimaryAction) {
-                    Text(primaryActionTitle)
-                        .frame(maxWidth: .infinity, minHeight: 44)
-                }
-                .buttonStyle(.borderedProminent)
-                .tint(AppTheme.accent)
-                .foregroundStyle(AppTheme.onAccent)
-
-                Button(action: onSecondaryAction) {
-                    Text(secondaryActionTitle)
-                        .frame(maxWidth: .infinity, minHeight: 44)
-                }
-                .buttonStyle(.bordered)
-                .tint(AppTheme.accentText)
-                .foregroundStyle(AppTheme.accentText)
-            }
-            .font(AppTheme.warmPaperBody)
+            actionButtons
+                .font(AppTheme.warmPaperBody)
         }
         .padding(AppTheme.spacingRegular)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -50,5 +35,40 @@ struct JournalOnboardingSuggestionView: View {
                 .stroke(palette.inputBorder, lineWidth: 1)
         )
         .accessibilityElement(children: .contain)
+    }
+
+    @ViewBuilder
+    private var actionButtons: some View {
+        if dynamicTypeSize.isAccessibilitySize {
+            VStack(spacing: AppTheme.spacingRegular) {
+                primaryActionButton
+                secondaryActionButton
+            }
+        } else {
+            HStack(spacing: AppTheme.spacingRegular) {
+                primaryActionButton
+                secondaryActionButton
+            }
+        }
+    }
+
+    private var primaryActionButton: some View {
+        Button(action: onPrimaryAction) {
+            Text(primaryActionTitle)
+                .frame(maxWidth: .infinity, minHeight: 44)
+        }
+        .buttonStyle(.borderedProminent)
+        .tint(AppTheme.accent)
+        .foregroundStyle(AppTheme.onAccent)
+    }
+
+    private var secondaryActionButton: some View {
+        Button(action: onSecondaryAction) {
+            Text(secondaryActionTitle)
+                .frame(maxWidth: .infinity, minHeight: 44)
+        }
+        .buttonStyle(.bordered)
+        .tint(AppTheme.accentText)
+        .foregroundStyle(AppTheme.accentText)
     }
 }


### PR DESCRIPTION
## Headline

Onboarding suggestion buttons stay readable when text is enlarged.

## User impact

People who use larger text (including accessibility sizes) were stuck with two side-by-side buttons that could feel cramped or hard to tap. The card now lays out actions in a single column at those sizes so labels and targets stay clear and reliable.

## What changed

The journal onboarding suggestion card still shows the same primary and secondary actions, but it now watches the system Dynamic Type size. At default sizes, the two buttons stay in one row as before. When Dynamic Type is in an accessibility range, the buttons switch to a vertical stack so each action can use the full width and breathe with longer labels. The button definitions were pulled into small private views so the horizontal and vertical layouts share one implementation without duplicating styling.

## Verification

On a Mac with Xcode and the iOS Simulator, run `grace ci` (or build and run the GraceNotes scheme). In the journal onboarding suggestion UI, toggle larger accessibility text sizes in Settings (or the simulator’s Environment overrides) and confirm the two actions stack vertically; at default text size, confirm they remain side by side.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
