### PR TITLE
Only update editor state after a successful entry delete

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/JournalScreenEntryHandling.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/JournalScreenEntryHandling.swift
@@ -84,14 +84,14 @@ enum JournalScreenEntryHandling {
         return true
     }
 
-    /// Performs the delete flow: removes the item and updates editing state.
+    /// Performs the delete flow: removes the item and updates editing state when removal succeeds.
     static func performDelete(
         index: Int,
         remove: @MainActor (Int) -> Bool,
         input: Binding<String>,
         editingIndex: Binding<Int?>
     ) {
-        _ = remove(index)
+        guard remove(index) else { return }
         if editingIndex.wrappedValue == index {
             editingIndex.wrappedValue = nil
             input.wrappedValue = ""


### PR DESCRIPTION
## Headline

Failed deletes no longer clear or shift the active edit selection.

## User impact

If removing a gratitude, need, or person line did not succeed, the app could still clear the draft or adjust which row you were editing, so the screen no longer matched what was saved. After this change, the editor and selection stay consistent with the list until a delete actually completes.

## What changed

The shared delete helper for sequential journal lines used to ignore whether the underlying remove operation succeeded. It always ran the follow-up logic that clears the draft when you were editing that row, or decrements the editing index when you were editing a later row.

The handler now exits early when removal fails, so local editing state is only updated after a successful delete. The doc comment was tightened to describe that behavior.

## Verification

On a Mac with the Grace Notes dev toolchain, run `grace ci` (or `grace test` with the project’s default simulator destination) to confirm the app builds and automated checks pass. Manually try deleting a line while another row is selected or while editing, including a case where persistence could refuse removal, and confirm the draft and highlighted row do not change unless the delete succeeds.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
