### PR TITLE
Trim journal onboarding guidance and hide empty whitespace-only cards

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalOnboardingGuidanceView.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalOnboardingGuidanceView.swift
@@ -13,25 +13,45 @@ struct JournalOnboardingGuidanceView: View {
         self.messageSecondary = messageSecondary
     }
 
+    private var trimmedTitle: String {
+        title.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var trimmedMessage: String {
+        message.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var trimmedSecondaryLine: String? {
+        guard let messageSecondary else { return nil }
+        let trimmed = messageSecondary.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private var hasMeaningfulContent: Bool {
+        !trimmedTitle.isEmpty || !trimmedMessage.isEmpty || trimmedSecondaryLine != nil
+    }
+
     var body: some View {
-        if message.isEmpty {
+        if !hasMeaningfulContent {
             EmptyView()
         } else {
             VStack(alignment: .leading, spacing: AppTheme.spacingTight) {
-                if !title.isEmpty {
-                    Text(title)
+                if !trimmedTitle.isEmpty {
+                    Text(trimmedTitle)
                         .font(AppTheme.warmPaperMetaEmphasis)
                         .foregroundStyle(AppTheme.accentText)
                         .accessibilityAddTraits(.isHeader)
                 }
 
-                Text(message)
-                    .font(AppTheme.warmPaperBody)
-                    .foregroundStyle(palette.textPrimary)
-                    .fixedSize(horizontal: false, vertical: true)
+                if !trimmedMessage.isEmpty {
+                    Text(trimmedMessage)
+                        .font(AppTheme.warmPaperBody)
+                        .foregroundStyle(palette.textPrimary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
 
-                if let messageSecondary {
-                    Text(messageSecondary)
+                if let trimmedSecondaryLine {
+                    Text(trimmedSecondaryLine)
                         .font(AppTheme.warmPaperBody)
                         .foregroundStyle(palette.textPrimary)
                         .fixedSize(horizontal: false, vertical: true)


### PR DESCRIPTION
## Headline

Onboarding hints no longer render blank cards or invisible lines when copy is only whitespace.

## User impact

Journal onboarding guidance treats trimmed text as the real content, so you do not get an empty-looking card or stray blank lines from spaces or newlines. Title-only or secondary-line-only hints can appear when the main message is empty after trimming, which matches how those strings are meant to be used.

## What changed

The guidance view now trims leading and trailing whitespace from the title, main message, and optional second line. It shows the card only when at least one of those trimmed values is non-empty, instead of keying visibility solely on the raw main message. Each line is drawn only when it has non-empty trimmed text, and an all-whitespace optional second line is dropped so it does not add noise.

## Verification

On a Mac with the repo and Xcode, run `grace ci` (or `grace test`) from the project root to confirm the app still builds and tests pass; in the simulator, open journal onboarding flows that use this view and confirm cards with only spaces do not appear, while title-only or hint-only content still shows as expected.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
