### PR TITLE
Fix spurious weekly review theme matches in mixed-language entries

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregatesBuilder+ThemeSections.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregatesBuilder+ThemeSections.swift
@@ -280,11 +280,20 @@ extension WeeklyReviewAggregatesBuilder {
         let normalizedSupport = textNormalizer.normalizeThemeLabel(supportText)
         let normalizedTheme = textNormalizer.normalizeThemeLabel(themeConcept)
         guard !normalizedSupport.isEmpty, !normalizedTheme.isEmpty else { return false }
-        // CJK: word boundaries and Latin token overlap do not apply; substring match either direction.
-        if containsHanCharacters(themeConcept) || containsHanCharacters(supportText) {
+        // Substring matching is for CJK themes where `\b` and token overlap do not apply. If the theme is
+        // Latin-only, substring matching whenever the support text also contains CJK would reintroduce
+        // Latin-in-word hits (e.g. "rest" inside "forest") in mixed-language passages.
+        if containsHanCharacters(themeConcept) {
             return normalizedSupport.contains(normalizedTheme) || normalizedTheme.contains(normalizedSupport)
         }
-        // Latin: naive `contains` matches inside other words (e.g. "rest" in "forest"); require word boundaries.
+        return latinNormalizedThemeMatchesSupport(
+            normalizedTheme: normalizedTheme,
+            normalizedSupport: normalizedSupport
+        )
+    }
+
+    /// Latin-safe matching after normalization: word boundaries, then multi-character token overlap.
+    private func latinNormalizedThemeMatchesSupport(normalizedTheme: String, normalizedSupport: String) -> Bool {
         if latinPhraseHasWordBoundaryMatch(haystack: normalizedSupport, needle: normalizedTheme)
             || latinPhraseHasWordBoundaryMatch(haystack: normalizedTheme, needle: normalizedSupport) {
             return true


### PR DESCRIPTION
## Headline

Weekly review theme evidence no longer treats Latin words as matching inside other words when notes also include Chinese or Japanese characters.

## User impact

Users with bilingual journaling may have seen unrelated reading notes or reflections attached to a theme because a short English theme could match as a substring (for example, “rest” inside “forest”). That weakens trust in recurring themes and trend evidence. The review should now only use loose substring matching when the theme itself needs CJK-style handling, while English themes stay on stricter word-based checks.

## What changed

Supporting evidence matching previously took a “substring either direction” shortcut whenever the support text contained CJK characters, even if the distilled theme label was Latin-only. That path skipped the Latin safeguards that avoid in-word hits. The logic now reserves substring matching for themes that actually contain Han characters, and routes Latin-only themes through the existing Latin-safe path (word-boundary checks, then multi-word token overlap) regardless of whether the passage mixes scripts. The Latin matching body was extracted into a small helper to keep the behavior obvious and reusable.

## Verification

On a Mac with the repo’s toolchain, run `grace ci` (or `grace test` with the project’s default simulator destination) to lint and build; spot-check a weekly review where reflections or reading notes mix English with Chinese or Japanese and confirm Latin themes do not pick up incidental substrings.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
