### PR TITLE
Thicken settings highlight border for Differentiate Without Color

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/SettingsTargetHighlightModifier.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/SettingsTargetHighlightModifier.swift
@@ -4,6 +4,7 @@ struct SettingsTargetHighlightModifier: ViewModifier {
     let isHighlighted: Bool
 
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+    @Environment(\.accessibilityDifferentiateWithoutColor) private var differentiateWithoutColor
 
     func body(content: Content) -> some View {
         content
@@ -18,7 +19,7 @@ struct SettingsTargetHighlightModifier: ViewModifier {
             .overlay {
                 if isHighlighted {
                     RoundedRectangle(cornerRadius: AppTheme.cornerRadiusMedium)
-                        .strokeBorder(AppTheme.accent, lineWidth: 1)
+                        .strokeBorder(AppTheme.accent, lineWidth: differentiateWithoutColor ? 2 : 1)
                         .allowsHitTesting(false)
                 }
             }


### PR DESCRIPTION
## Headline

Settings deep-link highlights stay visible when the system de-emphasizes color.

## User impact

People who turn on Differentiate Without Color rely on weight and contrast, not hue alone. A thin accent outline can be easy to miss. A slightly thicker border makes the highlighted settings target easier to spot without changing normal appearance for everyone else.

## What changed

The settings target highlight modifier now reads the system “Differentiate Without Color” accessibility setting. When that mode is on, the rounded highlight outline uses a heavier stroke so the selection reads clearly even when color differences are muted. When it is off, the outline matches the previous one-point stroke.

## Verification

On a Mac with Xcode, run `grace ci` (or `grace test` with the project’s default simulator destination). On device or Simulator, enable Settings → Accessibility → Display & Text Size → Differentiate Without Color, open a flow that applies the settings target highlight, and confirm the outline is visibly stronger while the feature still looks unchanged with the setting off.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
