### PR TITLE
Harden weekly review narrative summary against empty observations

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyInsightCandidateBuilder.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyInsightCandidateBuilder.swift
@@ -101,7 +101,7 @@ struct WeeklyInsightCandidateBuilder {
             let first = insights[0].observation
             let second = insights[1].observation
             if !observationsAreEffectivelyDuplicate(first, second) {
-                return second
+                return nonEmptyTrimmed(second) ?? nonEmptyTrimmed(first)
             }
             let themeA = insights[0].primaryTheme
             let themeB = insights[1].primaryTheme
@@ -111,13 +111,14 @@ struct WeeklyInsightCandidateBuilder {
                    textNormalizer.normalizeThemeLabel(firstTheme),
                    against: [textNormalizer.normalizeThemeLabel(secondTheme)]
                ) {
-                return String(
+                let combined = String(
                     format: String(localized: "review.insights.bothThemesMultiple"),
                     firstTheme,
                     secondTheme
                 )
+                return nonEmptyTrimmed(combined)
             }
-            return second
+            return nonEmptyTrimmed(second) ?? nonEmptyTrimmed(first)
         }
         if let theme = insights[0].primaryTheme, !theme.isEmpty {
             return String(
@@ -129,8 +130,7 @@ struct WeeklyInsightCandidateBuilder {
         if first.pattern == .sparseFallback, first.dayCount == 0 {
             return nil
         }
-        let observation = first.observation.trimmingCharacters(in: .whitespacesAndNewlines)
-        return observation.isEmpty ? nil : observation
+        return nonEmptyTrimmed(first.observation)
     }
 
     private func observationsAreEffectivelyDuplicate(_ lhs: String, _ rhs: String) -> Bool {
@@ -142,6 +142,11 @@ struct WeeklyInsightCandidateBuilder {
             .folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current)
             .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
             .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func nonEmptyTrimmed(_ text: String) -> String? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 }
 


### PR DESCRIPTION
## Headline

Weekly recap copy now falls back when an insight observation is only whitespace.

## User impact

The weekly review narrative is less likely to show a blank or meaningless line when a second insight is empty or localization yields only spaces. When two distinct themes are summarized together, the combined line is only shown if it has real text after trimming.

## What changed

The builder used to return raw second-insight text in several two-insight paths, so whitespace-only or empty strings could still become the visible summary. A small helper now trims whitespace and treats an empty result as missing, so the summary prefers the other insight or skips empty combined strings instead of surfacing junk. The single-insight path uses the same trimming rule for consistency.

## Verification

On a Mac with Xcode, run `grace ci` (or `grace test`) from the repo root to lint and exercise the GraceNotes scheme in the simulator.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
