### PR TITLE
Harden journal tutorial UserDefaults migration for plist/sync booleans

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalTutorialProgress.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalTutorialProgress.swift
@@ -36,10 +36,27 @@ enum JournalTutorialStorageKeys {
         }
     }
 
+    /// Interprets stored booleans whether `UserDefaults` returns `Bool` or `NSNumber` (plist / sync).
+    private static func optionalBool(forKey key: String, in defaults: UserDefaults) -> Bool? {
+        guard let object = defaults.object(forKey: key) else { return nil }
+        switch object {
+        case let value as Bool:
+            return value
+        case let number as NSNumber:
+            return number.boolValue
+        default:
+            return nil
+        }
+    }
+
     private static func migrateBool(from legacyKey: String, to key: String, defaults: UserDefaults) {
         guard defaults.object(forKey: legacyKey) != nil else { return }
-        if defaults.object(forKey: key) == nil {
-            defaults.set(defaults.bool(forKey: legacyKey), forKey: key)
+
+        // Prefer well-formed booleans only: `object(forKey:) != nil` is true for corrupted types,
+        // but `bool(forKey:)` can mis-read them; skipping migration would delete legacy without fixing the new key.
+        let newValue = optionalBool(forKey: key, in: defaults)
+        if newValue == nil, let legacyValue = optionalBool(forKey: legacyKey, in: defaults) {
+            defaults.set(legacyValue, forKey: key)
         }
         defaults.removeObject(forKey: legacyKey)
     }


### PR DESCRIPTION
## Headline

Tutorial hint flags migrate reliably when defaults store booleans as numbers or odd types.

## User impact

Fewer cases where onboarding hints or celebration flags come back after an update or sync, or get stuck in a bad state. The app keeps your tutorial progress consistent when old keys are migrated to the newer names.

## What changed

The legacy-key migration path no longer relies only on raw presence checks plus generic boolean reads. It now reads stored values as real booleans when they are Bool or NSNumber (common with plists and some sync paths), and only copies from a legacy key into the new key when the new key does not already hold a well-formed boolean. That avoids mis-reading corrupted or unexpected types, which could previously drop the legacy value without writing a correct new value.

## Verification

On a Mac with Xcode, run `grace ci` (or `grace test` with the project’s default simulator destination) to confirm the app builds and tests pass; optionally exercise a build that runs `migrateLegacyKeysIfNeeded` after seeding UserDefaults with legacy keys stored as 0/1 or Bool to confirm hints stay dismissed as expected.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
