### PR TITLE
Validate backup parent path is a directory before creating subfolder

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/Services/BackupFolderPickerResolution.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/Services/BackupFolderPickerResolution.swift
@@ -17,16 +17,24 @@ enum BackupFolderPickerResolution {
         if standardized.lastPathComponent == subfolderName {
             return try ensureDirectoryExistsOrCreate(at: standardized, fileManager: fileManager)
         }
+        try requireDirectoryIfExists(at: standardized, fileManager: fileManager)
         let child = standardized.appendingPathComponent(subfolderName, isDirectory: true)
         return try ensureDirectoryExistsOrCreate(at: child, fileManager: fileManager)
     }
 
+    /// Returns without error when nothing exists at `url` (caller may create a path below it).
+    private static func requireDirectoryIfExists(at url: URL, fileManager: FileManager) throws {
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory) else { return }
+        guard isDirectory.boolValue else {
+            throw ResolutionError.pathComponentIsNotDirectory(url)
+        }
+    }
+
     private static func ensureDirectoryExistsOrCreate(at url: URL, fileManager: FileManager) throws -> URL {
+        try requireDirectoryIfExists(at: url, fileManager: fileManager)
         var isDirectory: ObjCBool = false
         if fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory) {
-            guard isDirectory.boolValue else {
-                throw ResolutionError.pathComponentIsNotDirectory(url)
-            }
             return url
         }
         try fileManager.createDirectory(at: url, withIntermediateDirectories: true)


### PR DESCRIPTION
## Headline

Choosing a backup location now fails fast with a clear error when a file blocks the folder path.

## User impact

If you pick a location where a file (not a folder) sits on the path to “Grace Notes Backup,” the app surfaces the existing “not a directory” resolution error instead of hitting a murkier filesystem failure when it tries to create the backup folder. Backup setup stays predictable and easier to recover from by picking a real folder.

## What changed

Backup folder resolution used to append the “Grace Notes Backup” subfolder and create it without first checking that the user-selected parent path, when it already exists on disk, is actually a directory. A file at that path could lead to confusing or unreliable behavior when creating the nested folder.

The change introduces a small helper that, when something already exists at a path, requires it to be a directory; otherwise it throws the same resolution error used elsewhere. That check runs for the parent path before appending the subfolder name, and the helper is shared with directory creation so the directory-vs-file logic lives in one place.

## Verification

On a Mac with the repo’s Xcode setup, run `swiftlint lint` from the repo root and `grace test` (or `grace ci` for the default lint-and-build profile). Confirm unit coverage for `BackupFolderPickerResolution` still passes, including cases where the picked path is a file or a non-directory.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
