### PR TITLE
Improve startup loading accessibility for VoiceOver and retry

### DIFF
--- a/GraceNotes/GraceNotes/Application/StartupLoadingView.swift
+++ b/GraceNotes/GraceNotes/Application/StartupLoadingView.swift
@@ -24,10 +24,10 @@ struct StartupLoadingView: View {
         VStack(spacing: 20) {
             Spacer()
 
-            ProgressView()
-                .progressViewStyle(.circular)
-                .opacity(isFailure ? 0 : 1)
-                .accessibilityHidden(isFailure)
+            if !isFailure {
+                ProgressView()
+                    .progressViewStyle(.circular)
+            }
 
             Text(primaryMessage)
                 .font(AppTheme.warmPaperBody)
@@ -35,6 +35,7 @@ struct StartupLoadingView: View {
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 24)
                 .accessibilityIdentifier("StartupMessage")
+                .accessibilityAddTraits(isReassuranceMessage ? .updatesFrequently : [])
 
             if case .retryableFailure = state {
                 Button {
@@ -43,6 +44,7 @@ struct StartupLoadingView: View {
                     if isRetrying {
                         ProgressView()
                             .frame(maxWidth: .infinity)
+                            .accessibilityHidden(true)
                     } else {
                         Text(String(localized: "common.retry"))
                             .frame(maxWidth: .infinity)
@@ -57,6 +59,7 @@ struct StartupLoadingView: View {
                 .padding(.horizontal, 24)
                 .disabled(isRetrying)
                 .accessibilityIdentifier("StartupRetryButton")
+                .accessibilityLabel(String(localized: "common.retry"))
             }
 
             Spacer()
@@ -72,6 +75,13 @@ struct StartupLoadingView: View {
         case .retryableFailure(let message):
             return message
         }
+    }
+
+    private var isReassuranceMessage: Bool {
+        if case .loading(_, let isReassurance) = state {
+            return isReassurance
+        }
+        return false
     }
 
     private var isFailure: Bool {


### PR DESCRIPTION
## Headline

The startup screen announces loading and retry more clearly and avoids confusing hidden controls when something goes wrong.

## User impact

VoiceOver users get clearer guidance while the app starts and when a connection problem needs a retry. Screen reader output is less noisy during retry, and the retry action has an explicit label so it matches what sighted users see.

## What changed

The main spinner is no longer kept in the view tree hidden on failure; it only appears while loading, which avoids invisible focus targets and odd semantics. While showing reassurance-style loading copy, the status text is marked so assistive tech can treat it as updating frequently. When the user taps Retry and an inline progress indicator appears, that spinner is hidden from accessibility so it does not compete with the button. The Retry control now has an explicit accessibility label aligned with the localized Retry string.

## Verification

On a Mac with Xcode and the iOS Simulator, run `grace ci` (or `grace test` with the project’s usual destination) to confirm the app builds and tests pass. Optionally enable VoiceOver on the simulator and walk through startup failure and retry to hear the updated announcements.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
