### PR TITLE
Identify most recurring theme rows by theme, not list position

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewMostRecurringCard.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewMostRecurringCard.swift
@@ -77,7 +77,7 @@ struct ReviewMostRecurringCard: View {
         ) {
             VStack(alignment: .leading, spacing: 10) {
                 VStack(alignment: .leading, spacing: 8) {
-                    ForEach(Array(themes.prefix(3).enumerated()), id: \.offset) { _, theme in
+                    ForEach(Array(themes.prefix(3))) { theme in
                         mostRecurringThemeRow(theme)
                     }
                 }


### PR DESCRIPTION
## Headline

The weekly “most recurring themes” list now stays tied to each theme when insights refresh.

## User impact

When recurring themes load or update, SwiftUI was keying rows by their position in the top-three list. That can make updates feel wrong or reuse the wrong row when the order or membership changes. Rows now follow each theme’s own identity, so the list tracks the actual recurring topics more reliably.

## What changed

The top three recurring themes were rendered with a ForEach that used enumerated offsets as the view identity. That favors stable indices over stable theme records whenever the backing array changes.

The list now iterates the prefixed theme array directly so SwiftUI can use each theme’s identity for diffing and updates instead of positional keys.

## Verification

On a Mac with Xcode and the project’s grace CLI, run `grace ci` (or `grace test` with the usual simulator destination). In the app, open the review insights screen and trigger a refresh or a change that alters the top recurring themes; confirm the three rows still match the correct themes and behave sensibly.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
