### PR TITLE
Make journal export filenames unique per export

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/Services/JournalDataExportService.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/Services/JournalDataExportService.swift
@@ -13,7 +13,7 @@ struct JournalDataExportService {
         let entries = try context.fetch(descriptor)
         let data = try makeArchiveData(from: entries, exportedAt: now)
 
-        let filename = "grace-notes-export-\(timestampString(from: now)).json"
+        let filename = "grace-notes-export-\(timestampString(from: now))-\(UUID().uuidString).json"
         let fileURL = fileManager.temporaryDirectory.appendingPathComponent(filename, isDirectory: false)
         try data.write(to: fileURL, options: .atomic)
         return fileURL


### PR DESCRIPTION
## Headline

Each data export now gets a distinct temporary file name so rapid repeats cannot collide.

## User impact

Back-to-back exports in the same second no longer risk overwriting the previous file in the temporary directory, which avoids confusing share-sheet behavior or lost files when someone exports twice quickly. Reliability of the export flow improves without changing the archive format or what gets exported.

## What changed

The export service still writes a JSON archive under the system temporary directory with the same timestamp prefix for readability. The filename now includes an additional unique segment so two exports that share the same second cannot resolve to the same path. No changes were made to encoding, schema, or journal content.

## Verification

On a Mac with the repo and Xcode tooling, run `grace ci` (or `grace test` if that is your usual check) from the project root to confirm lint and simulator build still pass. Manually trigger two exports in quick succession from Settings and confirm both share actions receive distinct files if you want an extra sanity check.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
