### PR TITLE
Lock journal share composer while export runs and fix share state

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/JournalShareComposerView.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/JournalShareComposerView.swift
@@ -42,6 +42,7 @@ struct JournalShareComposerView: View {
                 }
                 .padding(.horizontal, 20)
                 .padding(.vertical, 16)
+                .disabled(isShareCommitInProgress)
             }
             .scrollContentBackground(.hidden)
             .background(AppTheme.settingsBackground.ignoresSafeArea())
@@ -201,10 +202,10 @@ struct JournalShareComposerView: View {
         .buttonStyle(.plain)
     }
 
+    @MainActor
     private func commitShare() {
         guard !isShareCommitInProgress else { return }
         isShareCommitInProgress = true
-        defer { isShareCommitInProgress = false }
 
         let built = ShareRenderPayloadBuilder.build(
             full: basePayload,
@@ -212,6 +213,7 @@ struct JournalShareComposerView: View {
             includePreviewStubs: false
         )
         guard let image = JournalShareRenderer.renderImage(from: built) else {
+            isShareCommitInProgress = false
             showRenderError = true
             return
         }


### PR DESCRIPTION
## Headline

Prevents edits and repeat shares while the share card image is being built and handed off.

## User impact

Tapping Share could previously leave preview controls active while rendering ran, so someone could change redactions or toggles mid-export or tap Share again. The composer now freezes those controls during the commit, and failed image creation clears the busy state so you can adjust settings and try again.

## What changed

The scrollable composer content is disabled whenever a share commit is in progress, matching the toolbar buttons and sheet dismiss behavior. The share commit path is marked to run on the main actor, and the old pattern that always reset the in-progress flag when the function returned was replaced: rendering failures explicitly clear the flag before showing the error, while a successful handoff leaves the surface locked until the flow ends (typically when the sheet is dismissed).

## Verification

On a Mac with the project toolchain, run `grace ci` (or `grace test` if you only need tests). In the simulator, open the journal share composer, tap Share, and confirm preview chips, toggles, and the scroll area do not respond until the sheet finishes or you cancel; trigger a render failure if possible and confirm you can edit and share again after dismissing the alert.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
