### PR TITLE
Use typed Locale.Language.Code for share typography selection

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/ShareTypographyScript.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ShareTypographyScript.swift
@@ -9,8 +9,8 @@ enum ShareTypographyScript: Equatable, Sendable {
 
 extension ShareTypographyScript {
     static func current() -> ShareTypographyScript {
-        switch Locale.current.language.languageCode?.identifier {
-        case "zh", "ja", "ko":
+        switch Locale.current.language.languageCode {
+        case .some(.chinese), .some(.japanese), .some(.korean):
             return .chinese
         default:
             return .latin


### PR DESCRIPTION
## Headline

Share cards pick CJK vs Latin typography using stable, typed language codes instead of string IDs.

## User impact

Chinese, Japanese, and Korean locales still get CJK-appropriate share typography; the choice is less brittle to identifier string quirks and aligns with how the system represents languages.

## What changed

Share typography selection no longer compares raw language code strings to "zh", "ja", and "ko". It now switches on the optional `Locale.Language.Code` from the current locale and treats Chinese, Japanese, and Korean as the CJK path. Behavior and comments stay the same; the implementation is more idiomatic and easier to keep correct as APIs evolve.

## Verification

On a Mac with Xcode and the project’s `grace` CLI (`grace test` / `grace ci`), confirm the GraceNotes scheme builds and tests pass; optionally sanity-check a share preview in zh/ja/ko vs a Latin locale to confirm typography still matches expectations.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
