### PR TITLE
Make journal history order stable when entry dates match

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/HistoryEntryGrouping.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/HistoryEntryGrouping.swift
@@ -10,7 +10,10 @@ enum HistoryEntryGrouping {
         }
         return grouped.keys.sorted(by: >).map { month in
             let groupedEntries = (grouped[month] ?? []).sorted {
-                $0.entryDate > $1.entryDate
+                if $0.entryDate != $1.entryDate {
+                    return $0.entryDate > $1.entryDate
+                }
+                return $0.id.uuidString < $1.id.uuidString
             }
             return (month, groupedEntries)
         }


### PR DESCRIPTION
## Headline

Journal history no longer shuffles when multiple entries share the same date.

## User impact

Entries that landed on the exact same timestamp could appear in an inconsistent order, which made the history list feel jumpy or unreliable when the list refreshed. Ordering is now predictable, so the same month always reads the same way.

## What changed

The history screen groups journals by month and sorts each group by entry date, newest first. Sorting by date alone does not define an order when two entries have identical timestamps, so their relative position was effectively arbitrary. The sort now uses the journal’s stable identifier as a tie-breaker whenever two entry dates are equal, so the sequence is deterministic and consistent across renders.

## Verification

On a Mac with Xcode and the iOS Simulator toolchain configured for this repo, run `grace ci` (or `grace test` with your usual destination from `gracenotes-dev.toml`) and confirm the GraceNotes scheme builds and tests pass. Spot-check Journal history: create or use two entries with the same entry time in one month and confirm their order stays fixed when you leave and return to the screen.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
