### PR TITLE
Harden journal onboarding guidance card and add optional hint line

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalOnboardingGuidanceView.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalOnboardingGuidanceView.swift
@@ -4,26 +4,48 @@ struct JournalOnboardingGuidanceView: View {
     @Environment(\.todayJournalPalette) private var palette
     let title: String
     let message: String
+    /// Optional second line under `message` (e.g. keyboard hint), matching `JournalOnboardingSectionGuidance`.
+    let messageSecondary: String?
+
+    init(title: String, message: String, messageSecondary: String? = nil) {
+        self.title = title
+        self.message = message
+        self.messageSecondary = messageSecondary
+    }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: AppTheme.spacingTight) {
-            Text(title)
-                .font(AppTheme.warmPaperMetaEmphasis)
-                .foregroundStyle(AppTheme.accentText)
+        if message.isEmpty {
+            EmptyView()
+        } else {
+            VStack(alignment: .leading, spacing: AppTheme.spacingTight) {
+                if !title.isEmpty {
+                    Text(title)
+                        .font(AppTheme.warmPaperMetaEmphasis)
+                        .foregroundStyle(AppTheme.accentText)
+                        .accessibilityAddTraits(.isHeader)
+                }
 
-            Text(message)
-                .font(AppTheme.warmPaperBody)
-                .foregroundStyle(palette.textPrimary)
-                .fixedSize(horizontal: false, vertical: true)
+                Text(message)
+                    .font(AppTheme.warmPaperBody)
+                    .foregroundStyle(palette.textPrimary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                if let messageSecondary {
+                    Text(messageSecondary)
+                        .font(AppTheme.warmPaperBody)
+                        .foregroundStyle(palette.textPrimary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .padding(AppTheme.spacingRegular)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(palette.paper.opacity(palette.sectionPaperOpacity))
+            .clipShape(RoundedRectangle(cornerRadius: AppTheme.cornerRadiusMedium))
+            .overlay(
+                RoundedRectangle(cornerRadius: AppTheme.cornerRadiusMedium)
+                    .stroke(palette.inputBorder, lineWidth: 1)
+            )
+            .accessibilityElement(children: .combine)
         }
-        .padding(AppTheme.spacingRegular)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(palette.paper.opacity(palette.sectionPaperOpacity))
-        .clipShape(RoundedRectangle(cornerRadius: AppTheme.cornerRadiusMedium))
-        .overlay(
-            RoundedRectangle(cornerRadius: AppTheme.cornerRadiusMedium)
-                .stroke(palette.inputBorder, lineWidth: 1)
-        )
-        .accessibilityElement(children: .combine)
     }
 }


### PR DESCRIPTION
## Headline

Onboarding tips now hide when empty, support a second line, and read better with VoiceOver.

## User impact

Users no longer see an empty guidance card when there is nothing to say. Callouts can include a short follow-up line (for example a keyboard hint) without crowding the main message. Screen reader users get a clearer structure when a title is shown.

## What changed

Journal onboarding guidance was updated so the card only appears when the main message is non-empty, avoiding blank boxes. An optional second line was added under the primary message, aligned with section guidance patterns, with a memberwise initializer defaulting it to nil. The title is omitted when it is empty, and when it is present it is exposed as a header for accessibility. The combined accessibility element and visual styling (padding, paper background, border) apply only to the non-empty content path.

## Verification

On a Mac with Xcode and the iOS Simulator, run `grace ci` (or `grace test` per project defaults). In the app, open the journal tutorial/onboarding flow and confirm guidance cards disappear when messaging is empty, titles and optional second lines render as expected, and VoiceOver announces titles as headers when shown.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
