### PR TITLE
Trim whitespace in journal export payload text

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/JournalExportPayload.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/JournalExportPayload.swift
@@ -22,12 +22,16 @@ struct JournalExportPayload {
     static func make(from source: JournalExportSnapshotSource) -> JournalExportPayload {
         JournalExportPayload(
             dateFormatted: source.entryDate.formatted(date: .long, time: .omitted),
-            gratitudes: source.gratitudes.map(\.fullText),
-            needs: source.needs.map(\.fullText),
-            people: source.people.map(\.fullText),
-            readingNotes: source.readingNotes.trimmingCharacters(in: .whitespacesAndNewlines),
-            reflections: source.reflections.trimmingCharacters(in: .whitespacesAndNewlines),
+            gratitudes: source.gratitudes.map { trimmed($0.fullText) },
+            needs: source.needs.map { trimmed($0.fullText) },
+            people: source.people.map { trimmed($0.fullText) },
+            readingNotes: trimmed(source.readingNotes),
+            reflections: trimmed(source.reflections),
             completionLevel: source.completionLevel
         )
+    }
+
+    private static func trimmed(_ text: String) -> String {
+        text.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }


### PR DESCRIPTION
## Headline

Exported journal content no longer carries accidental leading or trailing whitespace from section entries.

## User impact

Shared or exported journal text looks cleaner when entries had extra spaces or line breaks at the edges. It also avoids odd gaps or formatting quirks in previews or downstream use of the export payload.

## What changed

Building the export snapshot now trims leading and trailing whitespace and newlines from each gratitude, need, and person line, not only from reading notes and reflections. A small helper centralizes the same trimming rule used for free-text fields so behavior stays consistent across all exported strings.

## Verification

On a Mac with Xcode and the project CLI installed, run `grace ci` (or `grace test` with your usual simulator destination) to confirm the app still builds and tests pass; optionally export or share a journal with padded entry text and confirm the payload shows trimmed lines.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
