### PR TITLE
Harden weekly review warm-up detection against invalid ranges

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/ReviewWeekTrendPolicy.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ReviewWeekTrendPolicy.swift
@@ -7,12 +7,18 @@ enum ReviewWeekTrendPolicy {
 
     /// Whether `referenceDate` falls on the first or second local day of `currentPeriod`.
     static func isWarmUpPhase(currentPeriod: Range<Date>, referenceDate: Date, calendar: Calendar) -> Bool {
+        guard currentPeriod.lowerBound < currentPeriod.upperBound else {
+            return false
+        }
         let weekStart = calendar.startOfDay(for: currentPeriod.lowerBound)
         let refDay = calendar.startOfDay(for: referenceDate)
         guard refDay >= weekStart, refDay < currentPeriod.upperBound else {
             return false
         }
-        let dayOffset = calendar.dateComponents([.day], from: weekStart, to: refDay).day ?? 0
+        guard let dayOffset = calendar.dateComponents([.day], from: weekStart, to: refDay).day,
+              dayOffset >= 0 else {
+            return false
+        }
         return warmUpDayRange.contains(dayOffset)
     }
 


### PR DESCRIPTION
## Headline

Trending themes no longer misclassify the warm-up window when the week range or day math is ambiguous.

## User impact

The Review screen’s “Trending” logic uses a short warm-up window at the start of each week. If that window was computed from an empty range or a missing day offset, the app could treat the wrong days as warm-up, hiding or showing trend changes incorrectly. This change keeps that classification predictable and conservative when inputs are invalid.

## What changed

The warm-up check now bails out when the current week range is empty (lower bound not before upper bound), so we never infer “first two days” from a nonsensical interval.

Day offset between the week start and the reference date must be present and non-negative; we no longer substitute a missing component with zero, which could incorrectly count as the first warm-up day in edge cases.

## Verification

On a Mac with Xcode and the repo’s `grace` CLI installed, run `grace ci` (or `grace test` with the project’s default simulator destination) to lint and build; exercise the Journal Review / Trending area in the simulator and confirm early-week behavior still matches expectations.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
