### PR TITLE
Sentry: refine Theme.swift

### DIFF
--- a/GraceNotes/GraceNotes/DesignSystem/Theme.swift
+++ b/GraceNotes/GraceNotes/DesignSystem/Theme.swift
@@ -349,18 +349,31 @@ struct WarmPaperPressStyle: ButtonStyle {
 
 // MARK: - Color Hex Extension
 
+/// Shared 24-bit `0xRRGGBB` parsing; masks to the low 24 bits so stray high bits cannot skew channels.
+private struct HexRGBComponents {
+    let red: CGFloat
+    let green: CGFloat
+    let blue: CGFloat
+
+    init(hex: UInt) {
+        let rgb = UInt32(truncatingIfNeeded: hex) & 0xFFFFFF
+        red = CGFloat((rgb >> 16) & 0xFF) / 255
+        green = CGFloat((rgb >> 8) & 0xFF) / 255
+        blue = CGFloat(rgb & 0xFF) / 255
+    }
+}
+
 private extension UIColor {
     convenience init(hex: UInt) {
-        let red = CGFloat((hex >> 16) & 0xFF) / 255
-        let green = CGFloat((hex >> 8) & 0xFF) / 255
-        let blue = CGFloat(hex & 0xFF) / 255
-        self.init(red: red, green: green, blue: blue, alpha: 1)
+        let rgb = HexRGBComponents(hex: hex)
+        self.init(red: rgb.red, green: rgb.green, blue: rgb.blue, alpha: 1)
     }
 }
 
 private extension Color {
     init(hex: UInt) {
-        self.init(UIColor(hex: hex))
+        let rgb = HexRGBComponents(hex: hex)
+        self.init(red: Double(rgb.red), green: Double(rgb.green), blue: Double(rgb.blue))
     }
 
     static func adaptive(lightHex: UInt, darkHex: UInt) -> Color {


### PR DESCRIPTION
## Headline

Automated refinement from `grace sentry`.

## User impact

Maintainers get a small scoped change with CI preflight before review.

## What changed

Updates `GraceNotes/GraceNotes/DesignSystem/Theme.swift` in a single automated pass (see diff on the PR).

## Verification

`grace ci` on macOS using the configured sentry CI profile.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
