### PR TITLE
Validate curated review theme labels in DEBUG builds

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/ReviewCuratedThemeMap.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ReviewCuratedThemeMap.swift
@@ -8,159 +8,189 @@ struct ReviewCuratedThemeMap {
     let crossLanguageAliases: [String: String]
     let canonicalDisplayLabels: [String: String]
 
-    static let defaultMap = ReviewCuratedThemeMap(
-        globalAliases: [
-            "sleep": "sleep",
-            "better sleep": "sleep",
-            "slept": "sleep",
-            "rest": "rest",
-            "recover": "rest",
-            "recovery": "rest",
-            "downtime": "rest",
-            "quiet": "quiet time",
-            "quiet time": "quiet time",
-            "stillness": "quiet time",
-            "calm": "calm",
-            "peace": "calm",
-            "focused": "focus",
-            "focus": "focus",
-            "concentration": "focus",
-            "boundaries": "boundaries",
-            "boundary": "boundaries",
-            "time boundaries": "boundaries",
-            "exercise": "movement",
-            "workout": "movement",
-            "training": "movement",
-            "walk": "walking",
-            "walking": "walking",
-            "morning walk": "walking",
-            "walks": "walking",
-            "run": "movement",
-            "running": "movement",
-            "stretching": "movement",
-            "scripture": "scripture",
-            "bible": "scripture",
-            "devotional": "scripture",
-            "family dinner": "family connection",
-            "family time": "family connection",
-            "time with family": "family connection",
-            "friends": "friendship",
-            "friend": "friendship",
-            "friendship": "friendship",
-            "partner": "partner connection",
-            "husband": "partner connection",
-            "wife": "partner connection",
-            "spouse": "partner connection",
-            "parenting": "parenting",
-            "kids": "parenting",
-            "children": "parenting",
-            "work stress": "work pressure",
-            "work pressure": "work pressure",
-            "busy at work": "work pressure",
-            "finances": "financial pressure",
-            "money stress": "financial pressure",
-            "budget": "financial pressure",
-            "home chores": "home care",
-            "house chores": "home care",
-            "cleaning": "home care",
-            "meal prep": "home care",
-            "therapy": "therapy",
-            "counseling": "therapy",
-            "nature": "nature",
-            "sunlight": "nature",
-            "outside": "nature",
-            "reading": "learning",
-            "study": "learning",
-            "learning": "learning",
-            "creative work": "creativity",
-            "writing": "creativity",
-            "drawing": "creativity"
-        ],
-        sectionOverrides: [
-            .needs: [
-                "time alone": "personal time",
-                "alone time": "personal time",
-                "quiet morning": "quiet time",
-                "less pressure": "work pressure",
-                "space to breathe": "calm",
-                "clear priorities": "focus"
+    static let defaultMap: ReviewCuratedThemeMap = {
+        let map = ReviewCuratedThemeMap(
+            globalAliases: [
+                "sleep": "sleep",
+                "better sleep": "sleep",
+                "slept": "sleep",
+                "rest": "rest",
+                "recover": "rest",
+                "recovery": "rest",
+                "downtime": "rest",
+                "quiet": "quiet time",
+                "quiet time": "quiet time",
+                "stillness": "quiet time",
+                "calm": "calm",
+                "peace": "calm",
+                "focused": "focus",
+                "focus": "focus",
+                "concentration": "focus",
+                "boundaries": "boundaries",
+                "boundary": "boundaries",
+                "time boundaries": "boundaries",
+                "exercise": "movement",
+                "workout": "movement",
+                "training": "movement",
+                "walk": "walking",
+                "walking": "walking",
+                "morning walk": "walking",
+                "walks": "walking",
+                "run": "movement",
+                "running": "movement",
+                "stretching": "movement",
+                "scripture": "scripture",
+                "bible": "scripture",
+                "devotional": "scripture",
+                "family dinner": "family connection",
+                "family time": "family connection",
+                "time with family": "family connection",
+                "friends": "friendship",
+                "friend": "friendship",
+                "friendship": "friendship",
+                "partner": "partner connection",
+                "husband": "partner connection",
+                "wife": "partner connection",
+                "spouse": "partner connection",
+                "parenting": "parenting",
+                "kids": "parenting",
+                "children": "parenting",
+                "work stress": "work pressure",
+                "work pressure": "work pressure",
+                "busy at work": "work pressure",
+                "finances": "financial pressure",
+                "money stress": "financial pressure",
+                "budget": "financial pressure",
+                "home chores": "home care",
+                "house chores": "home care",
+                "cleaning": "home care",
+                "meal prep": "home care",
+                "therapy": "therapy",
+                "counseling": "therapy",
+                "nature": "nature",
+                "sunlight": "nature",
+                "outside": "nature",
+                "reading": "learning",
+                "study": "learning",
+                "learning": "learning",
+                "creative work": "creativity",
+                "writing": "creativity",
+                "drawing": "creativity"
             ],
-            .gratitudes: [
-                "good weather": "nature",
-                "sunny weather": "nature",
-                "warm sunlight": "nature",
-                "my routine": "daily rhythm",
-                "morning routine": "daily rhythm"
+            sectionOverrides: [
+                .needs: [
+                    "time alone": "personal time",
+                    "alone time": "personal time",
+                    "quiet morning": "quiet time",
+                    "less pressure": "work pressure",
+                    "space to breathe": "calm",
+                    "clear priorities": "focus"
+                ],
+                .gratitudes: [
+                    "good weather": "nature",
+                    "sunny weather": "nature",
+                    "warm sunlight": "nature",
+                    "my routine": "daily rhythm",
+                    "morning routine": "daily rhythm"
+                ],
+                .people: [
+                    "mom": "mom",
+                    "mother": "mom",
+                    "mama": "mom",
+                    "dad": "dad",
+                    "father": "dad",
+                    "爸": "dad",
+                    "妈妈": "mom",
+                    "爸爸": "dad"
+                ]
             ],
-            .people: [
-                "mom": "mom",
-                "mother": "mom",
-                "mama": "mom",
-                "dad": "dad",
-                "father": "dad",
-                "爸": "dad",
-                "妈妈": "mom",
-                "爸爸": "dad"
+            hardBannedConcepts: [
+                "today", "this week", "week", "thing", "things", "stuff", "something", "anything",
+                "nothing", "life", "moment", "moments", "reflection", "reflections", "entry",
+                "journal", "note", "notes", "feeling", "feelings",
+                "need", "needs", "needed",
+                "gratitude", "grateful", "thankful", "thankfulness", "thanks", "gratitude practice",
+                "pray", "prayer", "praying", "prayed",
+                "感恩", "祷告"
+            ],
+            penalizedConcepts: [
+                "work", "family", "health", "relationship", "home", "time", "people"
+            ],
+            crossLanguageAliases: [
+                "睡眠": "sleep",
+                "休息": "rest",
+                "安静": "quiet time",
+                "平静": "calm",
+                "专注": "focus",
+                "边界": "boundaries",
+                "散步": "walking",
+                "运动": "movement",
+                "圣经": "scripture",
+                "家人": "family connection",
+                "朋友": "friendship",
+                "伴侣": "partner connection",
+                "育儿": "parenting",
+                "工作压力": "work pressure",
+                "财务压力": "financial pressure",
+                "家务": "home care",
+                "大自然": "nature",
+                "学习": "learning",
+                "创造": "creativity"
+            ],
+            canonicalDisplayLabels: [
+                "sleep": "Sleep",
+                "rest": "Rest",
+                "quiet time": "Quiet time",
+                "calm": "Calm",
+                "focus": "Focus",
+                "boundaries": "Boundaries",
+                "movement": "Exercise",
+                "walking": "Walking",
+                "scripture": "Scripture",
+                "family connection": "Family connection",
+                "friendship": "Friendship",
+                "partner connection": "Partner connection",
+                "parenting": "Parenting",
+                "work pressure": "Work pressure",
+                "financial pressure": "Financial pressure",
+                "home care": "Home care",
+                "therapy": "Therapy",
+                "nature": "Nature",
+                "learning": "Learning",
+                "creativity": "Creativity",
+                "personal time": "Personal time",
+                "daily rhythm": "Daily rhythm",
+                "mom": "Mom",
+                "dad": "Dad"
             ]
-        ],
-        hardBannedConcepts: [
-            "today", "this week", "week", "thing", "things", "stuff", "something", "anything",
-            "nothing", "life", "moment", "moments", "reflection", "reflections", "entry",
-            "journal", "note", "notes", "feeling", "feelings",
-            "need", "needs", "needed",
-            "gratitude", "grateful", "thankful", "thankfulness", "thanks", "gratitude practice",
-            "pray", "prayer", "praying", "prayed",
-            "感恩", "祷告"
-        ],
-        penalizedConcepts: [
-            "work", "family", "health", "relationship", "home", "time", "people"
-        ],
-        crossLanguageAliases: [
-            "睡眠": "sleep",
-            "休息": "rest",
-            "安静": "quiet time",
-            "平静": "calm",
-            "专注": "focus",
-            "边界": "boundaries",
-            "散步": "walking",
-            "运动": "movement",
-            "圣经": "scripture",
-            "家人": "family connection",
-            "朋友": "friendship",
-            "伴侣": "partner connection",
-            "育儿": "parenting",
-            "工作压力": "work pressure",
-            "财务压力": "financial pressure",
-            "家务": "home care",
-            "大自然": "nature",
-            "学习": "learning",
-            "创造": "creativity"
-        ],
-        canonicalDisplayLabels: [
-            "sleep": "Sleep",
-            "rest": "Rest",
-            "quiet time": "Quiet time",
-            "calm": "Calm",
-            "focus": "Focus",
-            "boundaries": "Boundaries",
-            "movement": "Exercise",
-            "walking": "Walking",
-            "scripture": "Scripture",
-            "family connection": "Family connection",
-            "friendship": "Friendship",
-            "partner connection": "Partner connection",
-            "parenting": "Parenting",
-            "work pressure": "Work pressure",
-            "financial pressure": "Financial pressure",
-            "home care": "Home care",
-            "therapy": "Therapy",
-            "nature": "Nature",
-            "learning": "Learning",
-            "creativity": "Creativity",
-            "personal time": "Personal time",
-            "daily rhythm": "Daily rhythm",
-            "mom": "Mom",
-            "dad": "Dad"
-        ]
-    )
+        )
+        #if DEBUG
+        map.assertMappedCanonicalsHaveDisplayLabels()
+        #endif
+        return map
+    }()
+
+    #if DEBUG
+    /// Every alias target must appear in `canonicalDisplayLabels`, or `ReviewThemeConceptEngine.displayLabel`
+    /// falls back to naive title-casing and skips `review.theme.*` localization keys.
+    private func assertMappedCanonicalsHaveDisplayLabels() {
+        var targets = Set<String>()
+        for (_, canonical) in globalAliases {
+            targets.insert(canonical)
+        }
+        for (_, section) in sectionOverrides {
+            for (_, canonical) in section {
+                targets.insert(canonical)
+            }
+        }
+        for (_, canonical) in crossLanguageAliases {
+            targets.insert(canonical)
+        }
+        let missing = targets.filter { canonicalDisplayLabels[$0] == nil }.sorted()
+        precondition(
+            missing.isEmpty,
+            "ReviewCuratedThemeMap missing canonicalDisplayLabels: \(missing.joined(separator: ", "))"
+        )
+    }
+    #endif
 }


### PR DESCRIPTION
## Headline

Catch missing theme display labels before they ship and break localized review themes.

## User impact

When a curated alias points at a canonical theme that has no display label, the app can fall back to generic title-casing and skip proper `review.theme.*` strings, so labels look wrong or inconsistent. This change does not alter runtime behavior in release; it only fails fast in development when the map is incomplete.

## What changed

The default curated theme map is now built inside a small initializer closure so we can run a DEBUG-only consistency check before the static value is exposed. A new assertion walks every canonical target referenced by global aliases, section overrides, and cross-language aliases and requires each one to exist in `canonicalDisplayLabels`, crashing with a clear list of missing keys if not. That keeps the mapping table and localization story aligned as editors add or tweak aliases.

## Verification

On a Mac with Xcode, run `swiftlint lint` from the repo root and `grace ci` (or `grace test` with the project’s default simulator destination) to confirm the app still builds and tests pass; in DEBUG, launching code paths that touch `ReviewCuratedThemeMap.defaultMap` will trip the assertion if any canonical is missing a label.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
