### PR TITLE
Align VoiceOver hint with show-more control availability

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/SequentialEntryRowView.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/SequentialEntryRowView.swift
@@ -60,10 +60,15 @@ struct SequentialEntryRowView: View {
         self.onDelete = onDelete
     }
 
+    /// Matches when the show-more / show-less control is actually present (see `body`).
+    private var showsExpansionControls: Bool {
+        isExpandable && onToggleExpanded != nil
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             rowButton
-            if isExpandable, let onToggleExpanded {
+            if showsExpansionControls, let onToggleExpanded {
                 Button(action: onToggleExpanded) {
                     HStack(spacing: 4) {
                         Text(isExpanded ? String(localized: "common.showLess") : String(localized: "common.showMore"))
@@ -148,7 +153,7 @@ struct SequentialEntryRowView: View {
     }
 
     private var rowAccessibilityHint: String {
-        if isExpandable {
+        if showsExpansionControls {
             return String(localized: "accessibility.tapToEditSentenceShowMore")
         }
         return String(localized: "accessibility.tapToEditSentence")


### PR DESCRIPTION
## Headline

Journal entry rows no longer promise an expand action when the control is not shown.

## User impact

VoiceOver and other assistive technologies read a hint that matches what is on screen. When a row is marked expandable but no toggle handler is provided, users are no longer told to use “show more” for something that does not appear. That reduces confusion and makes editing long entries more predictable.

## What changed

Sequential entry rows now use a single rule for when the show-more / show-less control is drawn: the row must be expandable and a toggle callback must exist. The same rule drives the row’s accessibility hint, so the spoken guidance stays in sync with the visible UI.

A small private computed property documents that shared condition so the layout and accessibility text do not drift apart again.

## Verification

On a Mac with Xcode and the project’s dev tooling, run `grace ci` (or `grace test` with the default simulator destination from `gracenotes-dev.toml`). With VoiceOver on device or simulator, confirm rows that show the expand control get the “show more” style hint, and rows without that control get the simpler edit hint.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
