### PR TITLE
Ignore stale iCloud status when refresh calls overlap

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/ICloudAccountStatusModel.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/ICloudAccountStatusModel.swift
@@ -7,14 +7,19 @@ final class ICloudAccountStatusModel: ObservableObject {
     @Published private(set) var displayedBucket: ICloudAccountBucket?
 
     private let provider: any ICloudAccountStatusProviding
+    /// Increments on each `refresh()` so a slower, older fetch cannot overwrite a newer result.
+    private var refreshGeneration = 0
 
     init(provider: any ICloudAccountStatusProviding = ICloudAccountStatusService()) {
         self.provider = provider
     }
 
     func refresh() {
-        Task {
+        refreshGeneration += 1
+        let generation = refreshGeneration
+        Task { @MainActor in
             let bucket = await provider.fetchAccountBucket()
+            guard generation == refreshGeneration else { return }
             displayedBucket = bucket
         }
     }


### PR DESCRIPTION
## Headline

Settings keeps the latest iCloud account check when refreshes finish out of order.

## User impact

Overlapping iCloud account status checks no longer let a slow response replace a newer one, so the Settings row is less likely to flash or show the wrong availability. That makes the sync status easier to trust when you open settings or pull to refresh.

## What changed

The model used to assign every fetch result to the UI in whatever order network or system work finished. That could briefly show an outdated bucket after a quicker, newer check had already completed. The change adds a simple generation counter on each refresh and only applies the result when it still matches the latest generation. The refresh task is explicitly main-actor isolated to align with the observable model.

## Verification

On macOS with the project toolchain, from the repo root run `grace ci` (lint plus simulator build) or `grace test` for the default GraceNotes test destination, per project docs.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
