### PR TITLE
Respect Reduce Transparency and VoiceOver for settings highlight

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/SettingsTargetHighlightModifier.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/SettingsTargetHighlightModifier.swift
@@ -3,13 +3,15 @@ import SwiftUI
 struct SettingsTargetHighlightModifier: ViewModifier {
     let isHighlighted: Bool
 
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+
     func body(content: Content) -> some View {
         content
             .padding(isHighlighted ? AppTheme.spacingTight : 0)
             .background {
                 if isHighlighted {
                     RoundedRectangle(cornerRadius: AppTheme.cornerRadiusMedium)
-                        .fill(AppTheme.journalPaper.opacity(0.82))
+                        .fill(AppTheme.journalPaper.opacity(reduceTransparency ? 1.0 : 0.82))
                         .allowsHitTesting(false)
                 }
             }
@@ -20,6 +22,7 @@ struct SettingsTargetHighlightModifier: ViewModifier {
                         .allowsHitTesting(false)
                 }
             }
+            .accessibilityAddTraits(isHighlighted ? .isSelected : [])
     }
 }
 


### PR DESCRIPTION
## Headline

Settings jump targets now behave better for Reduce Transparency and screen readers.

## User impact

People who use Reduce Transparency get a solid highlight background instead of a semi-transparent one, which is easier to see and matches system expectations. VoiceOver users hear the highlighted row as selected, so it is clearer which setting the app is pointing to.

## What changed

The highlight modifier now reads whether Reduce Transparency is on. When it is, the paper-colored background uses full opacity instead of a translucent fill. When a row is highlighted, the view also advertises a selected accessibility trait so assistive tech can describe the active target.

## Verification

On a Mac with the Grace Notes dev toolchain, run `grace ci` (or `grace test` with the project’s default simulator destination). In the app, enable Reduce Transparency and jump to a setting: confirm the highlight reads clearly. With VoiceOver on, confirm the highlighted row is announced as selected.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
