### PR TITLE
Validate backup folder path is a directory

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/Services/BackupFolderPickerResolution.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/Services/BackupFolderPickerResolution.swift
@@ -4,21 +4,32 @@ enum BackupFolderPickerResolution {
     /// On-disk folder name (not localized—consistent across locales for iCloud Drive / Files).
     static let subfolderName = "Grace Notes Backup"
 
+    enum ResolutionError: Error {
+        /// A file (or other non-directory) already occupies the resolved path.
+        case pathComponentIsNotDirectory(URL)
+    }
+
     static func resolvedFolderURL(
         userPicked: URL,
         fileManager: FileManager = .default
     ) throws -> URL {
         let standardized = userPicked.standardizedFileURL
         if standardized.lastPathComponent == subfolderName {
-            if !fileManager.fileExists(atPath: standardized.path) {
-                try fileManager.createDirectory(at: standardized, withIntermediateDirectories: true)
-            }
-            return standardized
+            return try ensureDirectoryExistsOrCreate(at: standardized, fileManager: fileManager)
         }
         let child = standardized.appendingPathComponent(subfolderName, isDirectory: true)
-        if !fileManager.fileExists(atPath: child.path) {
-            try fileManager.createDirectory(at: child, withIntermediateDirectories: true)
+        return try ensureDirectoryExistsOrCreate(at: child, fileManager: fileManager)
+    }
+
+    private static func ensureDirectoryExistsOrCreate(at url: URL, fileManager: FileManager) throws -> URL {
+        var isDirectory: ObjCBool = false
+        if fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory) {
+            guard isDirectory.boolValue else {
+                throw ResolutionError.pathComponentIsNotDirectory(url)
+            }
+            return url
         }
-        return child
+        try fileManager.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
     }
 }

--- a/GraceNotesTests/Features/Settings/BackupFolderPickerResolutionTests.swift
+++ b/GraceNotesTests/Features/Settings/BackupFolderPickerResolutionTests.swift
@@ -36,4 +36,20 @@ final class BackupFolderPickerResolutionTests: XCTestCase {
         )
         XCTAssertEqual(resolved.path, existing.path)
     }
+
+    func test_throwsWhenReservedNameIsAFile() throws {
+        let blockingFile = tempRoot.appendingPathComponent(
+            BackupFolderPickerResolution.subfolderName,
+            isDirectory: false
+        )
+        FileManager.default.createFile(atPath: blockingFile.path, contents: Data("x".utf8))
+        XCTAssertThrowsError(
+            try BackupFolderPickerResolution.resolvedFolderURL(userPicked: tempRoot, fileManager: .default)
+        ) { error in
+            guard case BackupFolderPickerResolution.ResolutionError.pathComponentIsNotDirectory(let url) = error else {
+                return XCTFail("expected pathComponentIsNotDirectory, got \(error)")
+            }
+            XCTAssertEqual(url.path, blockingFile.path)
+        }
+    }
 }


### PR DESCRIPTION
## Headline

Backup location resolution now fails with a clear error when a file blocks the Grace Notes Backup folder.

## User impact

If something already exists at the expected backup path but it is a file (not a folder), the app no longer treats that path like a usable backup folder. Callers can surface a reliable failure instead of odd or inconsistent filesystem behavior when backing up.

## What changed

The resolver used to call only whether a path existed before creating a directory, without distinguishing a file from a folder at the same location. That could let a mis-resolved path slip through or produce confusing behavior when backups were written.

Resolution now uses one helper that creates the directory when missing, returns the URL when the path is already a folder, and throws a dedicated error when the path exists but is not a directory. Both the direct “Grace Notes Backup” selection and the child-under-the-picked-folder case follow the same rules.

## Verification

On a Mac with Xcode, run `grace ci` (or `grace test`) from the repo root. Confirm `BackupFolderPickerResolutionTests` pass, including coverage for the non-directory path case.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
