### PR TITLE
Respect Reduce Motion for themed button press scaling

### DIFF
--- a/GraceNotes/GraceNotes/DesignSystem/Theme.swift
+++ b/GraceNotes/GraceNotes/DesignSystem/Theme.swift
@@ -338,7 +338,7 @@ struct WarmPaperPressStyle: ButtonStyle {
 
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
-            .scaleEffect(configuration.isPressed ? 0.98 : 1.0)
+            .scaleEffect(configuration.isPressed && !reduceMotion ? 0.98 : 1.0)
             .opacity(configuration.isPressed ? 0.86 : 1.0)
             .animation(
                 reduceMotion ? nil : .easeOut(duration: 0.12),


### PR DESCRIPTION
## Headline

Press feedback stays calm for people who reduce interface motion.

## User impact

Users who enable Reduce Motion in iOS accessibility settings avoid a subtle shrink-on-press effect that can feel unnecessary or uncomfortable. Taps still read as pressed through non-scaling feedback (for example opacity), so affordance remains without extra motion.

## What changed

A Warm Paper button style in the design system applied a small scale-down whenever a control was pressed, even when the user asked the system to limit motion. The press scale is now skipped when Reduce Motion is on, matching the existing policy that already avoided animated easing in that case. This keeps interaction feedback consistent with system accessibility expectations and reduces vestibular or distraction risk from micro-motion.

## Verification

On a Mac with Xcode, run `grace ci` (or `grace test` with the project’s default simulator destination). In the Simulator or on device, turn on Settings → Accessibility → Motion → Reduce Motion, then press themed buttons and confirm they no longer shrink while pressed; with Reduce Motion off, confirm the subtle press scale still appears.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
