### PR TITLE
Stabilize journal export ordering and export filenames

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/Services/JournalDataExportService.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/Services/JournalDataExportService.swift
@@ -39,7 +39,7 @@ struct JournalDataExportService {
             if lhs.createdAt != rhs.createdAt {
                 return lhs.createdAt < rhs.createdAt
             }
-            return lhs.id.uuidString < rhs.id.uuidString
+            return lhs.id < rhs.id
         }
         return JournalDataExportArchive(
             schemaVersion: JournalDataExportArchive.currentSchemaVersion,
@@ -71,12 +71,18 @@ struct JournalDataExportService {
     }
 
     private func timestampString(from date: Date) -> String {
-        let formatter = DateFormatter()
-        formatter.calendar = Calendar(identifier: .gregorian)
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(secondsFromGMT: 0)
-        formatter.dateFormat = "yyyyMMdd-HHmmss"
-        return formatter.string(from: date)
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let parts = calendar.dateComponents([.year, .month, .day, .hour, .minute, .second], from: date)
+        return String(
+            format: "%04d%02d%02d-%02d%02d%02d",
+            parts.year ?? 0,
+            parts.month ?? 0,
+            parts.day ?? 0,
+            parts.hour ?? 0,
+            parts.minute ?? 0,
+            parts.second ?? 0
+        )
     }
 }
 


### PR DESCRIPTION
## Headline

Journal data exports now break ties with native UUID order and stamp filenames with a deterministic UTC timestamp.

## User impact

When two entries share the same day and creation time, the export order stays aligned with Swift’s UUID ordering instead of string-based UUID text. Export filenames keep the same human-readable pattern while avoiding locale-dependent date formatting quirks.

## What changed

The export archive’s secondary sort now compares journal IDs directly instead of comparing their string forms, which is a clearer tie-breaker and matches typical UUID ordering.

The timestamp embedded in export filenames is still Gregorian and UTC, but it is assembled from calendar components with fixed-width numeric formatting instead of a DateFormatter. That keeps the filename stamp predictable and less sensitive to formatting or locale edge cases.

## Verification

On a Mac with Xcode, run `grace ci` (or `grace test` per project defaults). Optionally trigger a journal data export from Settings and confirm the generated JSON filename uses the expected `yyyyMMdd-HHmmss` UTC-style segment before the random UUID suffix.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
