### PR TITLE
Reject invalid lapse thresholds in reminder notification body selection

### DIFF
--- a/GraceNotes/GraceNotes/Services/Reminders/ReminderNotificationBodySelector.swift
+++ b/GraceNotes/GraceNotes/Services/Reminders/ReminderNotificationBodySelector.swift
@@ -93,12 +93,16 @@ enum ReminderNotificationBodySelector {
     }
 
     /// True when we should use welcoming-back copy (requires a prior meaningful day and
-    /// a gap of at least ``minimumGapDays``).
+    /// a gap of at least ``minimumGapDays`` calendar days).
+    ///
+    /// Non-positive ``minimumGapDays`` is invalid configuration and never yields a lapse
+    /// (avoids treating `gapDays == 0` as a lapse when the threshold is zero).
     static func isLapse(
         gapDays: Int?,
         minimumGapDays: Int = 3
     ) -> Bool {
         guard let gapDays else { return false }
+        guard minimumGapDays > 0 else { return false }
         return gapDays >= minimumGapDays
     }
 


### PR DESCRIPTION
## Headline

Daily journal reminders no longer show “welcome back” copy when the lapse threshold is misconfigured.

## User impact

If the lapse threshold were ever set to zero or a negative value, the app could incorrectly treat a same-day gap as a lapse and show welcoming-back reminder text when you had actually journaled recently. This change treats non-positive thresholds as invalid so that path cannot fire by mistake, keeping reminder tone accurate and predictable.

## What changed

The reminder body selector’s lapse check now requires a positive minimum gap in calendar days before it can classify a period away from journaling as a lapse. Documentation was clarified to say the comparison uses calendar days and to explain that zero or negative thresholds are invalid configuration and never produce a lapse, preventing the edge case where a zero-day gap matched a zero threshold.

## Verification

On a Mac with Xcode and the project’s grace CLI installed, run `grace ci` (or `grace test` with the usual simulator destination from gracenotes-dev.toml) to confirm the app still builds and tests pass; optionally spot-check reminder scheduling logic or unit tests that cover `isLapse` if they exist in the test target.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
