### PR TITLE
Reset Settings highlights on disappear and remove unused app tour storage

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/SettingsScreen.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/SettingsScreen.swift
@@ -19,7 +19,6 @@ struct SettingsScreen: View {
     @State private var highlightedTarget: SettingsScrollTarget?
     @State private var settingsHighlightDismissTask: Task<Void, Never>?
     @State private var showAppTourFromSettings = false
-    @AppStorage(JournalOnboardingStorageKeys.hasSeenAppTour) private var hasSeenAppTour = false
     @AppStorage(JournalOnboardingStorageKeys.completedGuidedJournal) private var hasCompletedGuidedJournal = false
     /// Same storage as first Full/Harvest celebration; unlocks Bloom in Advanced settings.
     @AppStorage(JournalTutorialStorageKeys.celebratedFirstBloom) private var hasCelebratedFirstBloom = false
@@ -135,6 +134,8 @@ struct SettingsScreen: View {
             }
             .onDisappear {
                 settingsHighlightDismissTask?.cancel()
+                settingsHighlightDismissTask = nil
+                highlightedTarget = nil
             }
             .onChange(of: scenePhase) { _, newValue in
                 guard newValue == .active else { return }


### PR DESCRIPTION
## Headline

Leaving Settings now clears scroll highlight state and an unused onboarding flag is gone.

## User impact

If highlight or scroll-to-section state lingered after you left Settings, returning could show the wrong row emphasized or keep unnecessary background work tied to the old highlight. Dropping the unused “has seen app tour” binding also avoids pointless UserDefaults observation in this screen.

## What changed

Settings no longer holds an App Storage property for whether the user has seen the app tour, because this view did not use it. When Settings disappears, the code still cancels the highlight dismiss task, then clears the task handle and resets the active scroll target highlight so the next visit does not inherit stale UI state.

## Verification

On macOS with the repo’s dev tooling installed, run `grace ci` from the repository root (or `grace test` for the default simulator). In the Simulator, open Settings, trigger a flow that scrolls to and highlights a section (for example via navigation that sets a settings scroll target), leave Settings, and return to confirm the highlight is not stuck from the previous visit.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
