### PR TITLE
Prefer first non-empty weekly insight headline for resurfacing

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyInsightRuleEngine.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyInsightRuleEngine.swift
@@ -47,14 +47,9 @@ struct WeeklyInsightRuleEngine {
         )
 
         let narrativeSummary = candidateBuilder.narrativeSummary(from: selectedInsights)
-        let trimmedHeadline = selectedInsights.first?.observation
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        let resurfacingMessage: String
-        if let trimmedHeadline, !trimmedHeadline.isEmpty {
-            resurfacingMessage = trimmedHeadline
-        } else {
-            resurfacingMessage = String(localized: "review.insights.starterReflection")
-        }
+        let starterReflection = String(localized: "review.insights.starterReflection")
+        let trimmedHeadline = Self.firstNonEmptyTrimmedObservation(in: selectedInsights)
+        let resurfacingMessage = trimmedHeadline ?? starterReflection
 
         let continuityPrompt = selectedInsights.compactMap(\.action).map {
             $0.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -72,5 +67,17 @@ struct WeeklyInsightRuleEngine {
             weekStats: aggregates.stats,
             presentationMode: aggregates.supportsInsightNarrative ? .insight : .statsFirst
         )
+    }
+
+    /// Prefer the first non-empty observation line across selected insights. The first card can be
+    /// blank in pathological cases while a second selected insight still carries the visible headline.
+    private static func firstNonEmptyTrimmedObservation(in insights: [ReviewWeeklyInsight]) -> String? {
+        for insight in insights {
+            let trimmed = insight.observation.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                return trimmed
+            }
+        }
+        return nil
     }
 }


### PR DESCRIPTION
## Headline

Weekly review resurfacing text now skips blank first cards and uses the first real insight line.

## User impact

When the first selected weekly insight has an empty or whitespace-only observation but a later insight has real text, the review screen now shows that meaningful line instead of the generic starter reflection. This keeps the resurfacing message aligned with what you can actually read in the insight cards and avoids a confusing generic fallback.

## What changed

The weekly insight rule engine used to take the resurfacing headline only from the first selected insight’s observation, then fall back to the localized starter reflection if that string was empty after trimming. It now walks the full list of selected insights and uses the first non-empty trimmed observation, and only uses the starter reflection when none of the selected insights provide text. A small private helper encapsulates that scan so the behavior is explicit and documented for rare “blank first card” cases.

## Verification

On a Mac with the repo’s Xcode setup, run `grace ci` (or `grace test` with the project’s usual simulator destination) to confirm the app builds and tests pass; exercise the weekly review flow with data that produces multiple insights and confirm the resurfacing line matches the first non-empty insight observation.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
