### PR TITLE
Fix Settings deep links when the same section is opened twice

### DIFF
--- a/GraceNotes/GraceNotes/Application/AppNavigationModel.swift
+++ b/GraceNotes/GraceNotes/Application/AppNavigationModel.swift
@@ -20,8 +20,12 @@ final class AppNavigationModel: ObservableObject {
     /// Switches to Settings and requests scroll/highlight for `target`.
     /// Callers that deep-link from domain rules (e.g. journal onboarding) should validate intent before calling.
     func openSettings(target: SettingsScrollTarget) {
-        settingsScrollTarget = target
         selectedTab = .settings
+        // If the target is unchanged, SwiftUI `onChange` may not run; nil-out first so repeat deep links still scroll.
+        if settingsScrollTarget == target {
+            settingsScrollTarget = nil
+        }
+        settingsScrollTarget = target
     }
 
     func clearSettingsTarget(_ target: SettingsScrollTarget) {


### PR DESCRIPTION
## Headline

Opening the same Settings section again from a deep link now scrolls and highlights it reliably.

## User impact

If you followed a link into Settings (for example from journal onboarding) and the app was already focused on that section, a second tap could do nothing because the scroll target never changed. The app now resets that intent so repeat navigation still drives the Settings screen as expected.

## What changed

When navigating to Settings with a scroll target, the app switches to the Settings tab first, then clears the existing scroll target when it matches the new one before assigning the target again. That brief reset avoids a case where SwiftUI does not run change handling when the published value is unchanged, which blocked repeated deep links to the same section.

## Verification

On a Mac with Xcode and the project’s grace CLI, run `grace ci` (or `grace test`) for a full lint and simulator build. Manually verify by deep-linking to a Settings subsection (for example Reminders or Data & Privacy), staying on that section, and triggering the same deep link again; the view should still scroll or emphasize the section.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
