### PR TITLE
Improve journal share image scale and bitmap validation

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/JournalShareRenderer.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/JournalShareRenderer.swift
@@ -11,9 +11,12 @@ enum JournalShareRenderer {
         let cardView = JournalShareCardView(payload: payload, onLineTap: nil)
         let renderer = ImageRenderer(content: cardView)
         renderer.proposedSize = ProposedViewSize(width: Self.proposedLayoutWidth, height: nil)
-        renderer.scale = Self.pixelScale
+        renderer.scale = Self.recommendedPixelScale()
         guard let image = renderer.uiImage else { return nil }
         guard image.size.width > 0, image.size.height > 0 else { return nil }
+        if let cgImage = image.cgImage {
+            guard cgImage.width > 0, cgImage.height > 0 else { return nil }
+        }
         return image
     }
 
@@ -21,11 +24,21 @@ enum JournalShareRenderer {
     private static let proposedLayoutWidth: CGFloat = 448 + 24 * 2
 
     /// `ImageRenderer` runs without hosting in a window; `UITraitCollection.current.displayScale` can be
-    /// unset or 1× while the device screen is Retina. Take the best positive value between trait and screen.
-    private static var pixelScale: CGFloat {
+    /// unset or 1× while the device screen is Retina. Prefer an active window scene scale, then trait, then
+    /// screen, then a safe default.
+    @MainActor
+    private static func recommendedPixelScale() -> CGFloat {
         let traitScale = UITraitCollection.current.displayScale
+        let sceneScale = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .map { $0.screen.scale }
+            .max() ?? 0
         let screenScale = UIScreen.main.scale
-        let best = max(traitScale > 0 ? traitScale : 0, screenScale > 0 ? screenScale : 0)
+        let best = max(
+            traitScale > 0 ? traitScale : 0,
+            sceneScale > 0 ? sceneScale : 0,
+            screenScale > 0 ? screenScale : 0
+        )
         return best > 0 ? best : 3
     }
 }


### PR DESCRIPTION
## Headline

Shared journal cards render at the right pixel density more reliably and invalid images are rejected sooner.

## User impact

When you share a journal as an image, the export should look sharp on Retina displays instead of accidentally rendering at 1×. The update also avoids treating empty backing bitmaps as a successful share.

## What changed

Share rendering used trait and main-screen scale only; off-window rendering can still report a weak scale. The renderer now picks the strongest positive scale among the current trait, any connected window scene’s screen, and the main screen, with the same safe fallback when nothing valid is available. After building the image, it also checks the Core Graphics backing size when present so zero-sized bitmaps are not returned as success.

## Verification

On a Mac with Xcode, run `grace ci` (or `grace test` per project defaults). Manually share a journal entry and confirm the image looks crisp on a Retina device or simulator and that sharing still completes when content is valid.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
