### PR TITLE
Sentry: refine ShareSheet.swift

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/ShareSheet.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ShareSheet.swift
@@ -12,11 +12,34 @@ struct ShareSheet: UIViewControllerRepresentable {
     var applicationActivities: [UIActivity]?
 
     func makeUIViewController(context: Context) -> UIActivityViewController {
-        UIActivityViewController(
+        assert(!activityItems.isEmpty, "ShareSheet requires at least one activity item.")
+        let controller = UIActivityViewController(
             activityItems: activityItems,
             applicationActivities: applicationActivities
         )
+        configurePopoverPresentationIfNeeded(for: controller)
+        return controller
     }
 
     func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
+
+    /// On iPad and other horizontally regular layouts, `UIActivityViewController` uses a popover and must have a
+    /// valid popover source or the system can fail to present it.
+    private func configurePopoverPresentationIfNeeded(for controller: UIActivityViewController) {
+        guard let popover = controller.popoverPresentationController else { return }
+        guard let window = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .flatMap(\.windows)
+            .first(where: \.isKeyWindow)
+        else { return }
+
+        popover.sourceView = window
+        popover.sourceRect = CGRect(
+            x: window.bounds.midX,
+            y: window.bounds.midY,
+            width: 0,
+            height: 0
+        )
+        popover.permittedArrowDirections = []
+    }
 }


### PR DESCRIPTION
## Headline

Automated refinement from `grace sentry`.

## User impact

Maintainers get a small scoped change with CI preflight before review.

## What changed

Updates `GraceNotes/GraceNotes/Features/Journal/Views/ShareSheet.swift` in a single automated pass (see diff on the PR).

## Verification

`grace ci` on macOS using the configured sentry CI profile.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
