### PR TITLE
Harden guided journal onboarding banners and step progression

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalOnboardingFlowEvaluator.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalOnboardingFlowEvaluator.swift
@@ -6,6 +6,20 @@ enum JournalOnboardingStep: Equatable {
     case person
 }
 
+private extension JournalOnboardingStep {
+    /// Section whose row hosts the onboarding banner for this linear step.
+    var bannerSection: JournalOnboardingSection {
+        switch self {
+        case .gratitude:
+            .gratitude
+        case .need:
+            .need
+        case .person:
+            .person
+        }
+    }
+}
+
 enum JournalOnboardingSection: Hashable {
     case gratitude
     case need
@@ -58,23 +72,20 @@ struct JournalOnboardingPresentation: Equatable {
 
     /// Per-section placement: linear steps use the active row.
     func sectionGuidance(for section: JournalOnboardingSection) -> JournalOnboardingSectionGuidance? {
-        guard let title, let message, let step else { return nil }
-        let bannerSection: JournalOnboardingSection = switch step {
-        case .gratitude:
-            .gratitude
-        case .need:
-            .need
-        case .person:
-            .person
-        }
-        guard section == bannerSection else { return nil }
+        guard let message, let step else { return nil }
+        guard !message.isEmpty else { return nil }
+        guard section == step.bannerSection else { return nil }
         let secondary: String? = switch step {
         case .gratitude:
             String(localized: "journal.onboarding.keyboardFinishHint")
         case .need, .person:
             nil
         }
-        return JournalOnboardingSectionGuidance(title: title, message: message, messageSecondary: secondary)
+        return JournalOnboardingSectionGuidance(
+            title: title ?? "",
+            message: message,
+            messageSecondary: secondary
+        )
     }
 }
 
@@ -93,15 +104,19 @@ enum JournalOnboardingFlowEvaluator {
             return .inactive
         }
 
-        if context.gratitudesCount == 0 {
+        let gratitudes = max(0, context.gratitudesCount)
+        let needs = max(0, context.needsCount)
+        let people = max(0, context.peopleCount)
+
+        if gratitudes == 0 {
             return firstGratitudePresentation()
         }
 
-        if context.needsCount == 0 {
+        if needs == 0 {
             return firstNeedPresentation()
         }
 
-        if context.peopleCount == 0 {
+        if people == 0 {
             return firstPersonPresentation()
         }
 
@@ -112,7 +127,7 @@ enum JournalOnboardingFlowEvaluator {
 private extension JournalOnboardingFlowEvaluator {
     static func presentation(
         step: JournalOnboardingStep,
-        title: String,
+        title: String?,
         message: String,
         states: [JournalOnboardingSection: JournalOnboardingSectionState]
     ) -> JournalOnboardingPresentation {
@@ -135,7 +150,7 @@ private extension JournalOnboardingFlowEvaluator {
     static func firstGratitudePresentation() -> JournalOnboardingPresentation {
         presentation(
             step: .gratitude,
-            title: "",
+            title: nil,
             message: String(localized: "journal.onboarding.startWithGratitude"),
             states: [
                 .gratitude: .active,


### PR DESCRIPTION
## Headline

Journal onboarding stays on the right step, shows guidance only when there is real copy, and handles bad counts safely.

## User impact

First-time journal guidance is less likely to show empty or misplaced banners or get stuck on the wrong step if section counts are inconsistent. People going through the gratitude → need → person flow see clearer, more reliable coaching above the right section.

## What changed

Section guidance no longer requires a title for the first gratitude step; titles are optional in the helper and collapse to an empty banner title when absent, while messages must be non-empty so blank rows are not treated as active guidance.

A small mapping on each onboarding step names which section hosts the banner, so placement stays aligned with the linear flow without duplicating switch logic.

Counts for gratitudes, needs, and people are clamped to zero or more before deciding the next step, so negative or corrupted values do not skip ahead or mis-order the guided path.

## Verification

On a Mac with Xcode and the default simulator setup from gracenotes-dev.toml, run `grace ci` (or `grace test` with the project’s usual destination) and walk through guided journaling on Today: confirm the first gratitude banner appears with body copy and keyboard hint, then needs and people steps after 1/1/1, with no empty banner when copy is missing.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
