### PR TITLE
Serialize scheduled backup runs to prevent overlapping exports

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/Services/ScheduledBackupRunner.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/Services/ScheduledBackupRunner.swift
@@ -7,6 +7,29 @@ private let scheduledBackupLogger = Logger(
     category: "ScheduledBackup"
 )
 
+/// Prevents overlapping scheduled backup runs when the app becomes active repeatedly before
+/// `lastRunAt` is updated (each transition spawns a new `Task` in ``GraceNotesApp``).
+private final class ScheduledBackupSingleFlight: @unchecked Sendable {
+    private let lock = NSLock()
+    private var inFlight = false
+
+    func tryBegin() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !inFlight else { return false }
+        inFlight = true
+        return true
+    }
+
+    func end() {
+        lock.lock()
+        inFlight = false
+        lock.unlock()
+    }
+}
+
+private let scheduledBackupSingleFlight = ScheduledBackupSingleFlight()
+
 enum ScheduledBackupRunner {
     /// Writes a JSON export into the user’s appointed folder when the schedule says it is time.
     static func runIfDue(modelContainer: ModelContainer) async {
@@ -20,6 +43,9 @@ enum ScheduledBackupRunner {
             await recordScheduledFailure(detail: String(localized: "settings.dataPrivacy.scheduledBackup.folderError"))
             return
         }
+
+        guard scheduledBackupSingleFlight.tryBegin() else { return }
+        defer { scheduledBackupSingleFlight.end() }
 
         let result = await Task.detached(priority: .utility) {
             Self.performScheduledExport(modelContainer: modelContainer)


### PR DESCRIPTION
## Headline

Stops rapid foreground switches from stacking duplicate scheduled backups while a run is still finishing.

## User impact

When you bounce in and out of the app quickly, Grace Notes can trigger multiple scheduled backup tasks before the previous run records completion. That overlap wastes battery and storage, stresses SwiftData and disk I/O, and can produce confusing backup history. This change keeps scheduled exports to one at a time so backups stay predictable and reliable.

## What changed

The scheduled backup path now uses a small single-flight gate (a lock-backed “only one in flight” flag) around the work that runs after the folder bookmark is valid. If another activation tries to start a backup while one is already exporting and copying, the extra attempt exits early instead of launching a second detached export. The gate clears when the in-flight run finishes, whether it succeeds or fails, so the next due window can run normally.

## Verification

On a Mac with Xcode and the project’s dev tooling installed, run `grace ci` from the repo root (or `grace test` with your usual simulator destination) to lint and build the GraceNotes scheme.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
