### PR TITLE
Trim whitespace when decoding journal completion level from legacy strings

### DIFF
--- a/GraceNotes/GraceNotes/Data/Models/Journal.swift
+++ b/GraceNotes/GraceNotes/Data/Models/Journal.swift
@@ -25,7 +25,8 @@ extension JournalCompletionLevel: Codable {
 
     /// Maps persisted raw strings from older app versions and unknown values.
     init(decodingLegacyRawValue raw: String) {
-        switch raw.lowercased() {
+        let normalized = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        switch normalized {
         case "soil", "empty":
             self = .soil
         case "sprout", "started", "seed":


### PR DESCRIPTION
## Headline

Journal growth-stage labels from older data now decode reliably instead of falling back to Soil.

## User impact

If a saved completion label had leading or trailing spaces or line breaks, the app could misread it and treat the day as Soil (empty) even when it was not. That could skew history, streaks, or any UI that depends on the stored level. After this change, those values normalize the same way users expect when reading text.

## What changed

The legacy string decoder for journal completion level now trims whitespace and newlines before matching synonyms and lowercasing. That makes persisted labels from older app versions or odd inputs align with the known Soil → Bloom names instead of silently defaulting to Soil. No other journal model behavior was changed.

## Verification

On a Mac with Xcode, run `grace ci` (or `grace test`) from the repo root to lint and build against the project’s simulator destinations.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
