### PR TITLE
Fix review insights decoding for trending themes and legacy evidence

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/ReviewInsights.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ReviewInsights.swift
@@ -123,7 +123,9 @@ struct ReviewMostRecurringTheme: Equatable, Hashable, Sendable, Codable, Identif
             evidence = structuredEvidence
         } else if let legacyEvidence = try container.decodeIfPresent([ReviewThemeEvidence].self, forKey: .evidence) {
             evidence = legacyEvidence.flatMap { row in
-                row.sources.map { source in
+                var seenInRow = Set<ReviewThemeSourceCategory>()
+                let uniqueSources = row.sources.filter { seenInRow.insert($0).inserted }
+                return uniqueSources.map { source in
                     ReviewThemeSurfaceEvidence(entryDate: row.date, source: source, content: "")
                 }
             }
@@ -363,7 +365,8 @@ struct ReviewWeekStats: Equatable, Sendable, Codable {
     let historyCompletionMix: ReviewWeekCompletionMix
     let mostRecurringThemes: [ReviewMostRecurringTheme]
     let movementThemes: [ReviewMovementTheme]
-    /// Grouped trending rows (same models as ``movementThemes``, which is ``trendingBuckets.flattened``).
+    /// Grouped trending rows (new / rising / down). ``movementThemes`` is usually the same set, reordered.
+    /// If both fields exist in JSON, prefer non-empty ``movementThemes`` so stable rows are not dropped on decode.
     let trendingBuckets: ReviewTrendingBuckets
 
     init(
@@ -400,7 +403,7 @@ struct ReviewWeekStats: Equatable, Sendable, Codable {
         self.mostRecurringThemes = mostRecurringThemes
         if let buckets = trendingBuckets {
             self.trendingBuckets = buckets
-            self.movementThemes = buckets.flattened
+            self.movementThemes = movementThemes.isEmpty ? buckets.flattened : movementThemes
         } else {
             self.movementThemes = movementThemes
             self.trendingBuckets = ReviewTrendingBuckets(bucketing: movementThemes)
@@ -451,7 +454,7 @@ struct ReviewWeekStats: Equatable, Sendable, Codable {
             try container.decodeIfPresent([ReviewMovementTheme].self, forKey: .movementThemes) ?? []
         if let buckets = try container.decodeIfPresent(ReviewTrendingBuckets.self, forKey: .trendingBuckets) {
             trendingBuckets = buckets
-            movementThemes = buckets.flattened
+            movementThemes = decodedMovement.isEmpty ? buckets.flattened : decodedMovement
         } else {
             movementThemes = decodedMovement
             trendingBuckets = ReviewTrendingBuckets(bucketing: decodedMovement)


### PR DESCRIPTION
## Headline

Weekly review insights load more reliably from cached and mixed-format payloads.

## User impact

Trending themes and theme evidence should no longer disappear or look wrong when older saved data or payloads include both grouped buckets and a separate theme list, or when legacy evidence repeated the same section on one day. Review screens stay consistent with what was stored instead of silently dropping rows.

## What changed

Decoding of legacy theme evidence now removes duplicate journal sections per day before expanding rows, so evidence chips and lists are not inflated with repeats.

When both grouped trending buckets and a flat movement-themes list are present, decoding now keeps the non-empty flat list instead of always replacing it with the flattened buckets. That avoids dropping themes that only appear in one representation and keeps stable ordering where the payload provides it. Comments were updated to describe how those fields relate.

## Verification

On a Mac with the repo and Xcode per AGENTS.md, run `grace ci` (or `grace test` with the default simulator destination) to lint and build. Optionally open the journal review flow with mixed or cached review payloads and confirm trending themes and recurring-theme evidence match expectations.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
