### PR TITLE
Harden journal keyboard geometry and first-responder caret handling

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/JournalKeyboardScrollSupport.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/JournalKeyboardScrollSupport.swift
@@ -78,7 +78,7 @@ enum JournalKeyboardScrollMetrics {
 /// Keyboard overlap with the key window; sizes extra scroll affordance without guessing global safe-area behavior.
 enum JournalKeyboardOverlapReader {
     static func overlapHeight(from notification: Notification) -> CGFloat {
-        guard let frame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect else {
+        guard let frame = keyboardFrameEnd(from: notification) else {
             return 0
         }
         guard let window = JournalKeyWindowReader.keyWindow() else {
@@ -86,6 +86,20 @@ enum JournalKeyboardOverlapReader {
         }
         let keyboardInWindow = window.convert(frame, from: nil)
         return max(0, window.bounds.intersection(keyboardInWindow).height)
+    }
+
+    /// `keyboardFrameEndUserInfoKey` is documented as an `NSValue` wrapping `CGRect`; a bare `as? CGRect` often fails.
+    private static func keyboardFrameEnd(from notification: Notification) -> CGRect? {
+        guard let raw = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] else {
+            return nil
+        }
+        if let rect = raw as? CGRect {
+            return rect
+        }
+        if let value = raw as? NSValue {
+            return value.cgRectValue
+        }
+        return nil
     }
 }
 
@@ -114,7 +128,8 @@ enum JournalCaretVisibilityReader {
     /// Outer `scrollTo(anchor: .bottom)` aligns the **frame**; this aligns the **insertion point** inside the editor.
     static func nudgeFirstResponderUITextViewCaretIntoVisibleContent() {
         guard let window = JournalKeyWindowReader.keyWindow(),
-              let textView = findFirstResponder(in: window) as? UITextView,
+              let responder = findFirstResponder(in: window),
+              let textView = nearestTextView(from: responder),
               let range = textView.selectedTextRange else { return }
         var rect = textView.caretRect(for: range.end)
         if rect.height < 1 {
@@ -133,10 +148,10 @@ enum JournalCaretVisibilityReader {
         guard let window = JournalKeyWindowReader.keyWindow(),
               let responder = findFirstResponder(in: window) else { return nil }
         let caretInWindow: CGRect?
-        if let textView = responder as? UITextView, let range = textView.selectedTextRange {
+        if let textView = nearestTextView(from: responder), let range = textView.selectedTextRange {
             let local = textView.caretRect(for: range.end)
             caretInWindow = textView.convert(local, to: nil)
-        } else if let textField = responder as? UITextField, let range = textField.selectedTextRange {
+        } else if let textField = nearestTextField(from: responder), let range = textField.selectedTextRange {
             let local = textField.caretRect(for: range.end)
             caretInWindow = textField.convert(local, to: nil)
         } else {
@@ -149,6 +164,30 @@ enum JournalCaretVisibilityReader {
               caretInWindow.height.isFinite else { return nil }
         if caretInWindow == .zero { return nil }
         return caretInWindow.maxY
+    }
+
+    /// First responder is sometimes an internal subview; walk up to the `UITextView` that owns the caret APIs.
+    private static func nearestTextView(from view: UIView) -> UITextView? {
+        var current: UIView? = view
+        while let node = current {
+            if let textView = node as? UITextView {
+                return textView
+            }
+            current = node.superview
+        }
+        return nil
+    }
+
+    /// Same as `nearestTextView` but for single-line fields (`UITextField` and common subclasses).
+    private static func nearestTextField(from view: UIView) -> UITextField? {
+        var current: UIView? = view
+        while let node = current {
+            if let textField = node as? UITextField {
+                return textField
+            }
+            current = node.superview
+        }
+        return nil
     }
 
     private static func findFirstResponder(in view: UIView) -> UIView? {


### PR DESCRIPTION
## Headline

More reliable keyboard overlap and caret tracking while journaling so the editor scrolls correctly.

## User impact

The Today journal screen should keep the cursor and content aligned with the keyboard more consistently, including when the system reports keyboard frames in the documented NSValue form. When focus lands on an internal text subview, caret-based logic can still find the real text field, so you get fewer unnecessary full-section scrolls or missed caret nudges while typing.

## What changed

Keyboard overlap height now reads the end keyboard frame from notifications in a way that matches UIKit’s documented userInfo shape, instead of relying on a direct CGRect cast that often fails. Caret visibility and inner text view scrolling now resolve the owning UITextView or UITextField by walking up from whichever view is actually first responder, which covers cases where UIKit reports an internal subview as first responder. Together these changes make keyboard-related inset and scroll decisions reflect real geometry and caret position more often.

## Verification

On a Mac with Xcode and the iOS Simulator, run `grace ci` (or `grace test` with the project’s default destination) and manually smoke-test the Today journal: show and dismiss the keyboard, type in multiline notes and single-line fields, and confirm the caret stays visible without jarring extra scrolling.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
