### PR TITLE
Hash UI-test store paths and fix UITest persistence tracing

### DIFF
--- a/GraceNotes/GraceNotes/Data/Persistence/SwiftData/PersistenceController.swift
+++ b/GraceNotes/GraceNotes/Data/Persistence/SwiftData/PersistenceController.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 import SwiftData
 
@@ -62,20 +63,26 @@ final class PersistenceController {
             url: uiTestStoreURL,
             cloudKitDatabase: .none
         )
+        let container: ModelContainer
         do {
-            let container = try ModelContainer(for: schema, configurations: configuration)
-            try seedUITestDataIfNeeded(in: container)
-            PerformanceTrace.end("PersistenceController.makeForUITesting", startedAt: startupTrace)
-            let snapshot = PersistenceRuntimeSnapshot.forDiskLaunch(
-                userRequestedCloudSync: Self.cloudSyncEnabled(using: .standard),
-                storeUsesCloudKit: false,
-                startupUsedCloudKitFallback: false
-            )
-            return PersistenceController(container: container, runtimeSnapshot: snapshot)
+            container = try ModelContainer(for: schema, configurations: configuration)
         } catch {
             PerformanceTrace.end("PersistenceController.makeForUITesting.failed", startedAt: startupTrace)
             throw PersistenceControllerError.unableToCreateContainer(error)
         }
+        do {
+            try seedUITestDataIfNeeded(in: container)
+        } catch {
+            PerformanceTrace.end("PersistenceController.makeForUITesting.failed", startedAt: startupTrace)
+            throw error
+        }
+        PerformanceTrace.end("PersistenceController.makeForUITesting", startedAt: startupTrace)
+        let snapshot = PersistenceRuntimeSnapshot.forDiskLaunch(
+            userRequestedCloudSync: Self.cloudSyncEnabled(using: .standard),
+            storeUsesCloudKit: false,
+            startupUsedCloudKitFallback: false
+        )
+        return PersistenceController(container: container, runtimeSnapshot: snapshot)
     }
 
     static func makeInMemoryForTesting() throws -> PersistenceController {
@@ -156,6 +163,13 @@ final class PersistenceController {
     }
 #endif
 
+    /// Stable, bounded-length filename so long `XCTestConfigurationFilePath` values cannot exceed filesystem limits.
+    private static func uiTestStoreFileName(for sessionKey: String) -> String {
+        let digest = SHA256.hash(data: Data(sessionKey.utf8))
+        let hex = digest.map { String(format: "%02x", $0) }.joined()
+        return "ui-test-\(hex).store"
+    }
+
     private static var uiTestStoreURL: URL {
         let fileManager = FileManager.default
         let appSupportURL = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
@@ -181,10 +195,7 @@ final class PersistenceController {
             try? sessionKey.write(to: markerURL, atomically: true, encoding: .utf8)
         }
 
-        let safeSessionKey = sessionKey
-            .replacingOccurrences(of: "/", with: "_")
-            .replacingOccurrences(of: ":", with: "_")
-        let fileName = "ui-test-\(safeSessionKey).store"
+        let fileName = uiTestStoreFileName(for: sessionKey)
         return uiTestDirectory.appendingPathComponent(fileName, isDirectory: false)
     }
 


### PR DESCRIPTION
## Headline

Automated UI tests get stable on-disk store files and clearer failure signals when setup goes wrong.

## User impact

Everyday journaling in the shipping app is unchanged. This hardens the UI-test-only SwiftData store path so extreme Xcode configuration paths cannot hit filesystem length limits, and it makes automated runs more dependable and easier to diagnose when seeding fails.

## What changed

The UI-test session key is still derived the same way (XCTest config path when present, otherwise a remembered marker or a new UUID), but the on-disk filename is now a fixed-length SHA-256–based name instead of embedding a long path with a few character swaps. That keeps paths within typical OS limits while still giving each session its own store.

`makeForUITesting` now opens the `ModelContainer` first, then seeds test data in a separate step. Container creation failures still map to the existing startup error, while seed failures end the performance trace as failed and rethrow the underlying error instead of lumping everything into one failure type.

## Verification

On a Mac with Xcode and simulators, run `grace ci` (or `grace test` with your usual destination) so lint and the simulator build pass; exercise `GraceNotesUITests` in Xcode if you want to confirm UI-test startup and store selection end-to-end.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
