### PR TITLE
Stabilize weekly review recurring themes and tighten theme aggregation

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregates.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregates.swift
@@ -224,6 +224,9 @@ private extension WeeklyReviewAggregatesBuilder {
                 if $0.dayCount != $1.dayCount {
                     return $0.dayCount > $1.dayCount
                 }
+                if $0.firstSeenOrder != $1.firstSeenOrder {
+                    return $0.firstSeenOrder < $1.firstSeenOrder
+                }
                 return $0.displayLabel.localizedCaseInsensitiveCompare($1.displayLabel) == .orderedAscending
             }
             .prefix(maxThemesPerSection)
@@ -247,7 +250,12 @@ private extension WeeklyReviewAggregatesBuilder {
         let normalized = textNormalizer.normalizeThemeLabel(trimmedLabel)
         guard !normalized.isEmpty else { return }
 
-        if map[normalized] == nil {
+        if var existing = map[normalized] {
+            existing.mentionCount += 1
+            existing.weightedScore += weight
+            existing.days.insert(day)
+            map[normalized] = existing
+        } else {
             map[normalized] = ThemeAccumulator(
                 normalizedLabel: normalized,
                 displayLabel: trimmedLabel,
@@ -256,12 +264,7 @@ private extension WeeklyReviewAggregatesBuilder {
                 days: [day],
                 firstSeenOrder: sequence
             )
-            return
         }
-
-        map[normalized]?.mentionCount += 1
-        map[normalized]?.weightedScore += weight
-        map[normalized]?.days.insert(day)
     }
 
     func sortedThemeSummaries(from map: [String: ThemeAccumulator]) -> [ThemeSummary] {


### PR DESCRIPTION
## Headline

Weekly review chips pick clearer winners when themes tie, with more reliable aggregation under the hood.

## User impact

Recurring gratitude, need, and people themes in the weekly review are less likely to flip arbitrarily when counts match. The change also makes theme rollups behave more predictably when the same theme appears again in a week.

## What changed

Recurring theme selection for the weekly review now breaks ties using the order a theme first appeared in the scanned week, aligned with how full theme summaries are ranked. Theme accumulation was rewritten so updates merge into an existing normalized theme in one pass instead of relying on repeated optional lookups and early returns.

## Verification

On macOS, run `swiftlint lint` from the repo root and `grace ci` (or `grace test` with the project’s default simulator destination) to confirm lint and the GraceNotes scheme build/tests pass.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
