### PR TITLE
Fix prior-week range for review insights across DST boundaries

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/ReviewInsightsPeriod.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ReviewInsightsPeriod.swift
@@ -24,8 +24,12 @@ enum ReviewInsightsPeriod {
     /// The calendar week immediately before `current` (the seven local days whose end abuts
     /// `current.lowerBound`).
     static func previousPeriod(before current: Range<Date>, calendar: Calendar) -> Range<Date> {
-        let previousStart = calendar.date(byAdding: .day, value: -7, to: current.lowerBound)
-            ?? current.lowerBound.addingTimeInterval(-604_800)
+        // Anchor on the last instant before the current week so `startOfDay` + day offsets match
+        // local week boundaries (including across DST). A fixed −604_800s stride is not seven
+        // local days when offset changes break the SI-second count between week starts.
+        let lastInstantBeforeCurrent = current.lowerBound.addingTimeInterval(-1)
+        let lastDayStart = calendar.startOfDay(for: lastInstantBeforeCurrent)
+        let previousStart = calendar.date(byAdding: .day, value: -6, to: lastDayStart) ?? lastDayStart
         return previousStart..<current.lowerBound
     }
 


### PR DESCRIPTION
## Headline

Review insights now pick the true previous calendar week when daylight saving time shifts week length.

## User impact

The “previous week” comparison for review insights could be off by a day around DST changes because subtracting a fixed week in seconds does not always equal seven local days. Users comparing this week to last week get a consistent seven-day window aligned to local midnight and the calendar.

## What changed

The helper that computes the period immediately before the current review week no longer relies on subtracting seven days from the week start or on a fixed 604,800-second offset. It anchors on the instant just before the current week begins, takes that day’s start-of-day, then steps back six calendar days so the range is exactly seven local days ending where the current week starts. A short comment explains why fixed-second math is unsafe across offset changes.

## Verification

On a Mac with Xcode and the project’s grace CLI installed, run `grace ci` from the repo root (or `grace test` with the default simulator destination from gracenotes-dev.toml). Optionally spot-check review insights around a DST transition week in the simulator to confirm “previous week” matches expectations.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
