### PR TITLE
Use reliable pixel scale for journal share image rendering

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/JournalShareRenderer.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/JournalShareRenderer.swift
@@ -20,8 +20,12 @@ enum JournalShareRenderer {
     /// Keep in sync with `JournalShareCardView` (`cardWidth` + twice `padding`).
     private static let proposedLayoutWidth: CGFloat = 448 + 24 * 2
 
+    /// `ImageRenderer` runs without hosting in a window; `UITraitCollection.current.displayScale` can be
+    /// unset or 1× while the device screen is Retina. Take the best positive value between trait and screen.
     private static var pixelScale: CGFloat {
-        let scale = UITraitCollection.current.displayScale
-        return scale > 0 ? scale : UIScreen.main.scale
+        let traitScale = UITraitCollection.current.displayScale
+        let screenScale = UIScreen.main.scale
+        let best = max(traitScale > 0 ? traitScale : 0, screenScale > 0 ? screenScale : 0)
+        return best > 0 ? best : 3
     }
 }


### PR DESCRIPTION
## Headline

Exported journal share images stay sharp on Retina devices when rendered off-screen.

## User impact

Share images from your journal no longer risk looking soft or pixelated when the system reports a 1× scale during off-window rendering. The export path is more dependable across devices and sharing flows.

## What changed

Journal share cards are drawn with SwiftUI’s ImageRenderer outside a normal window. In that situation, UITraitCollection’s display scale can be missing or stuck at 1× even on Retina screens, so the old fallback could pick the wrong value and under-scale the bitmap.

The renderer now chooses the best positive scale between the current trait collection and the main screen, and uses a sensible default only if both are unusable. A short comment documents why this matters for off-window rendering.

## Verification

On a Mac with Xcode and the iOS Simulator, run `grace ci` (or `grace test` with the project’s usual destination) to confirm the app builds and tests pass. Manually share a journal entry and confirm the generated image looks crisp on a Retina simulator or device.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
