### PR TITLE
Drive completion badge info card tint from JournalCompletionLevel

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/CompletionBadgeInfo.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/CompletionBadgeInfo.swift
@@ -68,14 +68,14 @@ enum CompletionBadgeInfo: Equatable, Sendable {
     }
 
     func infoCardTintColor(using palette: TodayJournalPalette) -> Color {
-        switch self {
-        case .empty:
+        switch completionLevel {
+        case .soil:
             return palette.textMuted
-        case .started:
+        case .sprout:
             return palette.quickCheckInText
-        case .growing, .balanced:
+        case .twig, .leaf:
             return palette.standardText
-        case .full:
+        case .bloom:
             return palette.fullText
         }
     }


### PR DESCRIPTION
## Headline

Completion guidance card colors now follow the same completion-level mapping as the rest of the journal UI.

## User impact

Tint colors for the completion info card stay consistent with how progress is represented elsewhere. This reduces the chance of subtle mismatches if growth-stage mapping ever changes.

## What changed

The info card tint helper no longer switches on the badge enum cases directly. It switches on the existing `completionLevel` value (`JournalCompletionLevel`) and maps soil, sprout, twig/leaf, and bloom to the same palette colors as before. That removes duplicated branching and ties tint logic to the single canonical level used across the feature.

## Verification

On a Mac with Xcode, run `grace ci` (or `grace test` with the project’s default simulator destination). In the app, open the journal completion badge info and confirm tint colors match expectations for each growth stage.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
