### PR TITLE
Stabilize journal backup export order with deterministic tie-breakers

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/Services/JournalDataExportService.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/Services/JournalDataExportService.swift
@@ -8,7 +8,11 @@ struct JournalDataExportService {
         fileManager: FileManager = .default
     ) throws -> URL {
         let descriptor = FetchDescriptor<Journal>(
-            sortBy: [SortDescriptor(\.entryDate, order: .forward)]
+            sortBy: [
+                SortDescriptor(\.entryDate, order: .forward),
+                SortDescriptor(\.createdAt, order: .forward),
+                SortDescriptor(\.id, order: .forward)
+            ]
         )
         let entries = try context.fetch(descriptor)
         let data = try makeArchiveData(from: entries, exportedAt: now)
@@ -28,7 +32,15 @@ struct JournalDataExportService {
     }
 
     func makeArchive(from entries: [Journal], exportedAt: Date) -> JournalDataExportArchive {
-        let sortedEntries = entries.sorted { $0.entryDate < $1.entryDate }
+        let sortedEntries = entries.sorted { lhs, rhs in
+            if lhs.entryDate != rhs.entryDate {
+                return lhs.entryDate < rhs.entryDate
+            }
+            if lhs.createdAt != rhs.createdAt {
+                return lhs.createdAt < rhs.createdAt
+            }
+            return lhs.id.uuidString < rhs.id.uuidString
+        }
         return JournalDataExportArchive(
             schemaVersion: JournalDataExportArchive.currentSchemaVersion,
             exportedAt: exportedAt,


### PR DESCRIPTION
## Headline

Backups list same-day journals in a stable, repeatable order instead of an arbitrary one.

## User impact

If you have more than one journal on the same calendar day, exported JSON used to order those rows in a way that could vary between exports. That made diffs, scripts, and side-by-side comparisons noisy and could confuse anyone relying on a fixed sequence. Exports now use a clear, consistent order so backups are predictable and easier to trust.

## What changed

Journal export used to sort only by the journal’s calendar day. When two records shared that day, the relative order was not fully defined, so SwiftData fetches and simple array sorts could shuffle ties.

The export path now breaks ties the same way in both places: after the calendar day, it sorts by when the journal was created, and if those still match, by stable journal identity. Fetching from the store uses matching sort keys so read order aligns with the archive builder when entries are passed in from a query.

## Verification

On a Mac with Xcode, run `grace ci` (or `grace test`) from the repo root to confirm the project still builds and tests pass.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
