### PR TITLE
Pause Bloom leaf video when app is not active

### DIFF
--- a/GraceNotes/GraceNotes/DesignSystem/BloomLeavesOverlays.swift
+++ b/GraceNotes/GraceNotes/DesignSystem/BloomLeavesOverlays.swift
@@ -86,12 +86,18 @@ private struct LoopingVideoPlayerView: UIViewRepresentable {
 
     func updateUIView(_ uiView: LeavesVideoHostView, context: Context) {
         context.coordinator.updateBounds(uiView.bounds)
-        if scenePhase == .active {
+        switch scenePhase {
+        case .active:
             context.coordinator.resumePlaybackIfAttached()
+        case .inactive, .background:
+            context.coordinator.pausePlaybackIfAttached()
+        @unknown default:
+            context.coordinator.pausePlaybackIfAttached()
         }
     }
 
     static func dismantleUIView(_ uiView: LeavesVideoHostView, coordinator: Coordinator) {
+        uiView.onBoundsChange = nil
         coordinator.teardown()
     }
 
@@ -131,6 +137,10 @@ private struct LoopingVideoPlayerView: UIViewRepresentable {
 
         func resumePlaybackIfAttached() {
             player?.play()
+        }
+
+        func pausePlaybackIfAttached() {
+            player?.pause()
         }
 
         func teardown() {


### PR DESCRIPTION
## Headline

Bloom mode’s looping leaf video now stops when you leave the app and cleans up more safely when the overlay is torn down.

## User impact

The decorative leaf loop no longer keeps decoding and drawing while Grace Notes is in the background, which saves battery and avoids unnecessary work when you multitask or lock the phone. Clearing the bounds callback when the view is removed reduces the risk of stray updates after the overlay is gone.

## What changed

Playback was only explicitly resumed when the scene became active; inactive and background phases did not pause the player, so the loop could keep running off-screen. The overlay now switches on scene phase: play while active, pause when inactive, in the background, or for any future unknown phase. A dedicated pause path mirrors the existing resume helper. When SwiftUI dismantles the representable view, the host view’s bounds-change handler is cleared before teardown so layout callbacks do not fire after cleanup.

## Verification

On a Mac with Xcode, run `grace ci` (or `grace test` per project defaults) to lint and build the GraceNotes scheme for the configured simulator; in the simulator, open Bloom mode with the leaf overlay, send the app to background or open the app switcher, and confirm leaves stop animating; return to the app and confirm playback resumes.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
