### PR TITLE
Harden stored reminder time parsing from UserDefaults

### DIFF
--- a/GraceNotes/GraceNotes/Services/Reminders/DailyReminderNotificationSync.swift
+++ b/GraceNotes/GraceNotes/Services/Reminders/DailyReminderNotificationSync.swift
@@ -13,11 +13,7 @@ enum DailyReminderNotificationSync {
         let status = await reminderScheduler.currentReminderStatus()
         guard status == .enabled else { return }
 
-        let stored = userDefaults.object(forKey: ReminderSettings.timeIntervalKey) as? TimeInterval
-        var interval = stored ?? ReminderSettings.defaultTimeInterval
-        if !interval.isFinite {
-            interval = ReminderSettings.defaultTimeInterval
-        }
+        let interval = storedReminderTimeInterval(from: userDefaults)
         let reminderTime = ReminderSettings.date(from: interval)
         let body: String
         do {
@@ -30,5 +26,26 @@ enum DailyReminderNotificationSync {
             body = String(localized: String.LocalizationValue("notifications.reminder.body.fallback"))
         }
         _ = await reminderScheduler.rescheduleEnabledReminder(at: reminderTime, body: body)
+    }
+
+    /// Reads the saved clock time. `UserDefaults` is untyped; accept `NSNumber` and reject non-finite values.
+    private static func storedReminderTimeInterval(from userDefaults: UserDefaults) -> TimeInterval {
+        guard let raw = userDefaults.object(forKey: ReminderSettings.timeIntervalKey) else {
+            return ReminderSettings.defaultTimeInterval
+        }
+
+        let interval: TimeInterval
+        if let number = raw as? NSNumber {
+            interval = number.doubleValue
+        } else if let value = raw as? TimeInterval {
+            interval = value
+        } else {
+            return ReminderSettings.defaultTimeInterval
+        }
+
+        if !interval.isFinite {
+            return ReminderSettings.defaultTimeInterval
+        }
+        return interval
     }
 }


### PR DESCRIPTION
## Headline

Daily reminders now pick up your saved time even when UserDefaults stores it as a bridged number.

## User impact

If the app’s stored reminder clock time was bridged from UserDefaults as NSNumber, the old cast to TimeInterval could fail and silently fall back to the default time, so your notification might not match the time you chose. This path now reads the value in the forms the system actually persists and ignores corrupt or non-finite numbers, so rescheduling stays aligned with your reminder settings.

## What changed

The routine that refreshes the pending repeating reminder’s notification body no longer assumes UserDefaults returns a value you can cast directly to TimeInterval. A dedicated helper loads the key’s raw object, treats NSNumber and TimeInterval as valid sources for the interval, and uses the default reminder time when the value is missing, unrecognized, or not finite. The main flow calls that helper so the reminder time and localized body stay consistent without duplicating parsing logic.

## Verification

On a Mac with Xcode and the project’s `grace` CLI, run `grace ci` (or `grace test` per your usual workflow) to lint and simulator-build. Manually confirm behavior by enabling daily reminders, changing the reminder time, and verifying the next scheduled notification reflects the chosen time after foregrounding or other triggers that reschedule the reminder.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
