### PR TITLE
Align theme language gate with analysis prefix and bound work

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/ReviewJournalThemeLanguageResolver.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ReviewJournalThemeLanguageResolver.swift
@@ -53,18 +53,26 @@ struct ReviewJournalThemeLanguageResolver: ReviewJournalThemeLanguageResolving {
     /// Upper bound on text fed to `NLLanguageRecognizer` and script tie-break (prefix by extended grapheme cluster).
     private static let maximumAnalysisGraphemes = 50_000
 
+    /// Counts non-whitespace graphemes only in the same prefix we analyze, so the threshold matches
+    /// `normalizedAnalysisSample` and pathological corpora cannot spend unbounded time here.
     private static func hasEnoughMeaningfulGraphemes(_ text: String, minimum: Int) -> Bool {
+        if minimum <= 0 {
+            return true
+        }
+
+        let prefix = text.prefix(maximumAnalysisGraphemes)
         var count = 0
-        for character in text where !character.isWhitespace {
+        for character in prefix where !character.isWhitespace {
             count += 1
             if count >= minimum {
                 return true
             }
         }
-        return count >= minimum
+        return false
     }
 
-    /// Collapses whitespace runs only inside the analysis prefix so pathological corpora never run a full-string regex replace.
+    /// Collapses whitespace runs only inside the analysis prefix so pathological corpora never run a full-string
+    /// regex replace.
     private static func normalizedAnalysisSample(from trimmed: String) -> String {
         let head = String(trimmed.prefix(maximumAnalysisGraphemes))
         return collapseWhitespaceRuns(head)


### PR DESCRIPTION
## Headline

Past tab theme chip language detection now measures text the same way the analyzer does, without scanning huge journals.

## User impact

Very long journals no longer trigger expensive full-corpus counting just to decide if there is enough text to pick English or Chinese theme labels. The “enough meaningful text” rule now matches the portion of the journal that language detection actually uses, so chip language stays consistent with the model and avoids misleading picks from ignored tail content.

## What changed

The helper that checks whether the journal has enough non-whitespace text before running language detection was updated to count only within the same grapheme-limited prefix used for analysis. That caps work on pathological or enormous corpora and keeps the minimum-length gate aligned with the sample passed to the language recognizer. A zero or negative minimum is treated as “always enough,” avoiding pointless iteration when the threshold is disabled.

## Verification

On a Mac with Xcode and the project’s grace CLI installed, run `grace ci` (or `grace test` with the repo’s default simulator destination) to confirm the GraceNotes scheme still builds and tests pass.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
