### PR TITLE
Normalize weekly review day activity to calendar-day boundaries

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregates.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregates.swift
@@ -435,13 +435,12 @@ private extension WeeklyReviewAggregatesBuilder {
                 .map { calendar.startOfDay(for: $0.entryDate) }
         )
         var activity: [ReviewDayActivity] = []
-        var day = currentPeriod.lowerBound
-        while day < currentPeriod.upperBound {
-            let dayStart = calendar.startOfDay(for: day)
+        var dayStart = calendar.startOfDay(for: currentPeriod.lowerBound)
+        while dayStart < currentPeriod.upperBound {
             let hasPersistedEntry = strongestCompletionByDay[dayStart] != nil
             activity.append(
                 ReviewDayActivity(
-                    date: day,
+                    date: dayStart,
                     hasReflectiveActivity: activeDays.contains(dayStart),
                     strongestCompletionLevel: activeDays.contains(dayStart)
                         ? strongestCompletionByDay[dayStart]
@@ -449,7 +448,10 @@ private extension WeeklyReviewAggregatesBuilder {
                     hasPersistedEntry: hasPersistedEntry
                 )
             )
-            day = calendar.date(byAdding: .day, value: 1, to: day) ?? currentPeriod.upperBound
+            guard let nextDayStart = calendar.date(byAdding: .day, value: 1, to: dayStart) else {
+                break
+            }
+            dayStart = calendar.startOfDay(for: nextDayStart)
         }
         return activity
     }


### PR DESCRIPTION
## Headline

Weekly review’s per-day activity strip now lines up with real calendar days and your saved entries.

## User impact

If the review window’s dates weren’t exactly at local midnight, day rows could carry a mismatched timestamp while lookups used start-of-day keys, which could skew how completion and “had an entry” line up in the weekly summary. The change makes each row’s date and the loop’s cursor the same normalized calendar day so the strip stays consistent and trustworthy.

## What changed

The code that walks the current review week and builds `ReviewDayActivity` no longer carries a raw `Date` through the loop while comparing against dictionary keys built from `startOfDay`. It initializes from the period’s lower bound normalized to the start of that day, uses that same value for each row’s `date`, and steps forward by adding a day then re-normalizing to start-of-day. If advancing the day fails, the loop stops cleanly instead of forcing a fallback that could hide calendar edge cases.

## Verification

On a Mac with Xcode, run `grace ci` (or `grace test` with the project’s usual simulator destination) to confirm the GraceNotes scheme still builds and tests pass.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
