### PR TITLE
Align completion chip accessibility label with SwiftUI locale

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/JournalCompletionBarChip.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/JournalCompletionBarChip.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import UIKit
 
 /// Compact completion control for the navigation bar: **capsule** fill (tier colors).
 ///
@@ -194,7 +193,7 @@ struct JournalCompletionBarChip: View {
     private var accessibilityLabelText: String {
         let statusName = completionTitle
         let format = String(localized: "journal.share.sectionCountsSentence")
-        return String(format: format, locale: Locale.current, statusName, gratitudesCount, needsCount, peopleCount)
+        return String(format: format, locale: locale, statusName, gratitudesCount, needsCount, peopleCount)
     }
 
     private var labelColor: Color {


### PR DESCRIPTION
## Headline

VoiceOver now formats the sticky completion chip’s status sentence using the same locale as the journal UI.

## User impact

Screen Reader users hear section counts and wording that match the language and formatting rules of the on-screen journal, including when the UI is not using the device’s default locale. This avoids mismatches between what you see and what VoiceOver announces for the toolbar completion chip.

## What changed

The toolbar completion chip already reads locale from the SwiftUI environment for layout and measuring. The accessibility label for that chip was still building its formatted sentence with the process default locale, which could disagree with the environment in previews, tests, or any place the view hierarchy overrides locale.

Formatting now uses the same environment locale as the rest of the view. The unused UIKit import was removed because nothing in the file required it.

## Verification

On a Mac with Xcode and the project’s grace CLI installed, run `grace ci` from the repo root (or `grace test` with your usual simulator destination) to lint and build. Manually: change app or system language, open a journal day, expand the sticky completion chip label if needed, and use VoiceOver on the chip; confirm the spoken status sentence matches the visible language and number formatting.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
