### PR TITLE
Deduplicate merge conflict days during journal import

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/Services/JournalDataImportService.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/Services/JournalDataImportService.swift
@@ -167,14 +167,14 @@ struct JournalDataImportService {
         return (inserted, updated)
     }
 
-    /// Day starts (start-of-day) where merge mode would need a conflict decision.
+    /// Unique calendar day starts (start-of-day) where merge mode would need a conflict decision.
     func mergeConflictDayStarts(
         entries: [JournalDataExportEntry],
         context: ModelContext,
         calendar: Calendar
     ) throws -> [Date] {
         let repository = JournalRepository(calendar: calendar)
-        var conflicts: [Date] = []
+        var conflicts: Set<Date> = []
         for export in entries {
             let dayStart = calendar.startOfDay(for: export.entryDate)
             guard let existing = try repository.fetchEntry(dayStart: dayStart, context: context) else {
@@ -183,7 +183,7 @@ struct JournalDataImportService {
             let filePayload = comparisonPayload(for: export)
             let diskPayload = comparisonPayload(for: exportMapper.makeExportEntry(from: existing))
             if filePayload != diskPayload {
-                conflicts.append(dayStart)
+                conflicts.insert(dayStart)
             }
         }
         return conflicts.sorted()


### PR DESCRIPTION
## Headline

Merge import conflicts now list each affected day once, not repeated dates.

## User impact

When a merge import finds overlapping days that disagree with what is on the device, the app should name each calendar day only once. Duplicate entries made conflict lists noisy, harder to scan, and could exaggerate how many decisions you need to make.

## What changed

Conflict detection for merge imports used to append every conflicting day into an array, which could repeat the same calendar day. The service now records conflicting days in a set keyed by start-of-day, then returns them sorted, and the comment clarifies that these are unique calendar days. Behavior for a single pass over deduplicated entries stays the same, but the result is guaranteed unique and matches the documented intent.

## Verification

On a Mac with Xcode and the project’s grace CLI installed, run `grace ci` (or `grace test` with the repo’s default simulator destination) to lint and build the GraceNotes scheme.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
