### PR TITLE
Harden journal share image rendering scale and layout width

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/JournalShareRenderer.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/JournalShareRenderer.swift
@@ -21,16 +21,22 @@ enum JournalShareRenderer {
     }
 
     /// Keep in sync with `JournalShareCardView` (`cardWidth` + twice `padding`).
-    private static let proposedLayoutWidth: CGFloat = 448 + 24 * 2
+    private static let cardContentWidth: CGFloat = 448
+    private static let cardHorizontalPadding: CGFloat = 24
+    private static var proposedLayoutWidth: CGFloat {
+        cardContentWidth + cardHorizontalPadding * 2
+    }
 
     /// `ImageRenderer` runs without hosting in a window; `UITraitCollection.current.displayScale` can be
-    /// unset or 1× while the device screen is Retina. Prefer an active window scene scale, then trait, then
-    /// screen, then a safe default.
+    /// unset or 1× while the device screen is Retina. Prefer the foreground active window scene scale, then
+    /// trait, then screen, then a safe default. Ignores background scenes so multi-window layouts do not
+    /// pick an unrelated display’s scale.
     @MainActor
     private static func recommendedPixelScale() -> CGFloat {
         let traitScale = UITraitCollection.current.displayScale
         let sceneScale = UIApplication.shared.connectedScenes
             .compactMap { $0 as? UIWindowScene }
+            .filter { $0.activationState == .foregroundActive }
             .map { $0.screen.scale }
             .max() ?? 0
         let screenScale = UIScreen.main.scale
@@ -39,6 +45,7 @@ enum JournalShareRenderer {
             sceneScale > 0 ? sceneScale : 0,
             screenScale > 0 ? screenScale : 0
         )
-        return best > 0 ? best : 3
+        guard best > 0 else { return 3 }
+        return min(max(best, 1), 3)
     }
 }


### PR DESCRIPTION
## Headline

Sharper, more reliable share images by picking the right display scale and capping odd values.

## User impact

Shared journal images should look crisp on Retina displays and stay consistent with the on-screen card width. On iPad or multi-window setups, the export is less likely to pick a background window’s scale and end up soft or oddly sized.

## What changed

The share card export width is expressed as explicit content width and horizontal padding that mirror `JournalShareCardView`, so future layout tweaks are easier to keep aligned. When choosing the bitmap scale for `ImageRenderer`, the code now looks only at foreground active window scenes so a secondary or background scene on another display does not drive the scale. The chosen scale is clamped to a sensible 1×–3× range, with the previous fallback when nothing valid is available.

## Verification

On a Mac with Xcode and the project’s `grace` CLI, run `grace ci` (or `grace test` with the usual simulator destination) and manually share a journal entry on iPhone and iPad, including Stage Manager or split view if available, and confirm the shared image looks sharp and matches the card layout.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
