### PR TITLE
Harden backup folder list: scoped access helper and selection sync

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/ImportExportSettingsSupport.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/ImportExportSettingsSupport.swift
@@ -159,9 +159,10 @@ struct BackupFolderImportFileListView: View {
             load()
         }
         .onChange(of: files) { _, newFiles in
+            let validPaths = Set(newFiles.map(\.path))
+            selection = selection.intersection(validPaths)
             if newFiles.isEmpty {
                 isSelecting = false
-                selection.removeAll()
             }
         }
     }
@@ -184,22 +185,10 @@ struct BackupFolderImportFileListView: View {
     }
 
     private func load() {
-        let folderURL: URL
         do {
-            folderURL = try ScheduledBackupPreferences.resolveFolderURL()
-        } catch {
-            listError = String(localized: "settings.dataPrivacy.importExport.backupFolder.unreachable")
-            return
-        }
-        guard folderURL.startAccessingSecurityScopedResource() else {
-            listError = String(localized: "settings.dataPrivacy.importExport.backupFolder.unreachable")
-            return
-        }
-        defer {
-            folderURL.stopAccessingSecurityScopedResource()
-        }
-        do {
-            files = try BackupFolderLibrary.listExportFiles(in: folderURL)
+            files = try ScheduledBackupPreferences.withFolderSecurityScopedAccess { folderURL in
+                try BackupFolderLibrary.listExportFiles(in: folderURL)
+            }
             listError = nil
         } catch {
             listError = String(localized: "settings.dataPrivacy.importExport.backupFolder.unreachable")


### PR DESCRIPTION
## Headline

Backup exports list stays trustworthy when the folder contents refresh or the list reloads.

## User impact

People managing scheduled backup files in Settings see a list that stays in sync with what is actually on disk. Stale or invalid selections are dropped after a refresh, so delete confirmations and actions match real files and are less likely to target the wrong thing or behave oddly after the list changes.

## What changed

Loading the backup folder file list now uses the same security-scoped folder access helper as delete, instead of hand-rolled start/stop access around the folder URL. That keeps access rules in one place and reduces the chance of inconsistent handling between listing and deleting.

When the file array updates, the multi-select set is intersected with the paths that still exist in the new list. Empty lists still exit selection mode; non-empty refreshes prune selections for files that disappeared without wiping the whole set when some files remain.

## Verification

On a Mac with Xcode and the project’s grace CLI installed, run `grace ci` (or `grace test` with the default simulator destination from gracenotes-dev.toml). In the app, open Settings → the scheduled backup folder file list, enter multi-select, refresh the list (or change folder contents), and confirm selection and delete flows still match visible files.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
