### PR TITLE
Parse UI locale with Locale.Language for Simplified Chinese prompts

### DIFF
--- a/GraceNotes/GraceNotes/Application/AppInstructionLocale.swift
+++ b/GraceNotes/GraceNotes/Application/AppInstructionLocale.swift
@@ -17,10 +17,16 @@ enum AppInstructionLocale: Equatable, Sendable {
         return .english
     }
 
-    /// BCP 47 tags are case-insensitive; `Bundle` may return `zh-Hans` or `zh-hans`.
-    /// Require `zh-Hans` as a full tag or as the language-script prefix before the next subtag (`zh-Hans-CN`, …), not `zh-Hant`.
+    /// Uses `Locale.Language` so legacy tags (`zh_CN`, `zh_Hans_CN`) and bare `zh` resolve like the system,
+    /// instead of brittle `zh-hans` / `zh-hans-` string prefix checks that miss underscore forms.
     private static func isSimplifiedChineseUIIdentifier(_ identifier: String) -> Bool {
-        let tag = identifier.lowercased()
-        return tag == "zh-hans" || tag.hasPrefix("zh-hans-")
+        let language = Locale.Language(identifier: identifier)
+        guard language.languageCode?.identifier == "zh" else {
+            return false
+        }
+        guard let script = language.script?.identifier else {
+            return false
+        }
+        return script.caseInsensitiveCompare("Hans") == .orderedSame
     }
 }


### PR DESCRIPTION
## Headline

Review insights and LLM instructions follow Simplified Chinese when the system locale uses legacy or mixed tag forms, not only hyphenated zh-Hans.

## User impact

When the app’s active UI language is Chinese written in forms the old code did not recognize (for example underscore-style tags), cloud LLM instructions could fall back to English and feel mismatched with the rest of the interface. Detection now aligns with how the system interprets locale identifiers so the right instruction language is chosen more reliably.

## What changed

The helper that decides whether the bundle’s preferred localization is Simplified Chinese no longer relies on lowercased string equality and “zh-hans-” prefix checks. It builds a Locale.Language from the identifier, requires Chinese as the language, and treats the UI as Simplified Chinese only when the script is Hans, matching system parsing for legacy and variant tags.

## Verification

On a Mac with the repo and Xcode as in the project README, run `grace ci` (or `grace test` with the default simulator destination) to confirm the GraceNotes scheme still builds and tests pass; optionally switch the app/simulator language to Simplified Chinese and confirm Review-related LLM instructions use Chinese where expected.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
