### PR TITLE
Align custom past-statistics window with validated selection and safe date bounds

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/PastStatisticsIntervalPreference.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/PastStatisticsIntervalPreference.swift
@@ -46,11 +46,12 @@ struct PastStatisticsIntervalSelection: Codable, Equatable, Hashable, Sendable {
         calendar: Calendar,
         allEntries: [Journal]
     ) -> Range<Date> {
+        let selection = validated
         let refStart = calendar.startOfDay(for: referenceDate)
         guard let endExclusive = calendar.date(byAdding: .day, value: 1, to: refStart) else {
             return refStart..<refStart
         }
-        switch mode {
+        switch selection.mode {
         case .all:
             let days = allEntries.map { calendar.startOfDay(for: $0.entryDate) }
             let earliest = days.min() ?? refStart
@@ -59,10 +60,10 @@ struct PastStatisticsIntervalSelection: Codable, Equatable, Hashable, Sendable {
             let lower = min(earliest, refStart)
             return lower..<endExclusive
         case .custom:
-            let quantityValue = min(max(quantity, 1), 999)
+            let quantityValue = selection.quantity
             let anchor = refStart
             let startCandidate: Date?
-            switch unit {
+            switch selection.unit {
             case .week:
                 startCandidate = calendar.date(byAdding: .weekOfYear, value: -quantityValue, to: anchor)
             case .month:
@@ -71,7 +72,9 @@ struct PastStatisticsIntervalSelection: Codable, Equatable, Hashable, Sendable {
                 startCandidate = calendar.date(byAdding: .year, value: -quantityValue, to: anchor)
             }
             let startDay = calendar.startOfDay(for: startCandidate ?? anchor)
-            return startDay..<endExclusive
+            // Mirror `.all`: if the computed start is after the reference day, cap so the half-open range stays valid.
+            let lower = min(startDay, refStart)
+            return lower..<endExclusive
         }
     }
 


### PR DESCRIPTION
## Headline

Past statistics no longer risk a crashing or empty date range when a custom lookback resolves oddly versus today.

## User impact

Review and statistics that depend on your chosen “past interval” stay reliable instead of failing on edge cases where the computed window does not line up cleanly with the reference day. Custom windows now behave consistently with how “all journal history” already capped awkward dates.

## What changed

The history-range helper now works from a single validated copy of your interval (mode, quantity, unit), so quantity always follows the same clamping rules as everywhere else instead of re-applying limits in one branch.

For custom intervals, the start date is now capped so it is never after the reference day, matching the safety already used for “all entries.” That keeps the half-open day range well-formed when calendar math or unusual dates would otherwise put the start after “today.”

## Verification

On a Mac with the repo’s dev setup, run `grace ci` (or `grace test` with the project’s default simulator destination) so lint and the GraceNotes build complete successfully.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
