### PR TITLE
Polish Saved to Photos toast chrome and VoiceOver

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/SavedToPhotosToastView.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/SavedToPhotosToastView.swift
@@ -5,10 +5,15 @@ struct SavedToPhotosToastView: View {
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
     @Environment(\.todayJournalPalette) private var palette
 
+    private var toastChromeShape: RoundedRectangle {
+        RoundedRectangle(cornerRadius: AppTheme.cornerRadiusMedium, style: .continuous)
+    }
+
     var body: some View {
         HStack(spacing: 8) {
             Image(systemName: "checkmark.circle.fill")
                 .foregroundStyle(palette.complete)
+                .accessibilityHidden(true)
             Text(String(localized: "sharing.savedToPhotos"))
                 .font(AppTheme.warmPaperBody)
                 .foregroundStyle(palette.textPrimary)
@@ -20,11 +25,8 @@ struct SavedToPhotosToastView: View {
                 ? palette.paper
                 : palette.paper.opacity(palette.sectionPaperOpacity)
         )
-        .clipShape(RoundedRectangle(cornerRadius: AppTheme.cornerRadiusMedium))
-        .overlay(
-            RoundedRectangle(cornerRadius: AppTheme.cornerRadiusMedium)
-                .stroke(palette.border, lineWidth: 1)
-        )
+        .clipShape(toastChromeShape)
+        .overlay(toastChromeShape.stroke(palette.border, lineWidth: 1))
         .journalToastOuterGlow(accentColor: palette.complete, reduceTransparency: reduceTransparency)
         .padding(.bottom, 32)
     }


### PR DESCRIPTION
## Headline

The save-to-Photos toast looks more consistent and reads cleaner with VoiceOver.

## User impact

Decorative checkmark art no longer clutters VoiceOver, so the message is easier to hear. The toast’s rounded outline and fill stay aligned, with corners that match the rest of the app’s softer shape language.

## What changed

Introduced one shared rounded-rectangle definition for both clipping and the border stroke so the outline cannot drift from the background. Switched to continuously rounded corners to align with common app chrome. Marked the success icon as hidden from accessibility so assistive tech focuses on the localized “saved to Photos” text.

## Verification

On a Mac with Xcode, run `swiftlint lint` from the repo root, then `grace ci` (or `grace test` with the project’s default simulator destination) to confirm the GraceNotes scheme still builds and tests pass.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
