### PR TITLE
Hop StartupCoordinator work to MainActor from async startup tasks

### DIFF
--- a/GraceNotes/GraceNotes/Application/StartupCoordinator.swift
+++ b/GraceNotes/GraceNotes/Application/StartupCoordinator.swift
@@ -82,52 +82,68 @@ final class StartupCoordinator: ObservableObject {
 
         currentAttemptID += 1
         let attemptID = currentAttemptID
+        let runPersistence = persistenceFactory
+        let copyRotationInterval = timing.copyRotationInterval
+        let reassuranceDelay = timing.reassuranceDelay
         isStartingUp = true
         loadingCopyIndex = 0
         reassuranceCopyIndex = 0
         phase = .loading
         startupMessage = loadingMessage(for: loadingCopyIndex)
-        startCopyRotation(for: attemptID)
-        scheduleReassuranceTransition(for: attemptID)
+        startCopyRotation(for: attemptID, interval: copyRotationInterval)
+        scheduleReassuranceTransition(for: attemptID, delay: reassuranceDelay)
 
         startupTask?.cancel()
-        startupTask = Task { [weak self] in
-            guard let self else { return }
+        startupTask = Task {
             let trace = PerformanceTrace.begin("StartupCoordinator.startupAttempt")
             do {
-                let controller = try await persistenceFactory()
-                await handleStartupSuccess(controller, attemptID: attemptID, traceStart: trace)
+                let controller = try await runPersistence()
+                await MainActor.run { [weak self] in
+                    guard let self else {
+                        PerformanceTrace.end("StartupCoordinator.startupAttempt.superseded", startedAt: trace)
+                        return
+                    }
+                    self.handleStartupSuccess(controller, attemptID: attemptID, traceStart: trace)
+                }
             } catch {
-                await handleStartupFailure(error, attemptID: attemptID, traceStart: trace)
+                await MainActor.run { [weak self] in
+                    guard let self else {
+                        PerformanceTrace.end("StartupCoordinator.startupAttempt.superseded", startedAt: trace)
+                        return
+                    }
+                    self.handleStartupFailure(error, attemptID: attemptID, traceStart: trace)
+                }
             }
         }
     }
 
-    private func startCopyRotation(for attemptID: UInt64) {
+    private func startCopyRotation(for attemptID: UInt64, interval: Duration) {
         copyRotationTask?.cancel()
-        copyRotationTask = Task { [weak self] in
-            guard let self else { return }
+        copyRotationTask = Task {
             while !Task.isCancelled {
                 do {
-                    try await Task.sleep(for: timing.copyRotationInterval)
+                    try await Task.sleep(for: interval)
                 } catch {
                     break
                 }
-                await advanceCopyIfNeeded(for: attemptID)
+                await MainActor.run { [weak self] in
+                    self?.advanceCopyIfNeeded(for: attemptID)
+                }
             }
         }
     }
 
-    private func scheduleReassuranceTransition(for attemptID: UInt64) {
+    private func scheduleReassuranceTransition(for attemptID: UInt64, delay: Duration) {
         reassuranceTask?.cancel()
-        reassuranceTask = Task { [weak self] in
-            guard let self else { return }
+        reassuranceTask = Task {
             do {
-                try await Task.sleep(for: timing.reassuranceDelay)
+                try await Task.sleep(for: delay)
             } catch {
                 return
             }
-            await enterReassuranceIfNeeded(for: attemptID)
+            await MainActor.run { [weak self] in
+                self?.enterReassuranceIfNeeded(for: attemptID)
+            }
         }
     }
 


### PR DESCRIPTION
## Headline

Startup loading and reassurance updates now apply on the main thread after background work, with clearer handling when an attempt is cancelled.

## User impact

Startup should feel the same, but the app is less likely to hit subtle threading or Swift concurrency issues while persistence loads and the loading messages rotate. If you retry or the coordinator is torn down mid-startup, traces and state should line up more reliably instead of racing the UI.

## What changed

Background `Task` closures no longer capture `self` up front for the whole startup, copy rotation, and reassurance timers. Instead, the persistence factory and timing intervals are captured as plain values, async work runs off the actor, and success, failure, copy advances, and reassurance transitions are dispatched with `MainActor.run` so `@MainActor` state and `@Published` updates stay on the main actor. When the coordinator is gone before that hop (for example, a superseded attempt), performance traces are ended with a superseded event instead of dropping the trace.

## Verification

On a Mac with Xcode, run `grace ci` (or `grace test` with the project’s default simulator destination) to lint, build, and exercise tests; smoke the app launch and a retry after a simulated startup failure if you want extra confidence.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
