### PR TITLE
Gate multiline scroll and caret nudge on focused journal field

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/EditableTextSection.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/EditableTextSection.swift
@@ -76,13 +76,18 @@ struct EditableTextSection: View {
             textEditor
                 .onChange(of: text) { _, newValue in
                     let newCount = newValue.filter { $0 == "\n" }.count
-                    if let onMultilineLineAdded, newCount > storedNewlineCount {
+                    // `nudgeFirstResponderUITextViewCaretIntoVisibleContent` affects whichever UITextView is first
+                    // responder; only react when this section owns focus (or no focus binding is provided).
+                    let isThisFieldFocused = inputFocus?.wrappedValue ?? true
+                    if let onMultilineLineAdded, isThisFieldFocused, newCount > storedNewlineCount {
                         onMultilineLineAdded()
                     }
                     storedNewlineCount = newCount
-                    Task { @MainActor in
-                        await Task.yield()
-                        JournalCaretVisibilityReader.nudgeFirstResponderUITextViewCaretIntoVisibleContent()
+                    if isThisFieldFocused {
+                        Task { @MainActor in
+                            await Task.yield()
+                            JournalCaretVisibilityReader.nudgeFirstResponderUITextViewCaretIntoVisibleContent()
+                        }
                     }
                 }
         }


### PR DESCRIPTION
## Headline

Multiline Return handling only affects the text field you are actively editing.

## User impact

When the journal screen has several large text areas, invisible updates or another field owning the keyboard could still trigger caret nudges and scroll behavior meant for the focused editor. That could feel jumpy or scroll the wrong section. This change limits those reactions to the field that actually has focus so typing and keyboard scrolling stay aligned with what you are editing.

## What changed

The multiline text section watches the bound string for new line breaks so the parent can scroll the editor above the keyboard and a helper can keep the caret visible. The caret helper operates on whichever native text view is first responder, so every section was eligible to run even when this section was not the one being edited. The section now derives whether it owns focus from the optional focus binding when present, and only fires the multiline callback and schedules the visibility nudge when that is true. If no focus binding is supplied, behavior matches the prior assumption that this section is the active input. A short comment documents why the guard exists.

## Verification

On macOS with Xcode, build and run the GraceNotes scheme in Simulator; exercise a screen with multiple EditableTextSection instances (e.g. Reading Notes and Reflections), focus one field, and confirm Return in another path does not mis-scroll the unfocused area. For automation parity, run `grace ci` from the repo root (or `grace test` per your usual profile).

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
