### PR TITLE
Reset completion info card state without animating the hidden step

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/CompletionInfoCard.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/CompletionInfoCard.swift
@@ -83,7 +83,11 @@ struct CompletionInfoCard: View {
         }
         didPlayEntryAnimation = true
 
-        contentVisible = false
+        var transaction = Transaction()
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
+            contentVisible = false
+        }
 
         withAnimation(.easeOut(duration: 0.24)) {
             contentVisible = true


### PR DESCRIPTION
## Headline

The journal completion card’s intro animation stays crisp and predictable instead of fighting inherited motion.

## User impact

When the completion info card plays its first-time reveal, the transition should feel like one smooth motion into place. Previously, resetting visibility could pick up implicit animation and make the intro feel wrong or janky. The card still animates in on purpose; only the reset to the hidden state is immediate.

## What changed

The entry animation for the completion info card sets visibility to hidden immediately before running the explicit ease-out animation back to visible. That reset is now wrapped in a SwiftUI transaction that turns animations off for that step alone, so nothing else accidentally animates the hide. The following reveal still uses the same timed animation as before.

## Verification

On a Mac with the repo’s dev setup, run `grace ci` (or `grace test` with your usual simulator destination) to confirm lint and the GraceNotes scheme still build and tests pass. In the simulator, open a flow that shows the completion info card with motion enabled and confirm the card’s text fades and moves in once without a stray or doubled transition.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
