### PR TITLE
Play completion info card entry animation only once

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/CompletionInfoCard.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/CompletionInfoCard.swift
@@ -4,6 +4,7 @@ struct CompletionInfoCard: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.todayJournalPalette) private var palette
     @State private var contentVisible = false
+    @State private var didPlayEntryAnimation = false
 
     let badgeInfo: CompletionBadgeInfo
     let cardTintColor: Color
@@ -69,6 +70,12 @@ struct CompletionInfoCard: View {
             contentVisible = true
             return
         }
+
+        if didPlayEntryAnimation {
+            contentVisible = true
+            return
+        }
+        didPlayEntryAnimation = true
 
         contentVisible = false
 


### PR DESCRIPTION
## Headline

The journal completion hint card no longer replays its fade-in every time the view reappears.

## User impact

SwiftUI can call `onAppear` more than once when you navigate away and back or when parent state updates. Re-running the entry animation made the card briefly hide and slide in again, which felt glitchy and could distract while journaling. After this change, the first appearance still animates in; later appearances stay visible without repeating the motion.

## What changed

`CompletionInfoCard` tracks whether the entry animation has already run. When Reduce Motion is off, the first time `animateEntry()` runs it still starts hidden and eases the text in. If `onAppear` fires again, the view skips resetting to hidden and animating again—it simply keeps the content visible. Reduce Motion behavior is unchanged: content shows immediately with no animation.

## Verification

On a Mac with Xcode, build and run the GraceNotes scheme in the iOS Simulator and open a journal day where the completion info card appears; leave and return (or trigger whatever flow used to re-call `onAppear`) and confirm the card does not flash or replay the entrance. For CI parity, run `grace ci` from the repo root.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
