### PR TITLE
Align review calendar VoiceOver hints with day state

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewHistoryDrilldownCalendarGrid.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewHistoryDrilldownCalendarGrid.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import SwiftData
 
 // MARK: - Section strip (read-only)
 
@@ -184,7 +183,7 @@ struct ReviewHistoryDrilldownCalendarGrid: View {
                 }
                 .buttonStyle(PastTappablePressStyle())
                 .accessibilityLabel(dayCellAccessibilityLabel(dateSpeech: dateSpeech, disposition: disposition))
-                .accessibilityHint(String(localized: "review.themeDrilldown.openEntry.a11yHint"))
+                .accessibilityHint(dayCellButtonAccessibilityHint(disposition: disposition))
             }
         } else {
             Color.clear
@@ -358,6 +357,18 @@ struct ReviewHistoryDrilldownCalendarGrid: View {
         case .outsideHistoryWindow:
             return String(localized: "past.drilldown.calendarDay.a11yHint.outsideStatisticsRange")
         case .matched:
+            return ""
+        }
+    }
+
+    /// VoiceOver hint for tappable in-range days (empty days are not “open existing entry”).
+    private func dayCellButtonAccessibilityHint(disposition: ReviewHistoryDrilldownDayDisposition) -> String {
+        switch disposition {
+        case .emptyHistoryDay:
+            return String(localized: "past.accessibility.openDayToWrite")
+        case .matched, .journalDayNotMatched:
+            return String(localized: "past.accessibility.openEntryThatDay")
+        case .outsideHistoryWindow:
             return ""
         }
     }


### PR DESCRIPTION
## Headline

VoiceOver now describes each drill-down day button by what actually happens when you open it.

## User impact

People using VoiceOver were told every tappable day would open an existing entry, even on days with no journal yet. That mismatch made the Past review calendar harder to trust and navigate. The hints now match empty days versus days that already have writing.

## What changed

The review history drill-down calendar grid no longer applies one generic “open entry” VoiceOver hint to every in-range day button. A small helper picks the hint from the day’s disposition: days with no journal yet describe opening the day to write, while matched or otherwise journal-backed days describe opening what you wrote that day, and out-of-range cases stay non-interactive as before. An unused SwiftData import was removed because this view does not use SwiftData types directly, which keeps the module surface clear and avoids implying a dependency that is not there.

## Verification

On a Mac with Xcode and the iOS Simulator, run `grace ci` (or `grace test` with the project’s default destination). For accessibility, enable VoiceOver on the simulator, open the relevant Past review drill-down calendar, and confirm empty in-range days announce a write-oriented hint while days with journal content announce an entry-oriented hint.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
