### PR TITLE
Align scheduled backup timestamps and log export failures

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/Services/ScheduledBackupRunner.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/Services/ScheduledBackupRunner.swift
@@ -54,7 +54,8 @@ enum ScheduledBackupRunner {
 
     /// Export to a temp file, copy into the backup folder, then delete the temp file — all on the same background task.
     private static func performScheduledExport(modelContainer: ModelContainer) -> ScheduledExportResult {
-        let exportResult = exportToTemporaryFile(modelContainer: modelContainer)
+        let exportDate = Date()
+        let exportResult = exportToTemporaryFile(modelContainer: modelContainer, exportDate: exportDate)
         let tempFile: URL
         switch exportResult {
         case .success(let url):
@@ -66,20 +67,20 @@ enum ScheduledBackupRunner {
             try? FileManager.default.removeItem(at: tempFile)
         }
         do {
-            let fileName = try copyScheduledExportToFolder(tempFile: tempFile)
+            let fileName = try copyScheduledExportToFolder(tempFile: tempFile, exportDate: exportDate)
             return .success(fileName)
         } catch {
             return .copyFailed(error)
         }
     }
 
-    private static func copyScheduledExportToFolder(tempFile: URL) throws -> String {
+    private static func copyScheduledExportToFolder(tempFile: URL, exportDate: Date) throws -> String {
         try ScheduledBackupPreferences.withFolderSecurityScopedAccess { folderURL in
-            let name = try copyTempExport(at: tempFile, to: folderURL)
+            let name = try copyTempExport(at: tempFile, to: folderURL, exportDate: exportDate)
             do {
                 try BackupFolderLibrary.prune(
                     folderURL: folderURL,
-                    now: Date(),
+                    now: exportDate,
                     retention: ScheduledBackupPreferences.backupRetentionPeriod,
                     maxTotalBytes: ScheduledBackupPreferences.backupFolderSizeCap.maxBytes
                 )
@@ -94,14 +95,14 @@ enum ScheduledBackupRunner {
         }
     }
 
-    private static func copyTempExport(at tempFile: URL, to folderURL: URL) throws -> String {
+    private static func copyTempExport(at tempFile: URL, to folderURL: URL, exportDate: Date) throws -> String {
         let formatter = DateFormatter()
         formatter.calendar = Calendar(identifier: .gregorian)
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.timeZone = TimeZone(secondsFromGMT: 0)
         formatter.dateFormat = "yyyyMMdd-HHmmss"
         // UUID avoids same-second overwrites (copyTempFile replaces an existing destination name).
-        let name = "grace-notes-scheduled-\(formatter.string(from: .now))-\(UUID().uuidString).json"
+        let name = "grace-notes-scheduled-\(formatter.string(from: exportDate))-\(UUID().uuidString).json"
         return try BackupFolderJSONExport.copyTempFile(
             tempFile,
             into: folderURL,
@@ -127,13 +128,17 @@ enum ScheduledBackupRunner {
         case failure
     }
 
-    private static func exportToTemporaryFile(modelContainer: ModelContainer) -> ExportToTempResult {
+    private static func exportToTemporaryFile(modelContainer: ModelContainer, exportDate: Date) -> ExportToTempResult {
         do {
             let exportService = JournalDataExportService()
             let backgroundContext = ModelContext(modelContainer)
-            let tempFile = try exportService.exportArchiveFile(context: backgroundContext)
+            let tempFile = try exportService.exportArchiveFile(context: backgroundContext, now: exportDate)
             return .success(tempFile)
         } catch {
+            let detail = String(describing: error)
+            scheduledBackupLogger.error(
+                "Scheduled backup export to temp file failed. \(detail, privacy: .public)"
+            )
             return .failure
         }
     }


### PR DESCRIPTION
## Headline

Scheduled folder backups now use one consistent moment for the export, filename, and cleanup, and export failures are logged for debugging.

## User impact

Backup file names and retention cleanup now match the same point in time as the export, which avoids rare mismatches if the clock advances between steps. If a scheduled export fails while writing the temporary file, developers can see the error in the system log instead of only seeing a generic in-app failure.

## What changed

The runner captures a single date when a scheduled backup starts and passes it through the temp export, archive naming, and folder pruning so those steps do not each call the current time separately.

Failed exports to the temporary file are now recorded with an error log that includes the underlying error description to make diagnosing backup issues easier.

## Verification

On macOS with Xcode, run `grace ci` (or at least `grace test` if that matches your workflow) to confirm the project still builds and tests pass. Optionally trigger a scheduled backup path and confirm Console logs include details if the temp export fails.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
