### PR TITLE
Honor app UI language for share-card CJK typography

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/ShareTypographyScript.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ShareTypographyScript.swift
@@ -8,12 +8,23 @@ enum ShareTypographyScript: Equatable, Sendable {
 }
 
 extension ShareTypographyScript {
-    static func current() -> ShareTypographyScript {
-        switch Locale.current.language.languageCode {
-        case .some(.chinese), .some(.japanese), .some(.korean):
+    /// Consults the app bundle’s active UI language before the system locale, so CJK typography
+    /// applies when the app is localized to Chinese/Japanese/Korean even if the device language is English.
+    static func current(bundle: Bundle = .main) -> ShareTypographyScript {
+        let languages: [Locale.Language] = bundle.preferredLocalizations.map { Locale.Language(identifier: $0) }
+            + [Locale.current.language]
+        for language in languages where isCJK(language.languageCode) {
             return .chinese
+        }
+        return .latin
+    }
+
+    private static func isCJK(_ code: Locale.LanguageCode?) -> Bool {
+        switch code?.identifier {
+        case "zh", "ja", "ko":
+            return true
         default:
-            return .latin
+            return false
         }
     }
 }


### PR DESCRIPTION
## Headline

Share cards now pick CJK typography when the app is in Chinese, Japanese, or Korean—even if the device language is English.

## User impact

Share images and typography now match the language you chose in the app instead of only following the system language. That makes shared journals look correct for localized users who keep English as their device language.

## What changed

Share typography script selection used to rely on the system locale alone, so CJK styling could be wrong when the app UI was set to Chinese, Japanese, or Korean while the device stayed on English. The resolver now looks at the app bundle’s preferred localizations first, then the current locale, and treats zh, ja, and ko as CJK. A small helper centralizes that language-code check.

## Verification

On a Mac with Xcode and the project’s grace CLI: run `grace ci` (or `grace test` with the usual simulator destination) after building Grace Notes; manually verify a share preview or export with app language set to zh/ja/ko and system language English to confirm CJK typography applies.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
