### PR TITLE
Fix review week boundaries for non-Gregorian calendar users

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/ReviewWeekBoundaryPreference.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ReviewWeekBoundaryPreference.swift
@@ -29,8 +29,12 @@ enum ReviewWeekBoundaryPreference: String, CaseIterable, Equatable, Sendable {
         ReviewWeekBoundaryPreference(rawValue: rawValue) ?? defaultValue
     }
 
+    /// Uses Gregorian weekday numbering (1 = Sunday … 7 = Saturday) regardless of the user’s primary
+    /// calendar, while keeping their time zone and locale for local day boundaries and formatting.
     func configuredCalendar(base: Calendar = .current) -> Calendar {
-        var calendar = base
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = base.timeZone
+        calendar.locale = base.locale
         calendar.firstWeekday = firstWeekday
         return calendar
     }


### PR DESCRIPTION
## Headline

Weekly review now respects Sunday/Monday week starts consistently, even when the device uses another calendar system.

## User impact

People whose primary calendar is not Gregorian (for example Islamic or Hebrew) should see review weeks align with the chosen “week starts on Sunday or Monday” setting instead of drifting or mis-grouping days. This reduces confusing or wrong week slices when browsing or reviewing journals.

## What changed

The preference already encodes week start as Gregorian weekday numbers (Sunday through Saturday). The code used to start from the user’s current `Calendar`, which can be a non-Gregorian system where weekday numbering and week math do not match that assumption.

`configuredCalendar` now builds an explicit Gregorian calendar, copies the user’s time zone and locale from the base calendar so local days and formatting stay correct, then applies `firstWeekday`. A short doc comment explains that weekday numbering is always Gregorian while still honoring locale and time zone.

## Verification

On a Mac with the repo and `grace` installed, run `grace ci` (or `grace test` with the project’s default destinations) to confirm the app still builds and tests pass. Optionally change the device calendar to a non-Gregorian primary calendar in Settings, set review week start to Sunday vs Monday, and confirm week groupings in the review flow match expectations.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
