### PR TITLE
Lock share composer UI while the share card image is rendering

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/JournalShareComposerView.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/JournalShareComposerView.swift
@@ -52,6 +52,7 @@ struct JournalShareComposerView: View {
                     Button(String(localized: "common.cancel"), role: .cancel) {
                         onDismiss()
                     }
+                    .disabled(isShareCommitInProgress)
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button(String(localized: "sharing.composer.share")) {
@@ -66,6 +67,7 @@ struct JournalShareComposerView: View {
         .toolbarBackground(AppTheme.settingsBackground, for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)
         .presentationBackground(AppTheme.settingsBackground)
+        .interactiveDismissDisabled(isShareCommitInProgress)
         .preferredColorScheme(appPreferredColorScheme)
         .alert(String(localized: "sharing.error.unable"), isPresented: $showRenderError) {
             Button(String(localized: "common.dismiss")) {


### PR DESCRIPTION
## Headline

Prevents canceling or swiping away the share sheet until export finishes so sharing stays predictable.

## User impact

While the app builds the share image, leaving the composer early could feel flaky or leave people unsure whether sharing finished. Users now have a clearer, locked surface during that short work so they do not accidentally dismiss or back out mid-export.

## What changed

The journal share composer already tracked when a share commit was in progress and disabled the primary Share control. That state now also disables Cancel and blocks interactive sheet dismissal for the same period, so every obvious exit path matches the in-progress export. The change aligns toolbar behavior with swipe-to-dismiss on the presented sheet and avoids odd half-dismissed states during rendering.

## Verification

On a Mac with Xcode and the iOS Simulator, run `grace ci` (or `grace test` with the project’s default destination) to lint and build. Manually open the journal share composer, tap Share, and confirm Cancel and swipe-to-dismiss stay inactive until the image handoff completes.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
