### PR TITLE
Align journal share image width with card layout and harden export

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/JournalShareRenderer.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/JournalShareRenderer.swift
@@ -6,21 +6,22 @@ enum JournalShareRenderer {
     ///
     /// `ImageRenderer` proposes a size to the root view. If that size is effectively unbounded,
     /// flexible-width SwiftUI content can lay out poorly and `uiImage` may be nil or empty.
-    /// A concrete width matches typical phone layout and keeps the export stable across devices.
+    /// Width must match `JournalShareCardView` export layout: inner `cardWidth` plus horizontal `padding`.
     @MainActor static func renderImage(from payload: ShareRenderPayload) -> UIImage? {
         let cardView = JournalShareCardView(payload: payload, onLineTap: nil)
         let renderer = ImageRenderer(content: cardView)
         renderer.proposedSize = ProposedViewSize(width: Self.proposedLayoutWidth, height: nil)
         renderer.scale = Self.pixelScale
-        return renderer.uiImage
+        guard let image = renderer.uiImage else { return nil }
+        guard image.size.width > 0, image.size.height > 0 else { return nil }
+        return image
     }
 
-    private static let proposedLayoutWidth: CGFloat = 390
+    /// Keep in sync with `JournalShareCardView` (`cardWidth` + twice `padding`).
+    private static let proposedLayoutWidth: CGFloat = 448 + 24 * 2
 
     private static var pixelScale: CGFloat {
-        if #available(iOS 17.0, *) {
-            return UITraitCollection.current.displayScale
-        }
-        return UIScreen.main.scale
+        let scale = UITraitCollection.current.displayScale
+        return scale > 0 ? scale : UIScreen.main.scale
     }
 }


### PR DESCRIPTION
## Headline

Shared journal images now match the on-screen card and skip invalid bitmaps.

## User impact

Exports and shares that use the rendered image should look consistent with the journal share card instead of being squeezed or mis-sized from a mismatched width. If rendering fails or produces an empty image, the app can avoid handing callers a useless bitmap.

## What changed

The share image renderer now proposes the same horizontal width as `JournalShareCardView`’s export layout (inner card width plus side padding), instead of a generic phone width, so `ImageRenderer` lays out like the real card. `renderImage` returns nil when there is no image or when width or height is zero, avoiding blank or invalid results. Pixel scale now prefers the current trait collection’s display scale and falls back to the main screen scale only when that value is not usable, simplifying the previous availability split.

## Verification

On a Mac with Xcode and the project’s dev CLI, run `grace ci` (or `grace test` with the usual simulator destination from `gracenotes-dev.toml`). Manually share or export a journal entry and confirm the generated image matches the card preview and looks sharp on device or simulator.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
