### PR TITLE
Derive hex SwiftUI colors from UIColor for consistent conversion

### DIFF
--- a/GraceNotes/GraceNotes/DesignSystem/Theme.swift
+++ b/GraceNotes/GraceNotes/DesignSystem/Theme.swift
@@ -349,12 +349,18 @@ struct WarmPaperPressStyle: ButtonStyle {
 
 // MARK: - Color Hex Extension
 
+private extension UIColor {
+    convenience init(hex: UInt) {
+        let red = CGFloat((hex >> 16) & 0xFF) / 255
+        let green = CGFloat((hex >> 8) & 0xFF) / 255
+        let blue = CGFloat(hex & 0xFF) / 255
+        self.init(red: red, green: green, blue: blue, alpha: 1)
+    }
+}
+
 private extension Color {
     init(hex: UInt) {
-        let red = Double((hex >> 16) & 0xFF) / 255
-        let green = Double((hex >> 8) & 0xFF) / 255
-        let blue = Double(hex & 0xFF) / 255
-        self.init(red: red, green: green, blue: blue)
+        self.init(UIColor(hex: hex))
     }
 
     static func adaptive(lightHex: UInt, darkHex: UInt) -> Color {
@@ -364,14 +370,5 @@ private extension Color {
                 return UIColor(hex: colorHex)
             }
         )
-    }
-}
-
-private extension UIColor {
-    convenience init(hex: UInt) {
-        let red = CGFloat((hex >> 16) & 0xFF) / 255
-        let green = CGFloat((hex >> 8) & 0xFF) / 255
-        let blue = CGFloat(hex & 0xFF) / 255
-        self.init(red: red, green: green, blue: blue, alpha: 1)
     }
 }


### PR DESCRIPTION
## Headline

Theme colors built from hex values now share one UIKit-backed conversion path so the app renders them the same everywhere.

## User impact

Hex-based Warm Paper and other theme colors should look identical whether they are used through SwiftUI or underlying UIKit APIs, with less risk of tiny shifts from duplicate math. That keeps backgrounds, accents, and borders visually stable across screens and modes.

## What changed

The SwiftUI helper that turns a 24-bit hex value into a color no longer computes red, green, and blue with its own floating-point math. Instead it builds a UIKit color from those components and wraps it in SwiftUI, so there is a single definition of how hex maps to sRGB channels.

The private UIColor hex initializer was moved above the Color helper so that path is defined before use, without changing which hex values the theme exposes.

## Verification

On a Mac with Xcode and the project’s grace CLI installed, run `grace ci` (or `grace test` with the usual simulator destination from gracenotes-dev.toml) to confirm the GraceNotes scheme still builds and tests pass. Optionally spot-check a few hex-driven surfaces (e.g. journal chrome and review accents) in light and dark mode in the Simulator.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
