### PR TITLE
Close performance traces when a startup attempt is superseded

### DIFF
--- a/GraceNotes/GraceNotes/Application/StartupCoordinator.swift
+++ b/GraceNotes/GraceNotes/Application/StartupCoordinator.swift
@@ -158,7 +158,10 @@ final class StartupCoordinator: ObservableObject {
         attemptID: UInt64,
         traceStart: TimeInterval
     ) {
-        guard attemptID == currentAttemptID else { return }
+        guard attemptID == currentAttemptID else {
+            PerformanceTrace.end("StartupCoordinator.startupAttempt.superseded", startedAt: traceStart)
+            return
+        }
         finishAttempt()
         phase = .ready(controller)
         PerformanceTrace.end("StartupCoordinator.startupAttempt.success", startedAt: traceStart)
@@ -169,7 +172,10 @@ final class StartupCoordinator: ObservableObject {
         attemptID: UInt64,
         traceStart: TimeInterval
     ) {
-        guard attemptID == currentAttemptID else { return }
+        guard attemptID == currentAttemptID else {
+            PerformanceTrace.end("StartupCoordinator.startupAttempt.superseded", startedAt: traceStart)
+            return
+        }
         finishAttempt()
         let message = startupErrorMessage(from: error)
         startupMessage = message


### PR DESCRIPTION
## Headline

Finish superseded startup traces so Instruments and diagnostics stay honest during retries and overlapping attempts.

## User impact

If you tap Retry or a new startup begins before an older persistence attempt finishes, the stale attempt quietly returned and left its performance trace open. That skews startup timing signals and makes triage harder when something goes wrong during launch.

## What changed

Startup success and failure handlers still ignore work from an outdated attempt ID so only the current attempt updates the UI and state. When that guard fires, the code now ends the matching performance trace with an explicit superseded signal using the original trace start time, instead of returning without closing the span.

## Verification

On a Mac with Xcode, run `grace ci` (or `grace test` with the project’s usual simulator destination) to confirm the app still builds and tests pass.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
