### PR TITLE
Disable scrolling in the share composer while a share finishes

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/JournalShareComposerView.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/JournalShareComposerView.swift
@@ -44,6 +44,7 @@ struct JournalShareComposerView: View {
                 .padding(.vertical, 16)
                 .disabled(isShareCommitInProgress)
             }
+            .scrollDisabled(isShareCommitInProgress)
             .scrollContentBackground(.hidden)
             .background(AppTheme.settingsBackground.ignoresSafeArea())
             .navigationTitle(String(localized: "sharing.composer.title"))


### PR DESCRIPTION
## Headline

Prevents stray scroll gestures from changing the share card while the share sheet is committing.

## User impact

While a journal share is generating and handing off, the preview could still react to scroll in ways that feel inconsistent with the frozen UI (toolbar buttons and sheet dismiss are already locked). Disabling scroll matches that “please wait” state so people are less likely to adjust the card or fight the sheet at the wrong moment.

## What changed

The share composer is built from a scrollable preview plus controls. When a share is in progress we already gray out controls and block cancel, share, and swipe-to-dismiss. The scroll view did not explicitly opt out of scrolling in that state. This change ties the scroll view to the same in-progress flag so the list does not scroll while sharing is finishing. The rest of the composer behavior is unchanged.

## Verification

On a Mac with the Grace Notes dev toolchain, run `grace ci` (or `grace test`) from the repo root to lint and exercise the default simulator build. Manually open journal share, tap Share, and confirm the sheet does not scroll until the operation completes or errors.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
