### PR TITLE
Harden App Tour state updates and stabilize insights preview

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Tutorial/AppTourView.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Tutorial/AppTourView.swift
@@ -60,6 +60,12 @@ struct AppTourView: View {
                 .background(AppTheme.settingsBackground)
         }
         .background(AppTheme.settingsBackground.ignoresSafeArea())
+        .onAppear {
+            let clamped = min(max(pageIndex, firstPageIndex), lastPageIndex)
+            if clamped != pageIndex {
+                pageIndex = clamped
+            }
+        }
         .task {
             reminderState.reminderNotificationBody = { reminderTime in
                 (try? ReminderNotificationBodyBuilder.localizedBody(
@@ -73,7 +79,7 @@ struct AppTourView: View {
         }
         .onChange(of: scenePhase) { _, newValue in
             guard newValue == .active else { return }
-            Task {
+            Task { @MainActor in
                 await reminderState.refreshStatus()
             }
             iCloudAccountState.refresh()
@@ -339,13 +345,12 @@ struct AppTourInsightsPreview: View {
     /// Shows roughly the source row + upper ~4/5 of the Reflection rhythm panel, then fades before Observation.
     private static let previewClipHeight: CGFloat = 360
 
-    private var sampleInsights: ReviewInsights {
-        ReviewInsights.appTourTutorialPreview()
-    }
+    /// Built once so the panel does not rebuild identical preview data on every SwiftUI body pass.
+    private static let sampleInsights = ReviewInsights.appTourTutorialPreview()
 
     var body: some View {
         ReviewDaysYouWrotePanel(
-            insights: sampleInsights,
+            insights: Self.sampleInsights,
             isLoading: false
         )
         .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
## Headline

Makes the guided App Tour more reliable when returning from the background and cheaper to render on the Insights preview.

## User impact

Users should see fewer odd pager or indicator glitches if the tour’s page index ever drifts out of range, and smoother, more consistent behavior when the app becomes active again after switching away. The Insights preview should also do less redundant work while scrolling or re-rendering the tour.

## What changed

The tour now clamps the selected page to the valid first and last indices when the screen appears, so the TabView selection cannot sit on a page that does not exist (for example when the congratulations page is skipped). When the scene returns to the active state, reminder status refresh is explicitly scheduled on the main actor so UI-bound state updates stay on the right isolation domain. The sample Insights data used in the tour preview is stored once as a static value instead of being rebuilt on every view body evaluation, which cuts repeated allocation and unnecessary child updates during layout passes.

## Verification

On a Mac with Xcode and the project’s grace CLI installed, run `grace ci` (or `grace test` with the repo’s default simulator destination) to lint and build; manually open the App Tour from Settings or Today, switch away and back to exercise scene-phase refresh, and flip through pages including the skip-congratulations path to confirm paging and the Insights preview look stable.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
