### PR TITLE
Align journal Bloom level with at-or-above slot fill rule

### DIFF
--- a/GraceNotes/GraceNotes/Data/Models/Journal.swift
+++ b/GraceNotes/GraceNotes/Data/Models/Journal.swift
@@ -131,7 +131,7 @@ final class JournalEntry {
             return .soil
         }
 
-        if gratitudesCount == slotCount && needsCount == slotCount && peopleCount == slotCount {
+        if gratitudesCount >= slotCount && needsCount >= slotCount && peopleCount >= slotCount {
             return .bloom
         }
 


### PR DESCRIPTION
## Headline

Bloom now matches the same “enough entries in each section” rule as completion and history.

## User impact

Growth-stage labeling (Bloom) and what the app treats as a fully filled day stay in sync. That avoids confusing mismatches between the chip status and completion-style behavior if definitions ever diverge or data sits at the slot cap.

## What changed

Journal completion used an exact equality check against the per-section slot count to pick Bloom, while related helpers already used an at-or-above threshold for “all sections full.” The Bloom branch now uses that same at-or-above rule so one place cannot disagree with the others.

## Verification

On macOS with Xcode and the iOS Simulator, run `grace ci` from the repo root (or `grace test` with the project’s default destination) to lint and exercise the GraceNotes build.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
