### PR TITLE
Tighten weekly review theme support matching for Latin and Han text

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregatesBuilder+ThemeSections.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregatesBuilder+ThemeSections.swift
@@ -278,19 +278,30 @@ extension WeeklyReviewAggregatesBuilder {
 
     func moderateSurfaceSemanticMatch(themeConcept: String, supportText: String) -> Bool {
         let normalizedSupport = textNormalizer.normalizeThemeLabel(supportText)
-        guard !normalizedSupport.isEmpty else { return false }
-        if normalizedSupport.contains(themeConcept) || themeConcept.contains(normalizedSupport) {
+        let normalizedTheme = textNormalizer.normalizeThemeLabel(themeConcept)
+        guard !normalizedSupport.isEmpty, !normalizedTheme.isEmpty else { return false }
+        if containsHanCharacters(themeConcept) {
+            return normalizedSupport.contains(normalizedTheme) || normalizedTheme.contains(normalizedSupport)
+        }
+        // Latin: naive `contains` matches inside other words (e.g. "rest" in "forest"); require word boundaries.
+        if latinPhraseHasWordBoundaryMatch(haystack: normalizedSupport, needle: normalizedTheme)
+            || latinPhraseHasWordBoundaryMatch(haystack: normalizedTheme, needle: normalizedSupport) {
             return true
         }
-        if containsHanCharacters(themeConcept) {
-            return normalizedSupport.contains(themeConcept)
-        }
-        let themeTokens = Set(themeConcept.split(separator: " ").map(String.init).filter { $0.count >= 3 })
+        let themeTokens = Set(normalizedTheme.split(separator: " ").map(String.init).filter { $0.count >= 3 })
         let supportTokens = Set(normalizedSupport.split(separator: " ").map(String.init).filter { $0.count >= 3 })
         if themeTokens.isEmpty || supportTokens.isEmpty {
             return false
         }
         return !themeTokens.isDisjoint(with: supportTokens)
+    }
+
+    /// Whole-phrase / whole-word match for Latin script; avoids substring hits like "rest" inside "forest".
+    private func latinPhraseHasWordBoundaryMatch(haystack: String, needle: String) -> Bool {
+        guard needle.count <= haystack.count else { return false }
+        let escaped = NSRegularExpression.escapedPattern(for: needle)
+        let pattern = "\\b\(escaped)\\b"
+        return haystack.range(of: pattern, options: .regularExpression) != nil
     }
 
     func containsHanCharacters(_ text: String) -> Bool {


### PR DESCRIPTION
## Headline

Weekly review themes attach supporting evidence only for real word matches, not accidental substrings.

## User impact

Supporting lines under weekly themes (from readings and reflections) should feel more relevant to the theme label. You should see fewer unrelated snippets where a short word appeared inside another word. Chinese and Japanese theme labels are compared using normalized text on both sides, so matching stays consistent.

## What changed

The weekly review builder attaches extra support text to a theme when a moderate semantic match is found. The previous approach used naive substring checks and compared normalized support text to an unnormalized theme string. That could incorrectly link evidence when a theme word appeared inside an unrelated word (for example, rest inside forest), and it made Latin and mixed comparisons inconsistent. The update normalizes both the theme label and the support text before comparing them. For Latin script it requires whole-word or whole-phrase boundaries so substring hits inside longer words no longer count. For text that includes Han characters it uses the normalized strings for containment checks in both directions. Longer-word overlap still uses word tokens derived from the normalized theme label.

## Verification

On macOS with Xcode and the Grace Notes dev CLI installed, run `grace ci` from the repo root (or `grace test` with the default simulator destination from gracenotes-dev.toml). Confirm the GraceNotes scheme builds and automated tests pass; optionally open Weekly Review and spot-check that theme evidence looks on-topic for English and CJK journals.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
