### PR TITLE
Normalize streak day boundaries in StreakCalculator

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/StreakCalculator.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/StreakCalculator.swift
@@ -49,6 +49,7 @@ struct StreakCalculator {
 
     private func currentStreakLength(byDay: [Date: Bool], today: Date) -> Int {
         let yesterday = calendar.date(byAdding: .day, value: -1, to: today)
+            .map { calendar.startOfDay(for: $0) }
         let startDay: Date
         if byDay[today] == true {
             startDay = today
@@ -62,7 +63,11 @@ struct StreakCalculator {
         var cursor = startDay
         while byDay[cursor] == true {
             streakLength += 1
-            guard let previousDay = calendar.date(byAdding: .day, value: -1, to: cursor) else {
+            guard let rawPrevious = calendar.date(byAdding: .day, value: -1, to: cursor) else {
+                break
+            }
+            let previousDay = calendar.startOfDay(for: rawPrevious)
+            guard previousDay != cursor else {
                 break
             }
             cursor = previousDay


### PR DESCRIPTION
## Headline

Journal streak counts stay accurate when the calendar steps between days.

## User impact

Streak numbers could be wrong or unstable if “yesterday” and each step backward did not match the same midnight-normalized dates used everywhere else. After this change, basic and perfect streaks line up with how journal days are keyed, so what you see reflects real consecutive journaling days.

## What changed

The streak logic already stores completion per calendar day using start-of-day dates. The code now applies the same start-of-day normalization when it derives “yesterday” from today and when it walks backward day by day in the streak loop, so dictionary lookups always use the same date keys. A safety check stops the backward walk if the calendar would ever produce a non-advancing “previous” day, avoiding a runaway loop.

## Verification

On a Mac with Xcode and the repo’s grace CLI installed, run `grace ci` (or `grace test` with the project’s default simulator destination) to lint and exercise the GraceNotes scheme.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
