### PR TITLE
Treat whitespace-only journal onboarding guidance as inactive

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalOnboardingFlowEvaluator.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalOnboardingFlowEvaluator.swift
@@ -62,8 +62,10 @@ struct JournalOnboardingPresentation: Equatable {
         sectionStates: [:]
     )
 
+    /// True when guided copy is actually shown (`sectionGuidance` would be non-nil for the active step).
     var isGuidanceActive: Bool {
-        step != nil
+        guard step != nil, let message else { return false }
+        return !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     func state(for section: JournalOnboardingSection) -> JournalOnboardingSectionState {
@@ -73,14 +75,18 @@ struct JournalOnboardingPresentation: Equatable {
     /// Per-section placement: linear steps use the active row.
     func sectionGuidance(for section: JournalOnboardingSection) -> JournalOnboardingSectionGuidance? {
         guard let message, let step else { return nil }
-        guard !message.isEmpty else { return nil }
+        guard !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
         guard section == step.bannerSection else { return nil }
-        let secondary: String? = switch step {
-        case .gratitude:
-            String(localized: "journal.onboarding.keyboardFinishHint")
-        case .need, .person:
-            nil
-        }
+        let secondary: String? = {
+            switch step {
+            case .gratitude:
+                let hint = String(localized: "journal.onboarding.keyboardFinishHint")
+                let trimmed = hint.trimmingCharacters(in: .whitespacesAndNewlines)
+                return trimmed.isEmpty ? nil : trimmed
+            case .need, .person:
+                return nil
+            }
+        }()
         return JournalOnboardingSectionGuidance(
             title: title ?? "",
             message: message,


### PR DESCRIPTION
## Headline

Guided journal onboarding no longer pretends to show copy when the message is blank or only whitespace.

## User impact

Users see a consistent guided state: the app does not mark onboarding guidance as active when there is nothing meaningful to read. On the gratitude step, an empty or whitespace-only keyboard hint line is omitted instead of leaving an awkward blank second line if localization is missing or trimmed away.

## What changed

The onboarding presentation’s “guidance active” flag now matches what the UI would actually show: it requires a non-nil step and primary message text that is not empty after trimming leading and trailing whitespace and newlines. Section guidance uses the same trimmed-empty check for the primary message so whitespace-only strings do not produce a banner. For the optional gratitude keyboard hint, the localized secondary line is trimmed and dropped entirely when it would otherwise be blank, keeping the banner clean.

## Verification

On a Mac with Xcode and the project’s grace CLI installed, run `grace ci` (or `grace test` with the repo’s default simulator destination) to lint and build; optionally exercise the first-time journal onboarding flow in the simulator to confirm banners and hints only appear when copy is non-empty.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
