### PR TITLE
Guard past statistics interval state updates when unchanged

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/AdvancedSettingsScreen.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/AdvancedSettingsScreen.swift
@@ -164,9 +164,15 @@ struct AdvancedSettingsScreen: View {
 
     private func loadIntervalState() {
         let selection = PastStatisticsIntervalPreference.selection(fromAppStorage: intervalEncoded).validated
-        customQuantity = Self.clampedPickerQuantity(selection.quantity)
-        customUnit = selection.unit
-        intervalMode = selection.mode == .all ? .all : .custom
+        let nextQuantity = Self.clampedPickerQuantity(selection.quantity)
+        let nextUnit = selection.unit
+        let nextMode: PastStatisticsIntervalPickerMode = selection.mode == .all ? .all : .custom
+        if nextQuantity == customQuantity, nextUnit == customUnit, nextMode == intervalMode {
+            return
+        }
+        customQuantity = nextQuantity
+        customUnit = nextUnit
+        intervalMode = nextMode
     }
 
     private func applyIntervalMode(_ mode: PastStatisticsIntervalPickerMode) {


### PR DESCRIPTION
## Headline

Advanced Settings no longer re-applies the same Past Statistics interval when storage has not actually changed.

## User impact

This avoids needless churn when the screen loads or AppStorage refreshes with values that already match the pickers, which helps keep wheel pickers and persistence from firing redundant updates. The visible setting should stay the same; the win is calmer behavior and fewer accidental side effects.

## What changed

Past statistics interval loading now computes the next quantity, unit, and All versus Custom mode from saved preferences, then exits early when that matches what is already on screen. Only when something differs does it assign into local state.

That keeps unchanged preferences from triggering unnecessary state writes that could cascade into persistence or SwiftUI change handling.

## Verification

On a Mac with the repo and Xcode, run `grace ci` (or `grace test` if you only need tests). In the app, open Settings → Advanced, choose a custom Past Statistics interval, leave the screen and return, and confirm the pickers stay put without odd resets or duplicate saves.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
