### PR TITLE
Harden daily reminder scheduling with fallback body and calendar

### DIFF
--- a/GraceNotes/GraceNotes/Services/Reminders/ReminderScheduler.swift
+++ b/GraceNotes/GraceNotes/Services/Reminders/ReminderScheduler.swift
@@ -150,13 +150,17 @@ struct ReminderScheduler {
         // identifier replaces it; removing first would orphan the user if `add` throws.
         let content = UNMutableNotificationContent()
         content.title = String(localized: "app.name")
-        content.body = body
+        let trimmedBody = body.trimmingCharacters(in: .whitespacesAndNewlines)
+        content.body = trimmedBody.isEmpty
+            ? String(localized: String.LocalizationValue("notifications.reminder.body.fallback"))
+            : trimmedBody
         content.sound = .default
 
         let extracted = ReminderSettings.timeComponents(from: time, calendar: calendar)
         guard let hour = extracted.hour, let minute = extracted.minute else { return false }
 
         var triggerComponents = DateComponents()
+        triggerComponents.calendar = calendar
         triggerComponents.timeZone = calendar.timeZone
         triggerComponents.hour = hour
         triggerComponents.minute = minute


### PR DESCRIPTION
## Headline

Daily journal reminders fire more predictably and never ship with a blank message.

## User impact

If you left the reminder message blank or only whitespace, notifications could look empty or unhelpful; they now show a sensible default line. Matching the notification trigger to the same calendar used to read the time reduces edge cases where the reminder might not fire when you expect (for example around time zones or calendar rules).

## What changed

When building the notification, the reminder text is trimmed. If nothing remains, the scheduler uses a localized fallback body instead of an empty string. For the repeating calendar trigger, the date components now explicitly use the same calendar instance as the rest of the reminder logic, alongside the existing time zone, so hour and minute line up with how the app interpreted your chosen time.

## Verification

On a Mac with Xcode and the iOS Simulator, run `grace ci` (or `grace test` with the project’s default destination). Manually enable a daily reminder with a blank or whitespace-only message and confirm the notification shows the fallback text; change time or time zone and confirm the reminder still schedules as expected.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
