### PR TITLE
Fix journal onboarding flags when UserDefaults stores booleans as numbers

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalOnboardingProgress.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalOnboardingProgress.swift
@@ -60,7 +60,7 @@ final class JournalOnboardingProgress {
     }
 
     static func resolvedHasCompletedGuidedJournal(using defaults: UserDefaults = .standard) -> Bool {
-        if let storedValue = defaults.object(forKey: JournalOnboardingStorageKeys.completedGuidedJournal) as? Bool {
+        if let storedValue = optionalBool(forKey: JournalOnboardingStorageKeys.completedGuidedJournal, in: defaults) {
             return storedValue
         }
 
@@ -90,7 +90,7 @@ final class JournalOnboardingProgress {
         }
 
         if defaults.bool(forKey: branchKey),
-           defaults.object(forKey: JournalOnboardingStorageKeys.completedGuidedJournal) as? Bool == nil {
+           optionalBool(forKey: JournalOnboardingStorageKeys.completedGuidedJournal, in: defaults) == nil {
             defaults.set(false, forKey: JournalOnboardingStorageKeys.completedGuidedJournal)
         }
 
@@ -144,8 +144,21 @@ final class JournalOnboardingProgress {
         AppLaunchVersionTracker.resetLaunchTracking(in: defaults)
     }
 
+    /// Interprets stored booleans whether `UserDefaults` returns `Bool` or `NSNumber` (plist / sync).
+    private static func optionalBool(forKey key: String, in defaults: UserDefaults) -> Bool? {
+        guard let object = defaults.object(forKey: key) else { return nil }
+        switch object {
+        case let value as Bool:
+            return value
+        case let number as NSNumber:
+            return number.boolValue
+        default:
+            return nil
+        }
+    }
+
     private static func shouldTreatInstallAsPreviouslyOnboarded(using defaults: UserDefaults) -> Bool {
-        if defaults.object(forKey: FirstRunOnboardingStorageKeys.completed) as? Bool == true {
+        if optionalBool(forKey: FirstRunOnboardingStorageKeys.completed, in: defaults) == true {
             return true
         }
 


### PR DESCRIPTION
## Headline

Onboarding and guided-journal completion now stay accurate when defaults round-trip as numbers.

## User impact

Some installs can store boolean settings as numbers (for example from property lists or sync), so the app could misread “completed guided journal” or first-run completion and show the wrong onboarding or repeat prompts. This change keeps those states reliable so returning users see the experience that matches what they already finished.

## What changed

Journal onboarding logic used strict Swift Bool casting when reading a few UserDefaults keys. That fails when the same logical value is stored as NSNumber, so the code could treat a real true/false as missing and run the wrong migration or default path.

The update adds a small helper that accepts either Bool or NSNumber from UserDefaults and uses it wherever those onboarding flags are interpreted, including legacy upgrade migration checks. Behavior for normal Bool storage is unchanged; only the edge case of number-backed storage is handled correctly.

## Verification

On a Mac with the repo and Xcode, run `grace ci` (or `grace test` with the project’s default simulator destination) to confirm the GraceNotes scheme still builds and tests pass.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
