### PR TITLE
Align rhythm strip VoiceOver with displayed completion level

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewSummaryCard.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewSummaryCard.swift
@@ -527,7 +527,7 @@ struct ReviewDaysYouWrotePanel: View {
 
     private func activityAccessibilityLabel(for day: ReviewDayActivity) -> String {
         let dateText = day.date.formatted(date: .abbreviated, time: .omitted)
-        if let level = day.strongestCompletionLevel {
+        if let level = rhythmDisplayedCompletionLevel(for: day) {
             if level == .soil {
                 return String(
                     format: String(localized: "review.insights.wroteOnDate"),
@@ -537,12 +537,6 @@ struct ReviewDaysYouWrotePanel: View {
             return String(
                 format: String(localized: "review.insights.reachedStageOnDate"),
                 localizedCompletionStageName(for: level),
-                dateText
-            )
-        }
-        if day.hasPersistedEntry {
-            return String(
-                format: String(localized: "review.insights.wroteOnDate"),
                 dateText
             )
         }


### PR DESCRIPTION
## Headline

VoiceOver now describes each day’s rhythm column the same way the strip visually represents it.

## User impact

People using VoiceOver on the Past tab get announcements that match the growth-stage pill and empty-state treatment they see in the reflection rhythm strip, instead of a label that could disagree with the chart when underlying fields differ. That reduces confusion and makes the rhythm history easier to trust for assistive-tech users.

## What changed

The rhythm strip already drew completion using a single rule: only days with a persisted journal row show a growth stage, and a missing stage falls back to soil so the UI stays consistent with Growth Stages semantics. The accessibility label still used the raw strongest completion flag plus a separate “wrote on that date” branch, which could drift from what was actually drawn.

The VoiceOver label now uses the same `rhythmDisplayedCompletionLevel` helper as the chart, and the redundant persisted-entry branch is removed so one code path defines both what you see and what you hear.

## Verification

On a Mac with Xcode, run `grace ci` (or `grace test` with the project’s default simulator destination). In the simulator, open the Past tab, turn on VoiceOver, and move through the reflection rhythm columns; each day’s spoken label should match the visible stage (including soil when the journal exists but no higher stage is recorded).

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
