### PR TITLE
Harden hex colors for share cards with sRGB and 24-bit masking

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/ShareCardSurface.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ShareCardSurface.swift
@@ -111,10 +111,12 @@ private func darkCompletionChipBackground(style: ShareCardStyle) -> some View {
 }
 
 private extension Color {
+    /// 24-bit `RRGGBB`. High bits are masked so `AARRGGBB`-style literals still resolve to the same sRGB triplet.
     init(hex: UInt) {
-        let red = Double((hex >> 16) & 0xFF) / 255
-        let green = Double((hex >> 8) & 0xFF) / 255
-        let blue = Double(hex & 0xFF) / 255
-        self.init(red: red, green: green, blue: blue)
+        let rgb = hex & 0xFFFFFF
+        let red = Double((rgb >> 16) & 0xFF) / 255
+        let green = Double((rgb >> 8) & 0xFF) / 255
+        let blue = Double(rgb & 0xFF) / 255
+        self.init(.sRGB, red: red, green: green, blue: blue)
     }
 }


### PR DESCRIPTION
## Headline

Share card theme colors stay predictable when hex values include extra high bits or need explicit sRGB.

## User impact

Dark share card backgrounds, text, and accents should look consistent with the intended palette instead of drifting if a hex literal ever carries alpha or other high bits. Explicit sRGB keeps exported or rendered share images aligned with the same color math across contexts.

## What changed

The private `Color(hex:)` helper used for dark share card chrome now keeps only the low 24 bits before splitting into red, green, and blue, so values shaped like `AARRGGBB` still map to the same RGB triplet as plain `RRGGBB` literals. Color construction uses the sRGB initializer so components are interpreted in a single, well-defined color space. A short doc comment documents the masking behavior for future call sites.

## Verification

On a Mac with Xcode and the project’s `grace` CLI, run `grace ci` (or `grace test` with the default simulator destination) to lint and build; optionally open the share flow and confirm dark card styles still match expectations.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
