### PR TITLE
Skip autosave when reading notes and reflections are unchanged

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/ViewModels/JournalViewModel+EntryEditing.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/ViewModels/JournalViewModel+EntryEditing.swift
@@ -183,11 +183,13 @@ extension JournalViewModel {
     }
 
     func updateReadingNotes(_ value: String) {
+        guard value != readingNotes else { return }
         readingNotes = value
         scheduleAutosave()
     }
 
     func updateReflections(_ value: String) {
+        guard value != reflections else { return }
         reflections = value
         scheduleAutosave()
     }


### PR DESCRIPTION
## Headline

Journal editing no longer schedules redundant saves when the text did not actually change.

## User impact

SwiftUI and text fields can call update handlers even when the visible text is the same, which used to trigger autosave every time. That extra work is unnecessary and could add noise to debounced save behavior. Users should see the same saving behavior when they really edit, with less pointless churn in the background.

## What changed

The journal view model already avoids no-op updates for list-style entries by comparing new text to what is stored. Reading notes and reflections did not do that, so any repeated call with the same string still scheduled autosave.

This change adds the same kind of early exit for reading notes and reflections: if the incoming value matches what is already stored, the method returns without updating state or scheduling autosave. When the value is new, behavior is unchanged.

## Verification

On a Mac with Xcode, run `grace ci` (or `grace test` with your usual simulator destination). In the app, open a journal and edit Reading notes and Reflections: confirm changes still save as before, and that normal typing does not feel different. Optionally watch logs or breakpoints around autosave if you use them to confirm fewer no-op schedules when focus or bindings fire without a real edit.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
