### PR TITLE
Harden import/export anchors and backup folder selection

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/ImportExportSettingsSupport.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/ImportExportSettingsSupport.swift
@@ -9,6 +9,7 @@ struct JSONImportFileImporterAnchor: View {
     var body: some View {
         Color.clear
             .frame(width: 0, height: 0)
+            .accessibilityHidden(true)
             .fileImporter(
                 isPresented: $isPresented,
                 allowedContentTypes: [.json],
@@ -25,6 +26,7 @@ struct ScheduledFolderFileImporterAnchor: View {
     var body: some View {
         Color.clear
             .frame(width: 0, height: 0)
+            .accessibilityHidden(true)
             .fileImporter(
                 isPresented: $isPresented,
                 allowedContentTypes: [.folder],
@@ -47,11 +49,17 @@ struct BackupFolderLinkHint: ViewModifier {
 }
 
 struct ShareableFile: Identifiable {
+    /// Unique per presentation so `.sheet(item:)` can represent again when the export path matches a prior share.
+    let id = UUID()
     let url: URL
-    var id: String { url.absoluteString }
 }
 
 // MARK: - Backup folder file list
+
+private struct BackupFolderListRow: Identifiable {
+    let url: URL
+    var id: String { url.standardizedFileURL.path }
+}
 
 struct BackupFolderImportFileListView: View {
     let onSelect: (URL) -> Void
@@ -63,6 +71,10 @@ struct BackupFolderImportFileListView: View {
     @State private var showDeleteConfirm = false
     @State private var deleteErrorMessage: String?
     @State private var showDeleteError = false
+
+    private var rows: [BackupFolderListRow] {
+        files.map { BackupFolderListRow(url: $0) }
+    }
 
     var body: some View {
         Group {
@@ -78,11 +90,11 @@ struct BackupFolderImportFileListView: View {
                     .padding()
             } else if isSelecting {
                 List(selection: $selection) {
-                    ForEach(files, id: \.path) { url in
-                        Text(url.lastPathComponent)
+                    ForEach(rows) { row in
+                        Text(row.url.lastPathComponent)
                             .font(AppTheme.settingsTechnicalBody)
                             .foregroundStyle(AppTheme.settingsTextPrimary)
-                            .tag(url.path)
+                            .tag(row.id)
                     }
                 }
                 .environment(\.editMode, .constant(.active))
@@ -90,11 +102,11 @@ struct BackupFolderImportFileListView: View {
                 .scrollContentBackground(.hidden)
                 .background(AppTheme.settingsBackground)
             } else {
-                List(files, id: \.path) { url in
+                List(rows) { row in
                     Button {
-                        onSelect(url)
+                        onSelect(row.url)
                     } label: {
-                        Text(url.lastPathComponent)
+                        Text(row.url.lastPathComponent)
                             .font(AppTheme.settingsTechnicalBody)
                             .foregroundStyle(AppTheme.settingsTextPrimary)
                             .frame(maxWidth: .infinity, alignment: .leading)
@@ -159,7 +171,7 @@ struct BackupFolderImportFileListView: View {
             load()
         }
         .onChange(of: files) { _, newFiles in
-            let validPaths = Set(newFiles.map(\.path))
+            let validPaths = Set(newFiles.map { $0.standardizedFileURL.path })
             selection = selection.intersection(validPaths)
             if newFiles.isEmpty {
                 isSelecting = false
@@ -168,7 +180,7 @@ struct BackupFolderImportFileListView: View {
     }
 
     private func performDelete() {
-        let urls = files.filter { selection.contains($0.path) }
+        let urls = files.filter { selection.contains($0.standardizedFileURL.path) }
         guard !urls.isEmpty else { return }
         do {
             try ScheduledBackupPreferences.withFolderSecurityScopedAccess { _ in


### PR DESCRIPTION
## Headline

Import/export flows behave more reliably for sharing, selection, and assistive tech.

## User impact

Invisible file-picker anchors no longer clutter VoiceOver, so backup and import actions stay easier to follow. Export sharing can open again even when the file path matches a previous share. Backup folder multi-select and delete stay aligned with the real files on disk, including path normalization edge cases.

## What changed

Hidden zero-size views that host JSON and folder file importers are marked as hidden from accessibility so screen readers do not announce useless controls.

Share items used for the system share sheet now get a fresh identifier each time they are shown, so presenting the sheet again works when the export URL is the same as before.

The scheduled backup file list builds rows from standardized file paths for list identity, tags, and the selection set. Selection cleanup after reloads and delete matching now use the same normalized paths, reducing mismatches between what appears selected and what actually gets deleted.

## Verification

On a Mac with Xcode and the project’s grace CLI, run `grace ci` (or `grace test` with the usual simulator destination from gracenotes-dev.toml). Manually exercise Settings → Data & Privacy → import/export: trigger JSON import and backup folder pickers with VoiceOver and confirm the hidden anchors are not focused; export/share twice to the same location and confirm the share sheet appears again; open the backup folder file list, enter multi-select, reload the list, and delete selected files to confirm selection and deletion stay consistent.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
