### PR TITLE
Stabilize most recurring themes list in weekly review insights

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewMostRecurringCard.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewMostRecurringCard.swift
@@ -50,21 +50,18 @@ struct ReviewMostRecurringCard: View {
 
     private func contentForInsights(_ insights: ReviewInsights) -> some View {
         let themes = insights.weekStats.mostRecurringThemes
+        let panel = themesPanel(
+            themes: themes,
+            referenceDate: insights.generatedAt,
+            calendar: reviewCalendar
+        )
         return Group {
             if isLoading {
-                themesPanel(
-                    themes: themes,
-                    referenceDate: insights.generatedAt,
-                    calendar: reviewCalendar
-                )
-                .accessibilityHint(String(localized: "review.insights.updatedWhenReady"))
-                .accessibilityAddTraits(.updatesFrequently)
+                panel
+                    .accessibilityHint(String(localized: "review.insights.updatedWhenReady"))
+                    .accessibilityAddTraits(.updatesFrequently)
             } else {
-                themesPanel(
-                    themes: themes,
-                    referenceDate: insights.generatedAt,
-                    calendar: reviewCalendar
-                )
+                panel
             }
         }
     }
@@ -80,7 +77,7 @@ struct ReviewMostRecurringCard: View {
         ) {
             VStack(alignment: .leading, spacing: 10) {
                 VStack(alignment: .leading, spacing: 8) {
-                    ForEach(Array(themes.prefix(3))) { theme in
+                    ForEach(Array(themes.prefix(3).enumerated()), id: \.offset) { _, theme in
                         mostRecurringThemeRow(theme)
                     }
                 }


### PR DESCRIPTION
## Headline

Weekly review’s “most recurring” themes stay aligned with your data while insights refresh.

## User impact

When review stats reload, the top recurring themes should no longer feel like they “jump” or reuse the wrong row. Tapping a theme or using VoiceOver should match what you see on screen, including while numbers are still updating.

## What changed

The card now builds the recurring-themes panel once and reuses it for loading and loaded states, so only the loading-specific accessibility hint and “updates frequently” trait differ instead of duplicating the whole panel.

The top three theme rows are keyed by their position in the list (first, second, third) instead of each theme’s own identity. That gives SwiftUI a stable row identity when the underlying theme data or ordering changes during refresh, which reduces mistaken row reuse and odd updates.

Together, these changes improve reliability of the review card when insights are in flux and keep the loading experience consistent with the rest of review insights.

## Verification

On a Mac with Xcode and the project’s grace CLI installed, run `grace ci` from the repo root (or `grace test` with the usual simulator destination) to lint and build; in the simulator, open weekly review with recurring themes and trigger a refresh to confirm rows and accessibility behave as expected.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
