### PR TITLE
Sanitize invalid stored reminder time before rescheduling

### DIFF
--- a/GraceNotes/GraceNotes/Services/Reminders/DailyReminderNotificationSync.swift
+++ b/GraceNotes/GraceNotes/Services/Reminders/DailyReminderNotificationSync.swift
@@ -14,7 +14,10 @@ enum DailyReminderNotificationSync {
         guard status == .enabled else { return }
 
         let stored = userDefaults.object(forKey: ReminderSettings.timeIntervalKey) as? TimeInterval
-        let interval = stored ?? ReminderSettings.defaultTimeInterval
+        var interval = stored ?? ReminderSettings.defaultTimeInterval
+        if !interval.isFinite {
+            interval = ReminderSettings.defaultTimeInterval
+        }
         let reminderTime = ReminderSettings.date(from: interval)
         let body: String
         do {


### PR DESCRIPTION
## Headline

Daily reminders fall back to a sane default when saved time data is corrupted.

## User impact

Corrupted or invalid stored reminder times (for example NaN or infinity from UserDefaults) could produce unpredictable scheduling or odd notification behavior. This change treats those values as missing and uses the app’s default reminder time so notifications stay reliable and predictable.

## What changed

When syncing the repeating daily reminder, the code now reads the stored time interval into a mutable value and checks whether it is finite. If the stored value is not finite, it is replaced with the standard default interval before computing the reminder time and rescheduling. The rest of the flow—building the localized body and calling the scheduler—is unchanged.

## Verification

On a Mac with Xcode and the project’s grace CLI installed, run `grace ci` from the repo root (or `grace test` with the usual simulator destination) to confirm lint and build/tests pass.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
