### PR TITLE
Disable empty section-distribution segments and align VoiceOver

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewHistoryInsightsPanels.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewHistoryInsightsPanels.swift
@@ -410,6 +410,7 @@ private struct ReviewHistorySectionStrip: View {
                             .frame(width: segmentWidths[index], height: stripHeight)
                         }
                         .buttonStyle(PastTappablePressStyle())
+                        .disabled(item.count == 0)
                         .accessibilityLabel(
                             sectionMixAccessibilityLabel(
                                 kind: item.kind,
@@ -418,6 +419,7 @@ private struct ReviewHistorySectionStrip: View {
                             )
                         )
                         .accessibilityHint(segmentAccessibilityHint(forCount: item.count))
+                        .accessibilityAddTraits(item.count == 0 ? [] : .isButton)
                     }
                 }
                 .frame(width: width, height: stripHeight)
@@ -454,6 +456,7 @@ private struct ReviewHistorySectionStrip: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                     }
                     .buttonStyle(PastTappablePressStyle())
+                    .disabled(item.count == 0)
                     .accessibilityLabel(
                         sectionMixAccessibilityLabel(
                             kind: item.kind,
@@ -462,6 +465,7 @@ private struct ReviewHistorySectionStrip: View {
                         )
                     )
                     .accessibilityHint(segmentAccessibilityHint(forCount: item.count))
+                    .accessibilityAddTraits(item.count == 0 ? [] : .isButton)
                 }
             }
         }


### PR DESCRIPTION
## Headline

Empty section segments no longer behave like buttons or are announced as buttons in Review history.

## User impact

In Review history insights, section distribution segments with zero lines could still feel tappable and VoiceOver could announce them as buttons, which was misleading and could open a drilldown with nothing to show. Those segments are now inactive when the count is zero, and accessibility traits match the empty-state hints.

## What changed

The history section distribution strip uses buttons for Gratitudes, Needs, and People so people can drill into each kind of content. Segments with a line count of zero were still enabled as buttons, which was inconsistent with the growth stages skyline (which already disables zero-count columns) and weakened trust for VoiceOver users. The change disables interaction when a segment’s count is zero and drops the button trait in that case so assistive technology does not present the segment as an actionable control. The same behavior is applied in both strip layout variants that render those segments.

## Verification

On a Mac with Xcode and the iOS Simulator, run `grace ci` from the repo root (or `grace test` with the default destination in `gracenotes-dev.toml`). Manually open Review → History insights with data where one section count is zero; confirm the empty segment does not respond to taps and, with VoiceOver, that it is not announced as a button while the empty hint still reads sensibly.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
