### PR TITLE
Skip weekly insight candidate work when the week is sparse

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyInsightCandidateBuilder.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyInsightCandidateBuilder.swift
@@ -13,6 +13,10 @@ struct WeeklyInsightCandidateBuilder {
     }
 
     func buildCandidates(inputs: CandidateInputs) -> [InsightCandidate] {
+        if isSparseWeek(entries: inputs.entries, reflectionDayCount: inputs.currentDayCount) {
+            return []
+        }
+
         var candidates: [InsightCandidate] = []
 
         if let fullCompletion = fullCompletionCandidate(
@@ -37,9 +41,6 @@ struct WeeklyInsightCandidateBuilder {
             candidates.append(shift)
         }
 
-        if isSparseWeek(entries: inputs.entries, reflectionDayCount: inputs.currentDayCount) {
-            return []
-        }
         return candidates
     }
 


### PR DESCRIPTION
## Headline

Weekly review no longer builds pattern insights for sparse weeks only to throw them away.

## User impact

Sparse weeks still get the same gentle fallback messaging you expect, but the app avoids unnecessary work and the flow matches the product rule: pattern-based insights are not shown when reflection is thin.

## What changed

Previously, `buildCandidates` assembled every scored insight (completion streaks, recurring people/themes, gaps, continuity) and only then checked whether the week was sparse, returning an empty list and discarding that work. The sparse-week guard now runs first and returns no candidates immediately, so we never compute insights that would not be used. Behavior for callers is unchanged: an empty candidate list still leads to the existing fallback path.

## Verification

On a Mac with Xcode, run `grace ci` (or `grace test` with the project’s default simulator destination) to confirm the GraceNotes scheme still builds and tests pass. Optionally exercise the weekly review with a sparse week of journaling and confirm fallback insights still appear as before.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
