### PR TITLE
Harden daily reminder scheduling for reliable repeating notifications

### DIFF
--- a/GraceNotes/GraceNotes/Services/Reminders/ReminderScheduler.swift
+++ b/GraceNotes/GraceNotes/Services/Reminders/ReminderScheduler.swift
@@ -144,6 +144,8 @@ struct ReminderScheduler {
     }
 
     private func scheduleReminder(at time: Date, body: String) async -> Bool {
+        guard time.timeIntervalSinceReferenceDate.isFinite else { return false }
+
         // Do not remove the existing pending request first. Adding a request with the same
         // identifier replaces it; removing first would orphan the user if `add` throws.
         let content = UNMutableNotificationContent()
@@ -151,8 +153,15 @@ struct ReminderScheduler {
         content.body = body
         content.sound = .default
 
-        let timeComponents = ReminderSettings.timeComponents(from: time, calendar: calendar)
-        let trigger = UNCalendarNotificationTrigger(dateMatching: timeComponents, repeats: true)
+        let extracted = ReminderSettings.timeComponents(from: time, calendar: calendar)
+        guard let hour = extracted.hour, let minute = extracted.minute else { return false }
+
+        var triggerComponents = DateComponents()
+        triggerComponents.timeZone = calendar.timeZone
+        triggerComponents.hour = hour
+        triggerComponents.minute = minute
+
+        let trigger = UNCalendarNotificationTrigger(dateMatching: triggerComponents, repeats: true)
         let request = UNNotificationRequest(
             identifier: ReminderSettings.notificationIdentifier,
             content: content,


### PR DESCRIPTION
## Headline

Daily journaling reminders now schedule on a clean, timezone-aware clock time instead of fragile calendar fragments.

## User impact

Users who turn on or reschedule daily reminders should see them fire consistently at the chosen time, with fewer silent failures when something about the picked time cannot be turned into a valid schedule. The app also avoids treating nonsensical dates as schedulable, which keeps reminder state honest instead of looking enabled while nothing reliable was registered.

## What changed

Reminder scheduling used to build the repeating notification trigger from whatever date components were produced for the chosen time. That could be too loose for a repeating daily alarm and did not explicitly pin the calendar’s time zone on the trigger, which matters when translating a wall-clock choice into what UserNotifications actually fires.

The scheduler now rejects non-finite dates outright, requires a resolvable hour and minute, and constructs a minimal trigger carrying only those clock fields plus the calendar’s time zone. That makes the repeating daily trigger align with “same local time every day” and fails safely when those parts cannot be determined.

## Verification

On a Mac with Xcode and the iOS Simulator, run `grace ci` (or at least `grace test`) against the default simulator destinations in `gracenotes-dev.toml`. In the app, enable a daily reminder, pick a time, and confirm the pending notification is created; optionally change time zones or edge times and confirm scheduling still succeeds or surfaces failure without leaving a misleading “on” state.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
