### PR TITLE
Skip autosave when immediate line edits do not change text

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/ViewModels/JournalViewModel+EntryEditing.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/ViewModels/JournalViewModel+EntryEditing.swift
@@ -70,6 +70,7 @@ extension JournalViewModel {
     func updateGratitudeImmediate(at index: Int, fullText: String) -> Int? {
         let trimmed = fullText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard index >= 0, index < gratitudes.count, !trimmed.isEmpty else { return nil }
+        guard trimmed != gratitudes[index].fullText else { return index }
 
         gratitudes[index] = Entry(fullText: trimmed, id: gratitudes[index].id)
         scheduleAutosave()
@@ -90,6 +91,7 @@ extension JournalViewModel {
     func updateNeedImmediate(at index: Int, fullText: String) -> Int? {
         let trimmed = fullText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard index >= 0, index < needs.count, !trimmed.isEmpty else { return nil }
+        guard trimmed != needs[index].fullText else { return index }
 
         needs[index] = Entry(fullText: trimmed, id: needs[index].id)
         scheduleAutosave()
@@ -110,6 +112,7 @@ extension JournalViewModel {
     func updatePersonImmediate(at index: Int, fullText: String) -> Int? {
         let trimmed = fullText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard index >= 0, index < people.count, !trimmed.isEmpty else { return nil }
+        guard trimmed != people[index].fullText else { return index }
 
         people[index] = Entry(fullText: trimmed, id: people[index].id)
         scheduleAutosave()


### PR DESCRIPTION
## Headline

Journal line updates no longer trigger saves when the text is unchanged.

## User impact

Typing or focus changes that do not actually change a gratitude, need, or person line were still replacing the row and scheduling autosave, which could mean extra work, churn, and unnecessary persistence. After this change, those no-op edits are ignored so journaling feels the same while doing less redundant saving.

## What changed

The async update helpers already skipped work when trimmed text matched what was stored. The immediate update paths for gratitudes, needs, and people did not—they always rebuilt the entry and called autosave. This brings the immediate paths in line: if the trimmed text equals the current line, the method returns the same index without replacing the entry or scheduling autosave.

## Verification

On a Mac with the repo’s tooling, run `swiftlint lint` from the repo root and `grace ci` (or `grace test` with the project’s usual simulator destination). In the app, edit a line without changing its meaning (for example, blur focus or trigger updates with identical text) and confirm behavior is unchanged while redundant saves are avoided.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
