### PR TITLE
Optimize Past statistics section chip counts with single-pass day lookup

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/ReviewHistoryWindowing.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ReviewHistoryWindowing.swift
@@ -98,11 +98,20 @@ enum ReviewHistoryWindowing {
         contributingEntriesNewestFirst: [Journal],
         calendar: Calendar
     ) -> [Date: Int] {
+        // One pass: first row per calendar day matches `first(where:)` (see drill-down tests).
+        var firstContributingByDay: [Date: Journal] = [:]
+        firstContributingByDay.reserveCapacity(contributingEntriesNewestFirst.count)
+        for entry in contributingEntriesNewestFirst {
+            let day = calendar.startOfDay(for: entry.entryDate)
+            if firstContributingByDay[day] == nil {
+                firstContributingByDay[day] = entry
+            }
+        }
+
         var result: [Date: Int] = [:]
+        result.reserveCapacity(matchingDayStarts.count)
         for day in matchingDayStarts {
-            guard let journal = contributingEntriesNewestFirst.first(where: {
-                calendar.startOfDay(for: $0.entryDate) == day
-            }) else {
+            guard let journal = firstContributingByDay[day] else {
                 continue
             }
             let raw: Int


### PR DESCRIPTION
## Headline

Past statistics drill-down chip math stays the same but scales better when you have lots of journal history.

## User impact

Computing how many section chips to show for each matched day used to rescan your contributing entries for every day, which could add noticeable work on large histories. The app now picks the newest contributing entry per calendar day once, then reads counts from that map, so scrolling and stats stay responsive without changing what you see.

## What changed

The per-day chip helper for review statistics previously walked the newest-first contributing list with a linear search for each matched day, which could multiply work when many days matched. It now makes one forward pass over that list, recording the first (newest) journal per start-of-day key, reserves dictionary capacity, and uses those lookups when iterating matched days. Behavior matches the old “newest entry wins when several fall on the same day” rule that the drill-down tests lock in.

## Verification

On a Mac with Xcode and the project’s dev tooling installed, run `grace ci` (or `grace test` with the repo’s default simulator destination) to lint and build; exercise Past statistics with sections that have multiple entries on the same day to confirm chip counts still match expectations.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
