### PR TITLE
Align Review insights refresh key with a single reference date

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewScreen.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewScreen.swift
@@ -82,13 +82,18 @@ extension ReviewScreen {
     }
 
     private var currentInsightsRefreshKey: ReviewInsightsRefreshKey {
-        let now = Date()
-        let period = ReviewInsightsPeriod.currentPeriod(containing: now, calendar: calendar)
+        makeInsightsRefreshKey(referenceDate: Date())
+    }
+
+    /// Single `Date()` for both the refresh key and `generateInsights` keeps past-window math aligned
+    /// with the staleness token (important when `referenceDate` affects resolved history ranges).
+    private func makeInsightsRefreshKey(referenceDate: Date) -> ReviewInsightsRefreshKey {
+        let period = ReviewInsightsPeriod.currentPeriod(containing: referenceDate, calendar: calendar)
         return ReviewInsightsRefreshKey(
             weekStart: period.lowerBound,
             entrySnapshots: ReviewInsightsRefreshKey.entrySnapshotsAffectingInsights(
                 entries: entries,
-                referenceDate: now,
+                referenceDate: referenceDate,
                 calendar: calendar,
                 pastStatisticsInterval: pastStatisticsInterval,
                 currentReviewPeriod: period
@@ -96,10 +101,6 @@ extension ReviewScreen {
             weekBoundaryPreferenceRawValue: reviewWeekBoundaryRawValue,
             pastStatisticsIntervalToken: pastStatisticsInterval.cacheKeyToken
         )
-    }
-
-    private var currentReviewPeriod: Range<Date> {
-        ReviewInsightsPeriod.currentPeriod(containing: Date(), calendar: calendar)
     }
 
     private var calendar: Calendar {
@@ -423,7 +424,8 @@ extension ReviewScreen {
             return
         }
 
-        let refreshKey = currentInsightsRefreshKey
+        let referenceDate = Date()
+        let refreshKey = makeInsightsRefreshKey(referenceDate: referenceDate)
         let shouldRefresh = ReviewInsightsRefreshPolicy.shouldRefresh(
             hasInsights: reviewInsights != nil,
             previousKey: lastInsightsRefreshKey,
@@ -434,7 +436,7 @@ extension ReviewScreen {
         isLoadingInsights = true
         let generatedInsights = await reviewInsightsProvider.generateInsights(
             from: entries,
-            referenceDate: Date(),
+            referenceDate: referenceDate,
             calendar: calendar,
             pastStatisticsInterval: pastStatisticsInterval
         )
@@ -442,7 +444,7 @@ extension ReviewScreen {
             isLoadingInsights = false
             return
         }
-        if refreshKey != currentInsightsRefreshKey {
+        if refreshKey != makeInsightsRefreshKey(referenceDate: Date()) {
             isLoadingInsights = false
             return
         }
@@ -462,7 +464,7 @@ extension ReviewScreen {
         guard !entries.isEmpty else { return }
         guard reviewInsights == nil else { return }
         reviewInsights = await reviewInsightsCache.insights(
-            forWeekStart: currentReviewPeriod.lowerBound,
+            forWeekStart: currentInsightsRefreshKey.weekStart,
             calendar: calendar,
             weekBoundaryPreferenceRawValue: reviewWeekBoundaryRawValue,
             pastStatisticsIntervalToken: pastStatisticsInterval.cacheKeyToken


### PR DESCRIPTION
## Headline

Past tab insights now compute week boundaries and history windows from one shared moment.

## User impact

When the clock or data changes while insights load, week and “past window” math can disagree if different `Date()` values are mixed in. That mismatch can surface as wrong or discarded insights, odd cache hits, or extra refreshes around week boundaries. This change keeps generation, staleness checks, and cache hydration pointed at the same week token so Review feels stable and trustworthy.

## What changed

The screen used several separate `Date()` calls for the current review period, the insights refresh key, async generation, and cache hydration. Those can diverge across a single frame or an await, so the refresh token, computed snapshots, and cached week key were not guaranteed to describe the same instant.

The update introduces a small helper that builds the refresh key from an explicit reference date and uses one captured `Date()` for both the key and `generateInsights` during a refresh pass. Stale-run detection still compares against a fresh key after the await so work is abandoned when inputs truly change. Cache hydration now keys off the same week start as the refresh key instead of a second, independently computed period. The redundant period-only accessor was removed in favor of that single source.

## Verification

On a Mac with Xcode 26+, run `swiftlint lint` from the repo root and `grace ci` (or `grace test` with the project’s default simulator destination). Manually open the Past/Review tab and, if feasible, repeat near a week boundary or after changing the past-statistics interval to confirm insights load once and stay consistent with the visible week.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
