### PR TITLE
Fix Past search match IDs for whole-field journal text

### DIFF
--- a/GraceNotes/GraceNotes/Data/JournalSearchMatch.swift
+++ b/GraceNotes/GraceNotes/Data/JournalSearchMatch.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 
 /// One searchable line or note row tied to a journal day, for Past search results.
@@ -15,9 +16,20 @@ struct JournalSearchMatch: Identifiable, Equatable, Sendable {
     }
 
     init(entryDate: Date, journalEntryId: UUID, source: ReviewThemeSourceCategory, content: String) {
-        self.id = "\(journalEntryId.uuidString)|\(source.rawValue)"
+        self.id = Self.fieldMatchId(journalEntryId: journalEntryId, source: source, content: content)
         self.entryDate = entryDate
         self.source = source
         self.content = content
+    }
+
+    /// Stable identity for whole-field matches (reading notes, reflections) without storing full text in `id`.
+    private static func fieldMatchId(
+        journalEntryId: UUID,
+        source: ReviewThemeSourceCategory,
+        content: String
+    ) -> String {
+        let digest = SHA256.hash(data: Data(content.utf8))
+        let fingerprint = digest.prefix(8).map { String(format: "%02x", $0) }.joined()
+        return "\(journalEntryId.uuidString)|\(source.rawValue)|\(fingerprint)"
     }
 }


### PR DESCRIPTION
## Headline

Past search results now stay correctly identified when reading notes or reflections change.

## User impact

Whole-field matches (for example reading notes and reflections) used to share one identity per day and section, so SwiftUI could treat different text as the same row and reuse or update the wrong result. Identities now reflect the actual text, so lists and updates behave predictably after edits.

## What changed

Search match rows for whole-field results no longer use only the journal entry and section to form their identifier. The app now appends a short fingerprint derived from the field’s text so two different strings under the same entry and section are distinct. Line-based matches that already tie to a specific `Entry` item are unchanged. CryptoKit is used only to compute that compact hash; the full note text is not embedded in the id string.

## Verification

On a Mac with Xcode, run `grace ci` (or `grace test`) per the repo’s default simulator destinations. Manually, open Past search, edit a reading note or reflection, search again, and confirm results list and selection behave correctly without stale or duplicated rows.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
