### PR TITLE
Fix weekly review theme evidence when support text uses CJK script

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregatesBuilder+ThemeSections.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregatesBuilder+ThemeSections.swift
@@ -280,7 +280,8 @@ extension WeeklyReviewAggregatesBuilder {
         let normalizedSupport = textNormalizer.normalizeThemeLabel(supportText)
         let normalizedTheme = textNormalizer.normalizeThemeLabel(themeConcept)
         guard !normalizedSupport.isEmpty, !normalizedTheme.isEmpty else { return false }
-        if containsHanCharacters(themeConcept) {
+        // CJK: word boundaries and Latin token overlap do not apply; substring match either direction.
+        if containsHanCharacters(themeConcept) || containsHanCharacters(supportText) {
             return normalizedSupport.contains(normalizedTheme) || normalizedTheme.contains(normalizedSupport)
         }
         // Latin: naive `contains` matches inside other words (e.g. "rest" in "forest"); require word boundaries.


### PR DESCRIPTION
## Headline

Supporting notes and reflections now match recurring themes correctly when only the support text is in Chinese or other CJK script.

## User impact

Weekly review theme sections can pull in evidence from reading notes and reflections. Before this change, a Latin theme label paired with CJK-only (or CJK-heavy) support text could miss valid links because Latin word-boundary rules do not apply to those scripts. Users should see fuller, more accurate theme evidence in mixed-language journals.

## What changed

The helper that decides whether a support surface semantically matches a theme used Latin-style checks whenever the theme label looked Latin, even when the support passage was CJK. That mismatch could block substring-style matches that are appropriate when word boundaries and Latin token overlap are not meaningful. The logic now treats the pair as a CJK-style match when either the theme or the support text contains Han characters, and documents why. Latin text still uses word-boundary and token overlap behavior to avoid spurious substring hits inside other words.

## Verification

On a Mac with Xcode and the iOS Simulator, run `swiftlint lint` from the repo root, then `grace ci` (or `grace test` with the project’s default destination) to confirm the GraceNotes scheme builds and tests pass.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
