### PR TITLE
Clamp past statistics interval quantity to picker bounds

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/AdvancedSettingsScreen.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/AdvancedSettingsScreen.swift
@@ -24,7 +24,7 @@ struct AdvancedSettingsScreen: View {
         let encoded = UserDefaults.standard.string(forKey: PastStatisticsIntervalPreference.appStorageKey) ?? ""
         let selection = PastStatisticsIntervalPreference.selection(fromAppStorage: encoded).validated
         _intervalMode = State(initialValue: selection.mode == .all ? .all : .custom)
-        _customQuantity = State(initialValue: selection.quantity)
+        _customQuantity = State(initialValue: Self.clampedPickerQuantity(selection.quantity))
         _customUnit = State(initialValue: selection.unit)
     }
 
@@ -147,6 +147,10 @@ struct AdvancedSettingsScreen: View {
         )
     }
 
+    private static func clampedPickerQuantity(_ quantity: Int) -> Int {
+        min(max(quantity, 1), 999)
+    }
+
     private func localizedUnitLabel(_ unit: PastStatisticsIntervalUnit) -> String {
         switch unit {
         case .week:
@@ -160,7 +164,7 @@ struct AdvancedSettingsScreen: View {
 
     private func loadIntervalState() {
         let selection = PastStatisticsIntervalPreference.selection(fromAppStorage: intervalEncoded).validated
-        customQuantity = selection.quantity
+        customQuantity = Self.clampedPickerQuantity(selection.quantity)
         customUnit = selection.unit
         intervalMode = selection.mode == .all ? .all : .custom
     }


### PR DESCRIPTION
## Headline

Keeps the custom “past statistics” window length aligned with what the picker can actually show.

## User impact

If a saved or migrated value ever fell outside the 1–999 range the wheel supports, the control could behave oddly or fail to reflect your choice. This change normalizes the value so the picker always has a valid selection and the screen stays consistent.

## What changed

Advanced settings loads the saved “past statistics” interval from app storage and binds it to a wheel-style quantity picker that only offers 1 through 999. Previously, the code trusted the stored quantity as-is; any out-of-range value could disagree with the picker’s tags and produce unreliable UI state.

The screen now clamps the quantity to that same 1–999 range when initializing state and whenever the stored setting is reloaded—without changing the rest of the interval logic—so the visible value always matches what the picker can represent.

## Verification

On a Mac with Xcode, run `grace ci` (or `grace test` with the project’s usual simulator destination) to confirm the GraceNotes scheme still builds and tests pass. Open Settings → Advanced, choose Custom for the past statistics interval, and confirm the quantity wheel shows a value between 1 and 999 after relaunching after edge-case storage (if you can simulate a bad value).

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
