### PR TITLE
Cap review journal locale detection work for large histories

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/ReviewJournalThemeLanguageResolver.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ReviewJournalThemeLanguageResolver.swift
@@ -29,13 +29,14 @@ struct ReviewJournalThemeLanguageResolver: ReviewJournalThemeLanguageResolving {
             return Self.englishCatalogLocale
         }
 
-        let meaningfulCount = trimmed.filter { !$0.isWhitespace }.count
-        guard meaningfulCount >= minimumMeaningfulGraphemes else {
+        guard Self.hasEnoughMeaningfulGraphemes(trimmed, minimum: minimumMeaningfulGraphemes) else {
             return Self.englishCatalogLocale
         }
 
+        let analysisText = Self.analysisSample(from: trimmed)
+
         let recognizer = NLLanguageRecognizer()
-        recognizer.processString(trimmed)
+        recognizer.processString(analysisText)
 
         if let dominant = recognizer.dominantLanguage {
             let hypotheses = recognizer.languageHypotheses(withMaximum: 5)
@@ -45,10 +46,29 @@ struct ReviewJournalThemeLanguageResolver: ReviewJournalThemeLanguageResolving {
             }
         }
 
-        return Self.scriptTieBreakLocale(trimmed: trimmed)
+        return Self.scriptTieBreakLocale(trimmed: analysisText)
     }
 
     private static let englishCatalogLocale = Locale(identifier: "en")
+
+    /// Upper bound on text fed to `NLLanguageRecognizer` and script tie-break (prefix by extended grapheme cluster).
+    private static let maximumAnalysisGraphemes = 50_000
+
+    private static func hasEnoughMeaningfulGraphemes(_ text: String, minimum: Int) -> Bool {
+        var count = 0
+        for character in text where !character.isWhitespace {
+            count += 1
+            if count >= minimum {
+                return true
+            }
+        }
+        return count >= minimum
+    }
+
+    /// Keeps language detection and script scanning bounded on pathologically long corpora without scanning `count`.
+    private static func analysisSample(from trimmed: String) -> String {
+        String(trimmed.prefix(maximumAnalysisGraphemes))
+    }
 
     /// Maps recognizer output to a locale that exists in `Localizable.xcstrings` (we ship `en` + `zh-Hans`).
     private static func catalogLocale(for language: NLLanguage) -> Locale {


### PR DESCRIPTION
## Headline

Past tab theme chip language stays fast and stable even when journal text is enormous.

## User impact

Users with very large journals no longer pay the cost of scanning or analyzing the entire corpus just to pick English versus Simplified Chinese for curated theme copy. The Past tab should feel responsive and avoid unnecessary memory and CPU spikes when resolving that locale.

## What changed

Language detection for the Past tab’s curated theme chips used to count every non-whitespace character and feed the full trimmed journal text into Natural Language recognition and script tie-breaking. On pathologically long corpora that could mean a lot of extra work for little benefit.

The resolver now stops counting meaningful graphemes as soon as the minimum threshold is met, and it analyzes only a bounded prefix (by extended grapheme clusters) for recognition and script tie-breaks. Behavior for normal-sized journals should match prior intent; only extreme sizes are bounded.

## Verification

On a Mac with Xcode and the project’s grace CLI, run `grace ci` (or `grace test` with the usual simulator destination) to confirm the GraceNotes scheme still builds and tests pass.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
