### PR TITLE
Harden demo seeding: rollback failed saves and align day lookup

### DIFF
--- a/GraceNotes/GraceNotes/Data/Persistence/DemoDataSeeder.swift
+++ b/GraceNotes/GraceNotes/Data/Persistence/DemoDataSeeder.swift
@@ -31,6 +31,7 @@ enum DemoDataSeeder {
             UserDefaults.standard.set(seedVersion, forKey: seedVersionKey)
             PerformanceTrace.end("DemoDataSeeder.seedIfNeeded", startedAt: seedTrace)
         } catch {
+            context.rollback()
             PerformanceTrace.end("DemoDataSeeder.seedIfNeeded.failed", startedAt: seedTrace)
             assertionFailure("Failed to seed demo database: \(error)")
         }
@@ -264,18 +265,12 @@ enum DemoDataSeeder {
     }
 }
 
-/// Uses `[dayStart, nextDay)` like ``JournalRepository/fetchEntry(dayStart:context:)``.
+/// Delegates to ``JournalRepository/fetchEntry(dayStart:context:)`` so demo upserts target the same
+/// canonical journal Past and Today use when more than one row exists for a calendar day.
 private func fetchDemoJournalForDay(_ date: Date, context: ModelContext, calendar: Calendar) -> Journal? {
     let dayStart = calendar.startOfDay(for: date)
-    guard let nextDay = calendar.date(byAdding: .day, value: 1, to: dayStart) else { return nil }
-    let descriptor = FetchDescriptor<Journal>(
-        predicate: #Predicate { entry in
-            entry.entryDate >= dayStart && entry.entryDate < nextDay
-        },
-        sortBy: [SortDescriptor(\.createdAt, order: .forward)]
-    )
     do {
-        return try context.fetch(descriptor).first
+        return try JournalRepository(calendar: calendar).fetchEntry(dayStart: dayStart, context: context)
     } catch {
         assertionFailure("DemoDataSeeder: failed to fetch journal for demo seeding: \(error)")
         return nil


### PR DESCRIPTION
## Headline

Demo builds now update the same journal row the app considers canonical for a day, and failed saves leave no partial inserts behind.

## User impact

In the Demo scheme, seeding is less likely to leave the database half-written if saving fails, which avoids confusing or inconsistent sample data on the next launch. When duplicate journal rows exist for one calendar day, demo updates now match what Past and Today show instead of whichever row happened to sort first.

## What changed

When persisting demo seed data fails, the change rolls back the model context so unsaved inserts and edits are not left lingering in memory. The helper that finds an existing journal for a calendar day no longer uses a one-off fetch; it calls the same repository API the product uses to resolve a day’s journal, so upserts follow the app’s canonical choice if multiple rows share a day. Documentation comments were updated to describe that shared behavior.

## Verification

On a Mac with Xcode, build and run the GraceNotes (Demo) scheme, relaunch to confirm demo data seeds as expected, and run `grace ci` (or `grace test` with the project’s default simulator destination) to match CI.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
