### PR TITLE
Reuse prepared haptic generators for Past tap button styles

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/PastTappablePressStyle.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/PastTappablePressStyle.swift
@@ -1,6 +1,22 @@
 import SwiftUI
 import UIKit
 
+/// Shared generators so taps avoid per-press allocation; `prepare()` keeps latency predictable (UIKit guidance).
+private enum PastTappableHaptics {
+    private static let mediumImpact = UIImpactFeedbackGenerator(style: .medium)
+    private static let lightImpact = UIImpactFeedbackGenerator(style: .light)
+
+    static func playMediumImpact() {
+        mediumImpact.prepare()
+        mediumImpact.impactOccurred()
+    }
+
+    static func playLightImpact() {
+        lightImpact.prepare()
+        lightImpact.impactOccurred()
+    }
+}
+
 /// Scale, opacity, and haptic feedback for tappable controls on Past and related drilldowns / theme flows.
 struct PastTappablePressStyle: ButtonStyle {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -12,7 +28,7 @@ struct PastTappablePressStyle: ButtonStyle {
             .animation(reduceMotion ? .none : .easeInOut(duration: 0.16), value: configuration.isPressed)
             .onChange(of: configuration.isPressed) { wasPressed, isPressed in
                 guard isPressed, !wasPressed, !reduceMotion else { return }
-                UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                PastTappableHaptics.playMediumImpact()
             }
     }
 }
@@ -43,7 +59,7 @@ struct PastToolbarDoneButtonStyle: ButtonStyle {
             .animation(reduceMotion ? .none : .easeInOut(duration: 0.14), value: configuration.isPressed)
             .onChange(of: configuration.isPressed) { wasPressed, isPressed in
                 guard isPressed, !wasPressed, !reduceMotion else { return }
-                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                PastTappableHaptics.playLightImpact()
             }
     }
 }


### PR DESCRIPTION
## Headline

Past journal taps use shared, prepared haptic feedback instead of creating new generators on every press.

## User impact

Tapping items in Past and related sheets should feel the same or slightly more consistent, with less work on each tap. This mainly improves responsiveness and reliability by avoiding repeated allocations and by preparing the Taptic Engine before each impact, which can matter when scrolling and tapping quickly.

## What changed

The Past tappable press and toolbar Done button styles previously created a new impact feedback generator every time you pressed a button. The change introduces a small private helper that keeps one medium and one light generator and calls prepare before each impact, matching UIKit guidance for predictable latency. Visual press animations and Reduce Motion behavior are unchanged; only how haptics are produced under the hood was tightened.

## Verification

On a Mac with Xcode, run `grace ci` (or `grace test` if that matches your usual check) from the repo root to confirm lint and simulator build pass. Manually open Past, tap list items and the Done-style toolbar control, and confirm haptics still fire when Reduce Motion is off and stay suppressed when Reduce Motion is on.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
