### PR TITLE
Remove legacy app tour flag after one-time migration

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalOnboardingProgress.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalOnboardingProgress.swift
@@ -10,7 +10,7 @@ enum JournalOnboardingStorageKeys {
     /// Legacy upgrade cohort: Today clears this after one branch resolution. Listed for iCloud continuity.
     static let legacy051GuidedBranchResolution = "journalOnboarding.pending051GuidedJournalBranchResolution"
     static let hasSeenAppTour = "journalOnboarding.hasSeenAppTour"
-    /// Legacy key; value is copied once into ``hasSeenAppTour`` by ``migrateLegacyAppTourSeenFlagIfNeeded``.
+    /// Legacy key; value is copied once into ``hasSeenAppTour`` by ``migrateLegacyAppTourSeenFlagIfNeeded``, then removed.
     static let legacyHasSeenPostSeedJourney = "journalOnboarding.hasSeenPostSeedJourney"
     static let dismissedRemindersSuggestion = "journalOnboarding.dismissedRemindersSuggestion"
     static let dismissedICloudSuggestion = "journalOnboarding.dismissedICloudSuggestion"
@@ -97,7 +97,8 @@ final class JournalOnboardingProgress {
         defaults.removeObject(forKey: upgradeKey)
     }
 
-    /// Copies ``legacyHasSeenPostSeedJourney`` into ``hasSeenAppTour`` once so existing installs keep tour state.
+    /// Copies ``legacyHasSeenPostSeedJourney`` into ``hasSeenAppTour`` once so existing installs keep tour state,
+    /// then removes the legacy entry (same shape as ``JournalTutorialStorageKeys`` boolean migrations).
     static func migrateLegacyAppTourSeenFlagIfNeeded(using defaults: UserDefaults = .standard) {
         guard defaults.object(forKey: JournalOnboardingStorageKeys.hasSeenAppTour) == nil else { return }
         guard defaults.object(forKey: JournalOnboardingStorageKeys.legacyHasSeenPostSeedJourney) != nil else {
@@ -107,6 +108,7 @@ final class JournalOnboardingProgress {
             defaults.bool(forKey: JournalOnboardingStorageKeys.legacyHasSeenPostSeedJourney),
             forKey: JournalOnboardingStorageKeys.hasSeenAppTour
         )
+        defaults.removeObject(forKey: JournalOnboardingStorageKeys.legacyHasSeenPostSeedJourney)
     }
 
     /// After Today’s entry loads, finalize legacy upgrade cohort branch for `completedGuidedJournal`.


### PR DESCRIPTION
## Headline

Onboarding migration now drops the old tour-seen key so settings stay tidy and predictable.

## User impact

Upgrading users still keep whether they already saw the app tour, because the value is copied to the current key first. After that one-time step, the obsolete entry is gone, which reduces leftover cruft in preferences and matches how other boolean migrations behave.

## What changed

The app tour migration used to copy the legacy “post-seed journey seen” flag into the modern “has seen app tour” key but left the old key behind. That left duplicate state in UserDefaults and was inconsistent with other one-shot boolean migrations in this area.

The migration still runs only when the new key is unset and the legacy key exists: it copies the boolean, then removes the legacy entry. Comments were updated to describe that cleanup explicitly.

## Verification

On a Mac with Xcode and the project’s grace CLI, run `grace ci` (or `grace test` with the usual simulator destination) to confirm the project still builds and tests pass.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
