### PR TITLE
Fall back to weekly insight theme when observation is blank

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyInsightRuleEngine.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyInsightRuleEngine.swift
@@ -48,7 +48,7 @@ struct WeeklyInsightRuleEngine {
 
         let narrativeSummary = candidateBuilder.narrativeSummary(from: selectedInsights)
         let starterReflection = String(localized: "review.insights.starterReflection")
-        let trimmedHeadline = Self.firstNonEmptyTrimmedObservation(in: selectedInsights)
+        let trimmedHeadline = Self.firstNonEmptyTrimmedHeadline(in: selectedInsights)
         let resurfacingMessage = trimmedHeadline ?? starterReflection
 
         let continuityPrompt = selectedInsights.compactMap(\.action).map {
@@ -69,13 +69,18 @@ struct WeeklyInsightRuleEngine {
         )
     }
 
-    /// Prefer the first non-empty observation line across selected insights. The first card can be
-    /// blank in pathological cases while a second selected insight still carries the visible headline.
-    private static func firstNonEmptyTrimmedObservation(in insights: [ReviewWeeklyInsight]) -> String? {
+    /// Prefer the first non-empty trimmed `observation` across selected insights. If an observation is blank
+    /// but `primaryTheme` is present (e.g. failed template substitution), use the trimmed theme so the
+    /// resurfacing line still matches visible card context instead of the generic starter copy.
+    private static func firstNonEmptyTrimmedHeadline(in insights: [ReviewWeeklyInsight]) -> String? {
         for insight in insights {
-            let trimmed = insight.observation.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !trimmed.isEmpty {
-                return trimmed
+            let trimmedObservation = insight.observation.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmedObservation.isEmpty {
+                return trimmedObservation
+            }
+            if let theme = insight.primaryTheme?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !theme.isEmpty {
+                return theme
             }
         }
         return nil


### PR DESCRIPTION
## Headline

Weekly review resurfacing copy stays aligned with the insight card when the observation string is empty.

## User impact

In rare cases where an insight’s observation text was blank but a theme was still available, the resurfacing line could fall through to generic starter copy and feel disconnected from the cards you actually see. The review now prefers the trimmed theme in that situation so the resurfacing message matches visible context.

## What changed

The logic that picks the headline for the weekly insight resurfacing message was updated. It still prefers the first non-empty trimmed observation across selected insights. When an observation is empty after trimming, it now uses the first non-empty trimmed primary theme instead of skipping straight to the generic localized starter reflection. The helper was renamed to reflect that it is choosing a headline, not only an observation string, and the documentation was updated to describe the theme fallback and why it exists (for example when template substitution fails).

## Verification

On a Mac with Xcode and the project’s grace CLI installed, run `grace ci` (or `grace test` with the usual simulator destination) to confirm the GraceNotes scheme builds and tests pass. Manually spot-check a weekly review path where an insight can have an empty observation but a non-empty theme and confirm the resurfacing line matches the card context.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
