### PR TITLE
Harden weekly review aggregates: continuity text and rhythm history dates

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregates.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregates.swift
@@ -146,6 +146,14 @@ private extension WeeklyReviewAggregatesBuilder {
             || !textNormalizer.trimmed(entry.reflections).isEmpty
     }
 
+    /// Joins non-empty trimmed notes and reflections without a stray lone space when both are empty.
+    func reflectionCorpusForContinuity(_ entry: Journal) -> String {
+        [entry.readingNotes, entry.reflections]
+            .map { textNormalizer.trimmed($0) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+
     func buildChipStats(
         from entries: [Journal],
         itemsExtractor: (Journal) -> [Entry],
@@ -192,7 +200,7 @@ private extension WeeklyReviewAggregatesBuilder {
                 sequence += 1
             }
 
-            for textTheme in textNormalizer.extractThemesFromText(entry.readingNotes + " " + entry.reflections) {
+            for textTheme in textNormalizer.extractThemesFromText(reflectionCorpusForContinuity(entry)) {
                 accumulateTheme(
                     label: textTheme,
                     day: day,
@@ -373,8 +381,9 @@ private extension WeeklyReviewAggregatesBuilder {
             from: allEntries,
             calendar: calendar
         )
-        let weekLastInclusive = calendar.date(byAdding: .day, value: -1, to: currentPeriod.upperBound)
-            ?? currentPeriod.lowerBound
+        guard let weekLastInclusive = calendar.date(byAdding: .day, value: -1, to: currentPeriod.upperBound) else {
+            return nil
+        }
         let weekLastStart = calendar.startOfDay(for: weekLastInclusive)
         let referenceDayStart = calendar.startOfDay(for: referenceDate)
         let endDayInclusive = min(weekLastStart, referenceDayStart)
@@ -384,7 +393,9 @@ private extension WeeklyReviewAggregatesBuilder {
         let startDay = entryMinRaw
         guard startDay <= endDayInclusive else { return nil }
 
-        let rangeEndExclusive = calendar.date(byAdding: .day, value: 1, to: endDayInclusive) ?? currentPeriod.upperBound
+        guard let rangeEndExclusive = calendar.date(byAdding: .day, value: 1, to: endDayInclusive) else {
+            return nil
+        }
         let history = buildDayActivity(
             currentPeriod: startDay..<rangeEndExclusive,
             entries: allEntries,


### PR DESCRIPTION
## Headline

Weekly review insights skip bad calendar math and avoid phantom themes from empty reflection text.

## User impact

Continuity theme detection is less likely to pick up nonsense or whitespace-only signals when reading notes and reflections are both empty. If the calendar cannot compute key week boundaries safely, the rhythm history section is omitted instead of building from substitute dates that could skew the story.

## What changed

Added a small helper that trims reading notes and reflections, drops empty pieces, and joins the rest with a single space so theme extraction never receives a lone stray space. Continuity stats now feed that combined text into theme extraction instead of always inserting a space between raw fields.

In the rhythm history builder, two date steps that used fallback dates when calendar arithmetic returned nil now bail out and return no rhythm history, so we do not silently substitute week boundaries that could misrepresent the timeline.

## Verification

On a Mac with Xcode and the project CLI installed, run `grace ci` (or `grace test` with the repo’s default simulator destination) to lint, build, and exercise unit tests for the GraceNotes scheme.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
