### PR TITLE
Harden sticky completion chip visibility against invalid scroll geometry

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/JournalStickyCompletionVisibility.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/JournalStickyCompletionVisibility.swift
@@ -16,7 +16,7 @@ enum JournalStickyCompletionVisibility {
 
     /// Reveal the toolbar chip when the user has scrolled the journal body down past `scrollRevealThreshold`.
     ///
-    /// Uses the scroll view's ``ScrollGeometryProxy/contentOffset`` ``y`` (larger when content moves up).
+    /// Uses the scroll view's ``ScrollGeometry/contentOffset`` ``y`` (larger when content moves up).
     ///
     /// - Parameter currentlyRevealed: Pass the **current** sticky state so hysteresis can apply.
     static func shouldShowBarIndicator(
@@ -24,6 +24,9 @@ enum JournalStickyCompletionVisibility {
         scrollRevealThreshold: CGFloat,
         currentlyRevealed: Bool
     ) -> Bool {
+        guard scrollContentOffsetY.isFinite, scrollRevealThreshold.isFinite else {
+            return currentlyRevealed
+        }
         if currentlyRevealed {
             return scrollContentOffsetY > scrollRevealThreshold + releasePadding
         }
@@ -46,6 +49,9 @@ enum JournalStickyCompletionVisibility {
         scrollRevealThreshold: CGFloat,
         currentlyRevealed: Bool
     ) -> Bool {
+        guard headerMinYInScrollSpace.isFinite, scrollRevealThreshold.isFinite else {
+            return currentlyRevealed
+        }
         if currentlyRevealed {
             return headerMinYInScrollSpace < -(scrollRevealThreshold + releasePadding)
         }


### PR DESCRIPTION
## Headline

Keep the journal completion chip from glitching when scroll metrics are temporarily invalid.

## User impact

The sticky completion indicator should no longer jump or flip unpredictably if the system reports non-finite scroll or layout values during rare transitions. Documentation for the scroll API reference is corrected so future maintenance matches the actual Swift symbol.

## What changed

The visibility helpers that decide when to show the toolbar completion chip now bail out early when the scroll offset, header position in scroll space, or reveal threshold is not a finite number. In those cases the chip keeps its current shown or hidden state instead of re-evaluating comparisons that can behave oddly with NaN or infinity. A doc comment was updated to point at the correct ScrollGeometry symbol for content offset.

## Verification

On a Mac with Xcode, run `grace ci` (or `grace test` with the project’s usual simulator destination) to lint and build; exercise the journal screen and scroll so the completion chip appears and hides as before, including edge cases like rapid layout changes if you can reproduce them.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
