### PR TITLE
Align journal onboarding active state with banner-ready guidance

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalOnboardingFlowEvaluator.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalOnboardingFlowEvaluator.swift
@@ -62,8 +62,14 @@ struct JournalOnboardingPresentation: Equatable {
         sectionStates: [:]
     )
 
+    /// Guided step plus body copy; both are required for a visible banner (`sectionGuidance`).
+    private var guidedStepWithMessage: (step: JournalOnboardingStep, message: String)? {
+        guard let step, let message, !message.isEmpty else { return nil }
+        return (step, message)
+    }
+
     var isGuidanceActive: Bool {
-        step != nil
+        guidedStepWithMessage != nil
     }
 
     func state(for section: JournalOnboardingSection) -> JournalOnboardingSectionState {
@@ -72,10 +78,9 @@ struct JournalOnboardingPresentation: Equatable {
 
     /// Per-section placement: linear steps use the active row.
     func sectionGuidance(for section: JournalOnboardingSection) -> JournalOnboardingSectionGuidance? {
-        guard let message, let step else { return nil }
-        guard !message.isEmpty else { return nil }
-        guard section == step.bannerSection else { return nil }
-        let secondary: String? = switch step {
+        guard let guided = guidedStepWithMessage else { return nil }
+        guard section == guided.step.bannerSection else { return nil }
+        let secondary: String? = switch guided.step {
         case .gratitude:
             String(localized: "journal.onboarding.keyboardFinishHint")
         case .need, .person:
@@ -83,7 +88,7 @@ struct JournalOnboardingPresentation: Equatable {
         }
         return JournalOnboardingSectionGuidance(
             title: title ?? "",
-            message: message,
+            message: guided.message,
             messageSecondary: secondary
         )
     }


### PR DESCRIPTION
## Headline

Guided onboarding now reports “active” only when a step has real body copy, matching the banner.

## User impact

Before, `isGuidanceActive` could be true whenever a step was set, even if the message was missing or empty—so other UI could think coaching was on while no banner copy was ready. That mismatch could confuse layouts, accessibility, or logic that keys off “guidance is showing.” After this change, “active” tracks the same requirements as showing guidance: a step plus non-empty message.

## What changed

The presentation model now derives a single “guided step with message” concept: both the step and non-empty body text must be present, matching what `sectionGuidance` needs for a visible banner.

`isGuidanceActive` uses that shared rule instead of only checking for a non-nil step, and `sectionGuidance` reuses it so the active flag and per-section banner content stay aligned. A brief doc comment explains why both pieces are required.

## Verification

On a Mac with Xcode and the iOS Simulator, run `grace ci` (or `grace test` with the project’s usual destination) to lint and build. Manually spot-check Today journal onboarding: with the first guided steps, confirm guidance-related UI still activates with the expected banner copy, and that edge cases with empty or missing message (if constructible in tests or fixtures) do not mark guidance as active without visible copy.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
