### PR TITLE
Clear stale backup folder list error after a successful reload

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/ImportExportSettingsSupport.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/ImportExportSettingsSupport.swift
@@ -200,6 +200,7 @@ struct BackupFolderImportFileListView: View {
         }
         do {
             files = try BackupFolderLibrary.listExportFiles(in: folderURL)
+            listError = nil
         } catch {
             listError = String(localized: "settings.dataPrivacy.importExport.backupFolder.unreachable")
         }


### PR DESCRIPTION
## Headline

Scheduled backup exports screen no longer stays stuck on an old “unreachable” message after access is restored.

## User impact

If listing the backup folder failed once (for example, a brief permission or access hiccup), the screen could keep showing the error even after a later reload succeeded, which blocked normal browsing and actions. After this change, a successful refresh clears that error so the real file list and toolbar return.

## What changed

The backup folder file list reload path now clears the list error state when enumerating export files succeeds. Previously, a prior failure could leave the error text in place across subsequent successful loads, so the UI did not reflect the current folder state.

## Verification

On a Mac with Xcode and the iOS Simulator, run `grace ci` (or `grace test`) from the repo root. Manually, open Settings → the scheduled backup folder export list, trigger a scenario where listing fails once then succeeds (for example, restore folder access), and confirm the error clears and files appear.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
