### PR TITLE
Serialize backup export history on the main actor

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/Services/BackupExportHistoryStore.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/Services/BackupExportHistoryStore.swift
@@ -18,6 +18,8 @@ enum BackupExportHistoryStore {
     private static let userDefaultsKey = "BackupExportHistory.entries"
     private static let maxEntries = 40
 
+    /// Serialize with the main actor: `record` is a read-modify-write and must not interleave.
+    @MainActor
     static func record(
         finishedAt: Date = .now,
         success: Bool,
@@ -42,6 +44,7 @@ enum BackupExportHistoryStore {
         UserDefaults.standard.set(data, forKey: userDefaultsKey)
     }
 
+    @MainActor
     static func load() -> [BackupExportHistoryEntry] {
         guard let data = UserDefaults.standard.data(forKey: userDefaultsKey),
               let decoded = try? JSONDecoder().decode([BackupExportHistoryEntry].self, from: data) else {


### PR DESCRIPTION
## Headline

Backup and export history updates no longer race across threads when saving to settings storage.

## User impact

If multiple backup or export completions happened close together, the app could interleave reads and writes of the history list and lose or mix up entries. Keeping this path on the main actor makes updates predictable so the history you see matches what actually completed.

## What changed

Backup export history recording loads existing entries, inserts a new one, trims the list, and writes it back—a classic read-modify-write. Those steps are now main-actor isolated so they cannot interleave with each other from different threads. Loading the history for display uses the same isolation so reads and writes stay consistent with each other. A short note in code documents why serialization is tied to the main actor.

## Verification

On a Mac with Xcode and the iOS Simulator, run `grace ci` (or `grace test` with the project’s usual destination) to confirm the app still builds and tests pass after the concurrency annotation.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
