### PR TITLE
Harden journal completion pill morph overlays and hit testing

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/JournalCompletionPill.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/JournalCompletionPill.swift
@@ -15,6 +15,11 @@ struct JournalCompletionPill: View {
     var morphAccentColor: Color = .clear
     var morphBloomProgress: CGFloat = 0
 
+    /// Defensive clamp so morph bloom visuals stay stable if progress is driven past 0…1.
+    private var clampedMorphBloomProgress: CGFloat {
+        min(max(morphBloomProgress, 0), 1)
+    }
+
     var body: some View {
         pillLabel
             .fixedSize(horizontal: false, vertical: true)
@@ -25,6 +30,7 @@ struct JournalCompletionPill: View {
             .overlay(
                 RoundedRectangle(cornerRadius: AppTheme.cornerRadiusMedium)
                     .stroke(borderColor(for: completionLevel), lineWidth: 1)
+                    .allowsHitTesting(false)
             )
             .scaleEffect(scaleFactor(for: completionLevel, isCelebrating: isCelebrating))
             .shadow(
@@ -41,10 +47,11 @@ struct JournalCompletionPill: View {
                 if morphSource {
                     RoundedRectangle(cornerRadius: AppTheme.cornerRadiusMedium)
                         .stroke(
-                            morphAccentColor.opacity(0.32 * morphBloomProgress),
+                            morphAccentColor.opacity(0.32 * clampedMorphBloomProgress),
                             lineWidth: 1.6
                         )
-                        .scaleEffect(1.02 + (0.08 * (1 - morphBloomProgress)))
+                        .scaleEffect(morphBloomScale)
+                        .allowsHitTesting(false)
                 }
             }
             .opacity(morphSource && !reduceMotion ? 0.92 : 1)
@@ -53,6 +60,14 @@ struct JournalCompletionPill: View {
 
     private var isCelebrating: Bool {
         celebratingLevel == completionLevel && completionLevel != .soil
+    }
+
+    /// Matches background morph: skip frame-driven scale when Reduce Motion is on (settled outline only).
+    private var morphBloomScale: CGFloat {
+        if reduceMotion {
+            return 1.02
+        }
+        return 1.02 + (0.08 * (1 - clampedMorphBloomProgress))
     }
 
     private var pillLabel: some View {


### PR DESCRIPTION
## Headline

Smoother, more reliable completion pill during morph animations and with Reduce Motion.

## User impact

Decorative borders and morph outlines no longer intercept taps meant for the pill or surrounding controls, so interactions stay predictable. If bloom progress ever goes outside 0–1, the accent outline and scale stay visually sane instead of blowing out. With Reduce Motion on, the morph outline uses a steady scale that matches the static background instead of pulsing with every frame.

## What changed

The completion pill clamps morph bloom progress to the 0–1 range before driving opacity and scale, so outline strength and size cannot run away if callers pass bad values. The main border stroke and the morph accent stroke are marked non-interactive so they do not block touches. A dedicated scale helper applies the animated bloom scale only when Reduce Motion is off; when Reduce Motion is on, it holds a settled outline scale consistent with the non-animated matched-geometry background.

## Verification

On a Mac with Xcode and the project’s grace CLI installed, run `grace ci` from the repo root (or `grace test` with the usual simulator destination) to lint and build. Manually exercise the journal header completion pill with morph transitions: confirm taps still hit the pill, try Reduce Motion on and off, and sanity-check the morph outline during animations.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
