### PR TITLE
Align weekly review movement themes with trending bucket ordering

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/ReviewInsights.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ReviewInsights.swift
@@ -362,8 +362,9 @@ struct ReviewWeekStats: Equatable, Sendable, Codable {
     /// Strongest completion level per calendar day across that same slice; bucket counts sum to entry-days represented.
     let historyCompletionMix: ReviewWeekCompletionMix
     let mostRecurringThemes: [ReviewMostRecurringTheme]
+    /// Surfacing movement rows only (excludes stable trends), matching ``trendingBuckets``.
     let movementThemes: [ReviewMovementTheme]
-    /// Grouped trending rows (same models as ``movementThemes``, which is ``trendingBuckets.flattened``).
+    /// Grouped trending rows; ``movementThemes`` is ``trendingBuckets.flattened``.
     let trendingBuckets: ReviewTrendingBuckets
 
     init(
@@ -402,8 +403,9 @@ struct ReviewWeekStats: Equatable, Sendable, Codable {
             self.trendingBuckets = buckets
             self.movementThemes = buckets.flattened
         } else {
-            self.movementThemes = movementThemes
-            self.trendingBuckets = ReviewTrendingBuckets(bucketing: movementThemes)
+            let buckets = ReviewTrendingBuckets(bucketing: movementThemes)
+            self.trendingBuckets = buckets
+            self.movementThemes = buckets.flattened
         }
     }
 
@@ -453,8 +455,9 @@ struct ReviewWeekStats: Equatable, Sendable, Codable {
             trendingBuckets = buckets
             movementThemes = buckets.flattened
         } else {
-            movementThemes = decodedMovement
-            trendingBuckets = ReviewTrendingBuckets(bucketing: decodedMovement)
+            let buckets = ReviewTrendingBuckets(bucketing: decodedMovement)
+            trendingBuckets = buckets
+            movementThemes = buckets.flattened
         }
     }
 


### PR DESCRIPTION
## Headline

Weekly review trending lists now match the grouped buckets: same themes, order, and stable-theme filtering.

## User impact

Trending and movement rows stay consistent with the new, rising, and down sections, so users do not see extra stable themes or a different order in one place than another. Cached review data decodes the same way, with movement rows derived from the bucketed list.

## What changed

Previously, when week stats were built or decoded from raw movement rows, the flat movement list was kept as-is while grouped buckets were built separately by filtering and sorting. That could let stable themes appear in the flat list or let order diverge from the grouped UI.

The initializer and decoder now build trending buckets once and set movement themes from that bucket’s flattened list, so the flat list always matches the grouped buckets (movement-only, consistent ordering). Documentation was updated to describe movement themes as movement rows only and to clarify the relationship to trending buckets.

## Verification

On macOS with Xcode, run `grace ci` (or `grace test` with the project’s default simulator destination) from the repo root to lint and build. Optionally open the weekly review screen and confirm trending movement rows match the new, rising, and down sections in order and content.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
