### PR TITLE
Gate completion info card interaction until entry animation finishes

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/CompletionInfoCard.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/CompletionInfoCard.swift
@@ -13,6 +13,10 @@ struct CompletionInfoCard: View {
     let showMorph: Bool
     let bloomProgress: CGFloat
 
+    private var isEntryRevealed: Bool {
+        contentVisible || reduceMotion
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             Text(badgeInfo.description)
@@ -21,8 +25,8 @@ struct CompletionInfoCard: View {
                 .fixedSize(horizontal: false, vertical: true)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .opacity(contentVisible || reduceMotion ? 1 : 0)
-        .offset(y: contentVisible || reduceMotion ? 0 : 8)
+        .opacity(isEntryRevealed ? 1 : 0)
+        .offset(y: isEntryRevealed ? 0 : 8)
         .padding(AppTheme.spacingRegular)
         .background(cardSurface)
         .overlay(
@@ -30,6 +34,8 @@ struct CompletionInfoCard: View {
                 .stroke(cardTintColor.opacity(0.38), lineWidth: 1)
         )
         .shadow(color: cardTintColor.opacity(reduceTransparency ? 0.18 : 0.24), radius: 8, x: 0, y: 4)
+        .allowsHitTesting(isEntryRevealed)
+        .accessibilityHidden(!isEntryRevealed)
         .accessibilityElement(children: .contain)
         .onAppear {
             animateEntry()


### PR DESCRIPTION
## Headline

The journal completion hint card no longer steals taps or confuses VoiceOver while it is still fading in.

## User impact

During the brief entry animation, the card could still participate in hit testing and accessibility even though it looked invisible, which could block taps behind it or expose unreadable content to assistive technologies. The card now only accepts touches and appears in the accessibility tree once it is actually shown.

## What changed

The view now derives a single “entry revealed” flag from the existing animation state and reduced-motion setting, and uses it for opacity and vertical offset as before. That same flag drives hit testing and accessibility visibility so invisible-in-practice UI does not intercept input or announce to VoiceOver until the reveal completes.

## Verification

On a Mac with Xcode and the project’s grace CLI installed, run `grace ci` (or at least build and exercise the journal completion flow with VoiceOver and tap targets around the card during the animation).

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
