### PR TITLE
Prefer foreground key window and guard caret scroll rects

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/JournalKeyboardScrollSupport.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/JournalKeyboardScrollSupport.swift
@@ -2,9 +2,16 @@ import SwiftUI
 import UIKit
 
 enum JournalKeyWindowReader {
+    /// Prefer the foreground-active scene so Stage Manager / multi-window iPad does not pair keyboard or caret
+    /// geometry with another scene's window (`connectedScenes` order is undefined).
     static func keyWindow() -> UIWindow? {
-        UIApplication.shared.connectedScenes
-            .compactMap { $0 as? UIWindowScene }
+        let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+        if let foreground = scenes.first(where: { $0.activationState == .foregroundActive }) {
+            if let key = foreground.keyWindow ?? foreground.windows.first(where: \.isKeyWindow) {
+                return key
+            }
+        }
+        return scenes
             .flatMap(\.windows)
             .first(where: \.isKeyWindow)
     }
@@ -116,6 +123,9 @@ enum JournalCaretVisibilityReader {
         }
         let verticalPad = max(8, JournalKeyboardScrollMetrics.comfortMarginAboveKeyboard() * 0.4)
         rect = rect.insetBy(dx: -4, dy: -verticalPad)
+        guard rect.origin.x.isFinite, rect.origin.y.isFinite,
+              rect.size.width.isFinite, rect.size.height.isFinite,
+              !rect.isNull, !rect.isInfinite else { return }
         textView.scrollRectToVisible(rect, animated: false)
     }
 


### PR DESCRIPTION
## Headline

Journal keyboard avoidance now keys off the active scene’s window and ignores invalid caret rectangles.

## User impact

On iPad with Stage Manager or multiple windows, keyboard overlap and caret checks can align with the wrong window, so scrolling and skip logic feel wrong or jumpy. The caret nudge path also skips bad rectangles so multiline notes do not feed invalid geometry into scrolling.

## What changed

Key window lookup now resolves `UIWindowScene` instances and, when present, uses the foreground‑active scene, then that scene’s key window or first key window, before the prior flat scan across all scenes and windows. That makes keyboard frame conversion and caret position math match the scene the user is actually typing in when scene order is undefined.

Before scrolling the focused `UITextView` to show the caret, the code validates the computed rectangle is finite and not null or infinite, and bails out otherwise.

## Verification

On a Mac with Xcode, run `grace ci` (or `grace test` with your usual simulator destination) from the repo root. Manually spot‑check on iPad Simulator with Stage Manager or multiple scenes: open the journal, focus Reading Notes or Reflections, and confirm caret stays visible as the keyboard appears without obvious jumps or wrong-window behavior.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
