### PR TITLE
Fix review history calendar last day when the window ends mid-day

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewHistoryDrilldownCalendar.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewHistoryDrilldownCalendar.swift
@@ -113,8 +113,10 @@ enum ReviewHistoryDrilldownCalendarLayout {
 
     private static func normalizedRangeLastInclusive(displayRange: Range<Date>, calendar: Calendar) -> Date? {
         let upperEx = displayRange.upperBound
-        guard let dayBeforeUpper = calendar.date(byAdding: .day, value: -1, to: upperEx) else { return nil }
-        return calendar.startOfDay(for: dayBeforeUpper)
+        guard upperEx > displayRange.lowerBound else { return nil }
+        // Exclusive upper may fall mid-day; subtracting one *calendar* day only matches midnight uppers.
+        guard let lastInstant = calendar.date(byAdding: .second, value: -1, to: upperEx) else { return nil }
+        return calendar.startOfDay(for: lastInstant)
     }
 
     private static func paddedDayCells(lower: Date, lastInclusive: Date, calendar: Calendar) -> [Date?] {


### PR DESCRIPTION
## Headline

The drill-down calendar now ends on the right calendar day when the statistics window does not end at midnight.

## User impact

The continuous review history calendar could show the wrong final day (or omit or include a day incorrectly) when the history range’s exclusive end was not aligned to the start of a day. That made the grid and accessibility labels disagree with the actual history window for some real-world range calculations.

## What changed

The helper that turns a half-open display range into the last calendar day to render used to subtract one whole calendar day from the exclusive upper bound and then normalize to the start of that day. When the exclusive upper falls in the middle of a day, that day-based step can land on the wrong date compared with the instants the range actually covers.

The implementation now treats the exclusive upper as an instant: it steps back one second, then takes the start of that instant’s calendar day, which matches the last day included before the bound. An extra guard returns nil for empty or degenerate ranges so downstream layout does not build rows from invalid input.

## Verification

On a Mac with Xcode and the project’s grace CLI installed, run `grace ci` (or at least `grace test` with the default simulator destination from `gracenotes-dev.toml`). In the app, open the review history drill-down calendar for a history window whose end time is not midnight and confirm the last week row includes the expected final day and month banners stay coherent.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
