### PR TITLE
Debounce iCloud sync activity writes to UserDefaults

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/Services/ICloudSyncActivityModel.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/Services/ICloudSyncActivityModel.swift
@@ -10,6 +10,8 @@ final class ICloudSyncActivityModel: ObservableObject {
     @Published private(set) var lastRemoteChangeAt: Date?
 
     private var observerToken: NSObjectProtocol?
+    /// Limits disk writes when many remote-change notifications arrive in a short burst (e.g. sync).
+    private var pendingUserDefaultsPersist = false
 
     init() {
         let raw = UserDefaults.standard.double(forKey: Self.persistedTimestampKey)
@@ -36,8 +38,17 @@ final class ICloudSyncActivityModel: ObservableObject {
     }
 
     private func recordRemoteChange() {
-        let now = Date()
-        lastRemoteChangeAt = now
-        UserDefaults.standard.set(now.timeIntervalSince1970, forKey: Self.persistedTimestampKey)
+        lastRemoteChangeAt = Date()
+        if pendingUserDefaultsPersist {
+            return
+        }
+        pendingUserDefaultsPersist = true
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.pendingUserDefaultsPersist = false
+            if let stamp = self.lastRemoteChangeAt {
+                UserDefaults.standard.set(stamp.timeIntervalSince1970, forKey: Self.persistedTimestampKey)
+            }
+        }
     }
 }


### PR DESCRIPTION
## Headline

Settings’ last-sync indicator stays accurate while avoiding redundant disk writes during busy sync bursts.

## User impact

When iCloud pushes many remote changes in a short time, the app no longer writes the persisted timestamp on every single notification. That cuts unnecessary I/O and reduces wear on storage while the “last activity” signal users see in Settings remains up to date for practical purposes.

## What changed

The iCloud sync activity model still updates the in-memory “last remote change” time whenever a remote-store notification fires, so the UI can reflect fresh activity. Persisting that timestamp to UserDefaults is now coalesced: repeated notifications in a burst schedule a single main-queue flush instead of writing on every event. A small flag prevents stacking duplicate pending flushes until the scheduled write runs.

## Verification

On a Mac with Xcode and the repo’s `grace` CLI, run `grace ci` (or `grace test` with the project’s usual destination) to confirm the GraceNotes scheme still builds and tests pass; optionally exercise Settings with iCloud sync and confirm the last-activity line still updates without excessive churn under rapid sync.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
