### PR TITLE
Gate wide Review rhythm seed on UI test mode

### DIFF
--- a/GraceNotes/GraceNotes/Application/ProcessInfo+GraceNotesUITesting.swift
+++ b/GraceNotes/GraceNotes/Application/ProcessInfo+GraceNotesUITesting.swift
@@ -12,7 +12,9 @@ extension ProcessInfo {
         return isUITestBundle || hasUITestLaunchArgument
     }
 
+    /// True when UI tests request the wide Review rhythm seed (ignored unless `graceNotesIsRunningUITests` is also true).
     static var graceNotesUITestWideReviewRhythmSeed: Bool {
-        processInfo.arguments.contains(Self.graceNotesUITestWideReviewRhythmArgument)
+        guard graceNotesIsRunningUITests else { return false }
+        return Self.processInfo.arguments.contains(Self.graceNotesUITestWideReviewRhythmArgument)
     }
 }


### PR DESCRIPTION
## Headline

Test-only Review seeding no longer activates unless the app is actually running UI tests.

## User impact

Everyday journaling is unchanged. This tightens when the app honors the UI-test-only “wide Review rhythm” seed, so normal launches cannot pick up that behavior from a stray launch argument alone.

## What changed

The wide Review rhythm seed flag used to turn on whenever a specific launch argument appeared, even if the process was not running as a UI test. The flag is now ignored unless the app already detects UI testing (UITest bundle or the standard UI-testing launch argument). That keeps test seeding scoped to real UI test runs and avoids surprising Review data when someone launches the app with extra arguments by mistake.

## Verification

On a Mac with the repo and Xcode, run `grace ci` (or `grace test` for the relevant UITest target) to confirm the project still builds and UI tests pass. Optionally launch the app outside UI tests with the wide-rhythm argument and confirm Review is not seeded that way; run UI tests that pass the argument and confirm the wide rhythm still appears as expected.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
