### PR TITLE
Preserve pending reminders when reschedule hits undecided notification permission

### DIFF
--- a/GraceNotes/GraceNotes/Services/Reminders/ReminderScheduler.swift
+++ b/GraceNotes/GraceNotes/Services/Reminders/ReminderScheduler.swift
@@ -91,6 +91,13 @@ struct ReminderScheduler {
 
     /// Reschedules only when authorization is already available.
     func rescheduleEnabledReminder(at time: Date, body: String) async -> ReminderSyncResult {
+        // `notDetermined` is not a denial. This path does not prompt, so treat it as “cannot
+        // reconcile now” and keep any existing pending request (maps to the same UI result as
+        // before, without clearing a still-valid schedule).
+        if await notificationCenter.authorizationStatus() == .notDetermined {
+            return .permissionDenied
+        }
+
         switch await notificationPermissionOutcome(allowPermissionPrompt: false) {
         case .granted:
             let wasScheduled = await scheduleReminder(at: time, body: body)


### PR DESCRIPTION
## Headline

Silent reminder rescheduling no longer wipes a valid pending notification when iOS has not decided on alerts yet.

## User impact

If notification permission was still undecided, the reschedule path could treat that like a hard denial and remove the pending daily reminder, so users could lose a working schedule without meaning to. The app still reports that it cannot reconcile the reminder in that situation, but it no longer clears an existing pending request, which keeps reliability closer to what users expect.

## What changed

The daily reminder scheduler’s “reschedule without prompting” path used to flow through permission handling that classified an undecided authorization state the same as a denial and removed pending notification requests. That was too aggressive for a state that is not the same as the user saying no. The reschedule flow now handles the undecided case up front: it stops before the removal logic, returns the same high-level sync outcome the UI already understood, and leaves any still-valid pending reminder in place.

## Verification

On a Mac with Xcode and the project’s tooling, run `grace test` or `grace ci` for the GraceNotes scheme; optionally exercise reminder settings in the Simulator (toggle time while permission is undecided vs denied) to confirm reminders are not cleared in the undecided case.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
