### PR TITLE
Harden ReviewInsightsCache pruning and remove unsafe key lookups

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/ReviewInsightsCache.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ReviewInsightsCache.swift
@@ -124,23 +124,21 @@ actor ReviewInsightsCache {
         weeks: [String: ReviewInsights],
         keepingMostRecent: Int
     ) -> [String: ReviewInsights] {
-        guard weeks.count > keepingMostRecent else {
+        guard keepingMostRecent > 0, weeks.count > keepingMostRecent else {
             return weeks
         }
         // Evict by the decoded `weekStart` in each entry, not by re-parsing the composite key string.
         // That avoids mis-ordering when a key prefix is malformed (e.g. `Double` parse → 0) or the key
         // format diverges from the payload.
-        let sortedKeys = weeks.keys
-            .sorted { key1, key2 in
-                let lhsWeekStart = weeks[key1]!.weekStart
-                let rhsWeekStart = weeks[key2]!.weekStart
-                if lhsWeekStart != rhsWeekStart {
-                    return lhsWeekStart > rhsWeekStart
-                }
-                return key1 < key2
+        let sortedEntries = weeks.sorted { lhs, rhs in
+            let lhsWeekStart = lhs.value.weekStart
+            let rhsWeekStart = rhs.value.weekStart
+            if lhsWeekStart != rhsWeekStart {
+                return lhsWeekStart > rhsWeekStart
             }
-            .prefix(keepingMostRecent)
-        let keysToKeep = Set(sortedKeys)
+            return lhs.key < rhs.key
+        }
+        let keysToKeep = Set(sortedEntries.prefix(keepingMostRecent).map(\.key))
         return weeks.filter { keysToKeep.contains($0.key) }
     }
 }


### PR DESCRIPTION
## Headline

Weekly review insights cache eviction now skips nonsensical limits and sorts without force-unwrapping dictionary keys.

## User impact

Pruning no longer risks wiping the entire cached weekly review history when the retention limit is zero or invalid, so cold launches are more likely to keep the expected stale snapshots for the UI. Sorting by each entry’s stored week start uses the actual payload data consistently and avoids a rare crash if a key were ever missing from the map.

## What changed

The prune path for persisted review-insight weeks now returns the dictionary unchanged unless both the week count exceeds the limit and the “keep” count is a positive integer, which prevents an empty-prefix selection from deleting every cached week. Eviction ordering still prefers newer decoded week start dates with a stable tie-breaker on the composite cache key string, but the implementation sorts key–value pairs directly instead of sorting bare keys and force-unwrapping lookups. That removes force unwraps and makes the sort step easier to reason about.

## Verification

On a Mac with the repo’s Xcode toolchain, run `swiftlint lint` from the repo root and `grace ci` (or `grace test` with the project’s default simulator destination) to confirm the GraceNotes scheme still builds and tests pass.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
