### PR TITLE
Fix monthly scheduled backups to follow calendar months

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/Services/ScheduledBackupPreferences.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/Services/ScheduledBackupPreferences.swift
@@ -23,7 +23,10 @@ enum ScheduledBackupInterval: String, CaseIterable, Codable {
         case .biweekly:
             return dayDelta >= 14
         case .monthly:
-            return dayDelta >= 30
+            guard let nextEligibleDay = calendar.date(byAdding: .month, value: 1, to: startLast) else {
+                return false
+            }
+            return startNow >= calendar.startOfDay(for: nextEligibleDay)
         }
     }
 }


### PR DESCRIPTION
## Headline

Monthly backups now line up with real calendar months instead of a fixed 30-day wait.

## User impact

The old “monthly” rule waited at least 30 days between runs, which could fire too early or feel misaligned with a true monthly rhythm across months of different lengths. This makes scheduled backup timing more predictable and closer to what people expect from “once a month.”

## What changed

Scheduled backup “monthly” eligibility no longer uses a simple 30-day day count from the last run. It now asks the calendar for the start of the day one month after the last run’s calendar day and only treats a new backup as due once today reaches that day (or later). If the calendar cannot compute that next date, the code conservatively reports not due.

## Verification

On a Mac with Xcode and the iOS Simulator, run `grace ci` (or `grace test` with the project’s usual destination) to lint, build, and run tests.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
