### PR TITLE
Stabilize journal history month grouping and sort entries by date

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/HistoryEntryGrouping.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/HistoryEntryGrouping.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SwiftData
 
 enum HistoryEntryGrouping {
     static func groupedByMonth(
@@ -10,7 +9,9 @@ enum HistoryEntryGrouping {
             monthKey(for: entry.entryDate, calendar: calendar)
         }
         return grouped.keys.sorted(by: >).map { month in
-            let groupedEntries = grouped[month] ?? []
+            let groupedEntries = (grouped[month] ?? []).sorted {
+                $0.entryDate > $1.entryDate
+            }
             return (month, groupedEntries)
         }
     }
@@ -21,6 +22,24 @@ enum HistoryEntryGrouping {
         if let intervalStart = calendar.dateInterval(of: .month, for: date)?.start {
             return intervalStart
         }
+        var components = calendar.dateComponents([.year, .month], from: date)
+        components.day = 1
+        components.hour = 0
+        components.minute = 0
+        components.second = 0
+        components.nanosecond = 0
+        if let normalized = calendar.date(from: components) {
+            return normalized
+        }
+        return gregorianUTCMonthStart(for: date)
+    }
+
+    /// When the active calendar cannot form a month start, anchor by Gregorian UTC year/month
+    /// so entries in the same month are not split by day. `startOfDay` is only used if even
+    /// this normalization fails.
+    private static func gregorianUTCMonthStart(for date: Date) -> Date {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
         var components = calendar.dateComponents([.year, .month], from: date)
         components.day = 1
         components.hour = 0


### PR DESCRIPTION
## Headline

Journal history lists months reliably and shows the newest entries first within each month.

## User impact

History is easier to scan when days in a month appear in a sensible order instead of arbitrary grouping order. Unusual or edge-case calendars are less likely to split one month into multiple sections or scatter entries, so the list stays trustworthy.

## What changed

Removed an unused SwiftData import from the history grouping helper. Within each month bucket, entries are now ordered by entry date with the most recent first. When the user’s calendar cannot build a month key from components, the code no longer jumps straight to start-of-day on that calendar (which could fragment a month). It instead anchors the bucket to the start of the month in the Gregorian calendar at UTC, and only uses a day-based fallback if that still fails.

## Verification

On a Mac with the repo’s dev setup, run `grace ci` (or `grace test`) to confirm the GraceNotes scheme builds and tests pass; optionally open Journal history and confirm entries under a month are newest-first and month headers do not duplicate for the same calendar month.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
