### PR TITLE
Canonicalize peek viewport height to avoid negative zero in layout

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewHistoryDrilldownPeekMetrics.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewHistoryDrilldownPeekMetrics.swift
@@ -16,9 +16,10 @@ enum ReviewHistoryDrilldownPeekMetrics {
     /// Uses at most the non-negative space remaining; never inflates above `remainingHeight`.
     ///
     /// Non-finite values (NaN or infinity) collapse to `0` so invalid geometry math cannot propagate into
-    /// frame sizes for the calendar grid.
+    /// frame sizes for the calendar grid. `abs` canonicalizes non-negative output: `max(0, -0)` can leave
+    /// IEEE negative zero, which is a poor signal for layout heights.
     static func clampedViewportHeight(remainingHeight: CGFloat) -> CGFloat {
         guard remainingHeight.isFinite else { return 0 }
-        return max(0, remainingHeight)
+        return abs(Swift.max(0, remainingHeight))
     }
 }


### PR DESCRIPTION
## Headline

Review History calendar peek heights now normalize edge-case floating-point values so layout stays predictable.

## User impact

Rare floating-point edge cases could leave the calendar peek with a negative-zero height signal, which can confuse layout or downstream comparisons. Normalizing the clamped height keeps the feathered calendar grid sizing stable and consistent for reviewers browsing history.

## What changed

The peek viewport height helper still rejects non-finite values and never exceeds the remaining space, but after clamping to a non-negative value it now canonicalizes the result so IEEE negative zero cannot propagate into frame sizing for the calendar grid. Documentation was updated to explain why that normalization matters for layout.

## Verification

On a Mac with the project toolchain, run `grace ci` (or `grace test` with the repo’s default simulator destination) to confirm the GraceNotes scheme still builds and tests pass.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
