### PR TITLE
Fix review inset titles crowding trailing metadata in two-column layout

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewInsightInsetPanel.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewInsightInsetPanel.swift
@@ -61,6 +61,15 @@ struct ReviewInsightInsetPanel<Content: View>: View {
         }
     }
 
+    /// Title in the side-by-side row: wrap and shrink so long copy does not crowd out trailing meta text.
+    private var titlePrimaryForHorizontalPair: some View {
+        titlePrimary
+            .lineLimit(2)
+            .minimumScaleFactor(0.85)
+            .multilineTextAlignment(.leading)
+            .frame(minWidth: 0, maxWidth: .infinity, alignment: .leading)
+    }
+
     @ViewBuilder
     private var titleRow: some View {
         if let trailing = titleTrailingText, !trailing.isEmpty {
@@ -75,8 +84,7 @@ struct ReviewInsightInsetPanel<Content: View>: View {
             } else {
                 ViewThatFits(in: .horizontal) {
                     HStack(alignment: .firstTextBaseline, spacing: 8) {
-                        titlePrimary
-                        Spacer(minLength: 8)
+                        titlePrimaryForHorizontalPair
                         Text(trailing)
                             .font(AppTheme.warmPaperMeta)
                             .foregroundStyle(AppTheme.reviewTextMuted)


### PR DESCRIPTION
## Headline

Review insight panels keep dates and meta visible when section titles are long.

## User impact

In Past review, inset panels can show a bold title beside small trailing text (for example dates or rhythm hints). Very long titles could dominate the row and make that trailing information hard to read or feel cramped. This change lets the title flex within the row so the trailing line stays readable.

## What changed

The side-by-side title row for non-accessibility sizes previously put the title and trailing meta in an HStack with a spacer between them. That layout gave the title less predictable room when copy was long or localized strings varied in length, so the trailing meta could feel squeezed or harder to scan.

The title in that horizontal row is now a flexible region: it can wrap to two lines with leading alignment, shrink slightly when space is tight, and expand to fill available width before the trailing label. The spacer between title and meta was removed in favor of that flexible title region. The stacked fallback inside ViewThatFits and the accessibility-size stacked layout are unchanged.

## Verification

On macOS with Xcode and the iOS Simulator installed, run grace ci from the repository root (grace test is also available for the default test workflow). In the simulator, open Past review and inspect inset panels that show both a title and trailing meta; try long titles and larger Dynamic Type to confirm the title wraps or scales while the trailing text remains visible when the horizontal layout is used.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
