### PR TITLE
Unify sticky completion chip hysteresis across iOS 17 and 18+

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/JournalStickyCompletionVisibility.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/JournalStickyCompletionVisibility.swift
@@ -27,10 +27,8 @@ enum JournalStickyCompletionVisibility {
         guard scrollContentOffsetY.isFinite, scrollRevealThreshold.isFinite else {
             return currentlyRevealed
         }
-        if currentlyRevealed {
-            return scrollContentOffsetY > scrollRevealThreshold + releasePadding
-        }
-        return scrollContentOffsetY > scrollRevealThreshold + engagePadding
+        let scrollPastThreshold = scrollContentOffsetY - scrollRevealThreshold
+        return shouldShow(scrollPastThreshold: scrollPastThreshold, currentlyRevealed: currentlyRevealed)
     }
 
     // MARK: - iOS 17 (header frame in scroll space)
@@ -52,9 +50,19 @@ enum JournalStickyCompletionVisibility {
         guard headerMinYInScrollSpace.isFinite, scrollRevealThreshold.isFinite else {
             return currentlyRevealed
         }
-        if currentlyRevealed {
-            return headerMinYInScrollSpace < -(scrollRevealThreshold + releasePadding)
+        let scrollPastThreshold = -headerMinYInScrollSpace - scrollRevealThreshold
+        return shouldShow(scrollPastThreshold: scrollPastThreshold, currentlyRevealed: currentlyRevealed)
+    }
+
+    /// Shared hysteresis: both code paths normalize to “how far past the reveal line” (in points) so the
+    /// engage/release bands cannot drift between iOS 17 and iOS 18 implementations.
+    private static func shouldShow(scrollPastThreshold: CGFloat, currentlyRevealed: Bool) -> Bool {
+        guard scrollPastThreshold.isFinite else {
+            return currentlyRevealed
         }
-        return headerMinYInScrollSpace < -(scrollRevealThreshold + engagePadding)
+        if currentlyRevealed {
+            return scrollPastThreshold > releasePadding
+        }
+        return scrollPastThreshold > engagePadding
     }
 }


### PR DESCRIPTION
## Headline

The journal’s sticky completion chip now uses one hysteresis rule on every supported iOS version.

## User impact

The completion indicator in the toolbar should show and hide at the same scroll positions relative to your content on older and newer iOS, so you get steadier behavior and less flicker or mismatch near the reveal line. That keeps unlock feedback and the chip from fighting tiny layout differences between OS versions.

## What changed

The iOS 18+ path (scroll content offset) and the iOS 17 path (header position in scroll space) used mathematically different ways to combine the reveal threshold with engage and release padding. That could make the “how far past the line” bands differ between implementations even when the UI felt the same.

Both paths now convert their inputs into a single value—how many points past the reveal threshold the scroll state is—and feed that into one private helper that applies the same Schmitt-style hysteresis for showing versus hiding. Non-finite values still fall back to the current revealed state.

## Verification

On a Mac with Xcode and the iOS Simulator, run `grace ci` (or `grace test` with your usual destination from `gracenotes-dev.toml`). In the journal, scroll so the completion block crosses the reveal line on both the iOS 17-style and iOS 18+ scroll paths if you can exercise both; confirm the chip does not jitter at the boundary and engages/releases consistently.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
