### PR TITLE
Scale inline journal editing layout for Dynamic Type

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/SequentialSectionInlineLayout.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/SequentialSectionInlineLayout.swift
@@ -1,12 +1,26 @@
-import Foundation
+import UIKit
 
 /// Shared metrics for inline sentence editing (entry-row editor and add morph composer).
 enum SequentialSectionInlineLayout {
-    static let editorMorphHorizontalInset: CGFloat = 6
-    static let editorMorphVerticalOffset: CGFloat = 8
-    static let editorBottomSpacing: CGFloat = 10
+    private static let bodyMetrics = UIFontMetrics(forTextStyle: .body)
+
+    static var editorMorphHorizontalInset: CGFloat {
+        bodyMetrics.scaledValue(for: 6)
+    }
+
+    static var editorMorphVerticalOffset: CGFloat {
+        bodyMetrics.scaledValue(for: 8)
+    }
+
+    static var editorBottomSpacing: CGFloat {
+        bodyMetrics.scaledValue(for: 10)
+    }
+
     /// Opacity for non-focused rows and guidance while inline editing is active elsewhere in the journal.
     static let ambientUnfocusedOpacity: CGFloat = 0.45
+
     /// Minimum height for bottom tap catcher when journal content is short (dismiss inline edit from empty space).
-    static let inlineEditBottomTapCatcherMinHeight: CGFloat = 280
+    static var inlineEditBottomTapCatcherMinHeight: CGFloat {
+        bodyMetrics.scaledValue(for: 280)
+    }
 }


### PR DESCRIPTION
## Headline

Inline sentence editing spacing now grows with the user’s text size instead of staying fixed.

## User impact

People who use larger or smaller text in Settings get editor insets, vertical offsets, bottom spacing, and the dismiss tap area scaled so the layout stays proportionate and easier to use. Ambient dimming of unfocused rows is unchanged.

## What changed

The shared `SequentialSectionInlineLayout` values that control the morphing editor’s horizontal inset, vertical offset, bottom spacing, and minimum height for the bottom tap catcher were switched from fixed constants to values scaled with `UIFontMetrics` for the body text style (replacing the prior `Foundation` import with `UIKit`).

Opacity for non-focused content during inline editing stays a fixed value and was not altered.

## Verification

On a Mac with Xcode and the project’s `grace` CLI installed, run `grace ci` (or `grace test` with the usual simulator destination from `gracenom-dev.toml`) to confirm the app builds and automated checks pass. On device or Simulator, open journal inline editing with different Dynamic Type sizes in Display & Text Size and confirm spacing and dismiss behavior still feel right.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
