### PR TITLE
Remove unused AppNavigationModel from ReviewScreen

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewScreen.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewScreen.swift
@@ -51,7 +51,6 @@ struct ReviewScreen: View {
     @State private var journalSearchText = ""
     @State private var journalSearchMatches: [JournalSearchMatch] = []
     @FocusState private var isPastSearchFieldFocused: Bool
-    @EnvironmentObject private var appNavigation: AppNavigationModel
 
     private let reviewInsightsProvider = ReviewInsightsProvider.shared
     private let reviewInsightsCache = ReviewInsightsCache.shared


### PR DESCRIPTION
## Headline

The Past/Review screen no longer depends on navigation state it never read.

## User impact

You should not notice any change in the Review tab, sheets, or day navigation. The screen simply stops requiring an AppNavigationModel in the environment, which avoids a misleading contract and reduces the chance of setup drift in tests or refactors.

## What changed

ReviewScreen still owned an AppNavigationModel environment object even though the view did not use it. That unused dependency has been removed so the screen only declares the state and services it actually needs.

This tightens the view’s real requirements, which makes embedding and future changes safer because callers are not implicitly obligated to inject navigation state the screen ignores.

## Verification

On a Mac with the repo’s supported Xcode and simulators, run `grace ci` (lint plus simulator build) or `grace test` for the default destination. Smoke the Past/Review tab: open insights, browse sheets, and open a journal day to confirm flows still present and dismiss as before.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
