### PR TITLE
Fix iCloud last-activity time when timestamp is in the future

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/Services/ICloudSyncLastActivityFormatting.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/Services/ICloudSyncLastActivityFormatting.swift
@@ -11,12 +11,15 @@ enum ICloudSyncLastActivityFormatting {
         referenceNow: Date,
         localizationLocale: Locale = .current
     ) -> String {
-        let elapsed = referenceNow.timeIntervalSince(lastActivity)
+        // Clock skew or bad metadata can make `lastActivity` slightly (or wildly) in the future.
+        // Cap to `referenceNow` so relative math never goes negative (which would clamp to “1 second”).
+        let effectiveLastActivity = min(lastActivity, referenceNow)
+        let elapsed = referenceNow.timeIntervalSince(effectiveLastActivity)
         if elapsed >= twentyFourHours {
             let style = Date.FormatStyle(date: .abbreviated, time: .shortened).locale(localizationLocale)
-            return lastActivity.formatted(style)
+            return effectiveLastActivity.formatted(style)
         }
-        return relativePhrase(since: lastActivity, now: referenceNow, locale: localizationLocale)
+        return relativePhrase(since: effectiveLastActivity, now: referenceNow, locale: localizationLocale)
     }
 
     /// Full subtitle line (prefix + time phrase).


### PR DESCRIPTION
## Headline

Last sync time no longer shows a misleading “just now” when metadata is ahead of the clock.

## User impact

If the stored last-activity time was slightly or wildly in the future (clock skew or bad metadata), the UI could treat the gap as negative and clamp it to about one second, so Settings looked like sync just happened. Capping the timestamp to “now” keeps the relative phrase honest and avoids that confusing flash of “1 second ago.”

## What changed

The formatter now treats the last-activity date as no later than the reference “now” before computing elapsed time and before choosing abbreviated date/time vs. relative wording. A short comment documents why: future timestamps should not drive negative intervals that downstream logic floors to a one-second minimum.

## Verification

On a Mac with Xcode, run `swiftlint lint` from the repo root, then `grace ci` (or `grace test` with the project’s usual simulator destination) to match CI. Manually, exercise Settings → Data & privacy (or equivalent) iCloud sync last-activity with a mocked or adjusted last-activity in the future and confirm the subtitle no longer shows a bogus “1 second” relative time.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
