### PR TITLE
Fix interface chrome font fallback and disabled bar button styling

### DIFF
--- a/GraceNotes/GraceNotes/DesignSystem/AppInterfaceAppearance.swift
+++ b/GraceNotes/GraceNotes/DesignSystem/AppInterfaceAppearance.swift
@@ -16,7 +16,14 @@ enum AppInterfaceAppearance {
         textStyle: UIFont.TextStyle,
         maximumForContentSizeCategory limit: UIContentSizeCategory? = nil
     ) -> UIFont {
-        let baseFont = UIFont(name: name, size: baseSize) ?? UIFont.preferredFont(forTextStyle: textStyle)
+        let baseFont: UIFont
+        if let outfit = UIFont(name: name, size: baseSize) {
+            baseFont = outfit
+        } else {
+            // `preferredFont(forTextStyle:)` uses the *current* Dynamic Type size; `UIFontMetrics` would scale again.
+            let largeTraits = UITraitCollection(preferredContentSizeCategory: .large)
+            baseFont = UIFont.preferredFont(forTextStyle: textStyle, compatibleWith: largeTraits)
+        }
         let metrics = UIFontMetrics(forTextStyle: textStyle)
         guard let limit else {
             return metrics.scaledFont(for: baseFont)
@@ -90,5 +97,6 @@ enum AppInterfaceAppearance {
         let barButton = UIBarButtonItem.appearance()
         barButton.setTitleTextAttributes([.font: font], for: .normal)
         barButton.setTitleTextAttributes([.font: font], for: .highlighted)
+        barButton.setTitleTextAttributes([.font: font], for: .disabled)
     }
 }


### PR DESCRIPTION
## Headline

System chrome typography stays predictable when Outfit is missing, and disabled toolbar buttons match the rest of the UI.

## User impact

If the bundled Outfit font failed to load, navigation bars, tab bars, and bar buttons could end up oversized or inconsistent with Dynamic Type because the fallback was scaled twice. Disabled bar buttons could also look different from enabled ones because only normal and highlighted states used the custom font.

## What changed

The Dynamic Type scaling helper now uses the system text style at a fixed Large content size when Outfit is unavailable, so UIFontMetrics applies a single predictable scaling path instead of compounding the user’s current text size. Global bar button item appearance also sets the same font for the disabled control state so disabled actions stay visually consistent with normal and highlighted titles.

## Verification

On a Mac with Xcode, check out the branch and run `grace ci` (or `grace test` with the project’s default simulator destination). In Simulator, optionally remove or break the Outfit font face to confirm chrome falls back without absurd scaling, and verify disabled bar buttons use the same typography as enabled ones at a few Dynamic Type sizes.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
