### PR TITLE
Request photo library authorization before Save to Photos

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/SaveToPhotosActivity.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/SaveToPhotosActivity.swift
@@ -32,6 +32,19 @@ final class SaveToPhotosActivity: UIActivity {
     }
 
     override func perform() {
+        PHPhotoLibrary.requestAuthorization(for: .addOnly) { [weak self] status in
+            DispatchQueue.main.async {
+                guard let self else { return }
+                guard status == .authorized else {
+                    self.activityDidFinish(false)
+                    return
+                }
+                self.saveImageToPhotoLibrary()
+            }
+        }
+    }
+
+    private func saveImageToPhotoLibrary() {
         PHPhotoLibrary.shared().performChanges {
             PHAssetChangeRequest.creationRequestForAsset(from: self.image)
         } completionHandler: { [weak self] success, _ in


### PR DESCRIPTION
## Headline

Saving a shared image to Photos now asks for add access first and finishes cleanly if it is denied.

## User impact

Previously, the custom share action could try to add the image without explicitly handling Photos permission, which could lead to failed or confusing saves on first use. Users now see the system add-to-library prompt when needed, and if they decline, the activity ends with a clear failure instead of an ambiguous outcome.

## What changed

The Save to Photos share activity now calls the Photos framework to request add-only access before it runs the save. The actual save logic was moved into a small helper so authorization, main-thread UI work, and the existing change request stay in a clear order. If authorization is not granted, the activity reports completion as unsuccessful and does not attempt the save.

## Verification

On a Mac with Xcode and the iOS Simulator (or a device), open the share sheet, choose Save to Photos, and confirm the permission prompt appears when needed and that saving succeeds or fails predictably. From the repo root, run `grace ci` to match CI (lint plus simulator build).

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
