### PR TITLE
Harden journal share image export scale and bitmap validation

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/JournalShareRenderer.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/JournalShareRenderer.swift
@@ -14,9 +14,8 @@ enum JournalShareRenderer {
         renderer.scale = Self.recommendedPixelScale()
         guard let image = renderer.uiImage else { return nil }
         guard image.size.width > 0, image.size.height > 0 else { return nil }
-        if let cgImage = image.cgImage {
-            guard cgImage.width > 0, cgImage.height > 0 else { return nil }
-        }
+        guard let cgImage = image.cgImage else { return nil }
+        guard cgImage.width > 0, cgImage.height > 0 else { return nil }
         return image
     }
 
@@ -28,15 +27,18 @@ enum JournalShareRenderer {
     }
 
     /// `ImageRenderer` runs without hosting in a window; `UITraitCollection.current.displayScale` can be
-    /// unset or 1× while the device screen is Retina. Prefer the foreground active window scene scale, then
-    /// trait, then screen, then a safe default. Ignores background scenes so multi-window layouts do not
-    /// pick an unrelated display’s scale.
+    /// unset or 1× while the device screen is Retina. Prefer the foreground window scene scale (active or
+    /// inactive — a presented sheet can leave the root scene inactive), then trait, then screen, then a
+    /// safe default. Ignores background/unattached scenes so multi-window layouts do not pick an unrelated
+    /// display’s scale.
     @MainActor
     private static func recommendedPixelScale() -> CGFloat {
         let traitScale = UITraitCollection.current.displayScale
         let sceneScale = UIApplication.shared.connectedScenes
             .compactMap { $0 as? UIWindowScene }
-            .filter { $0.activationState == .foregroundActive }
+            .filter {
+                $0.activationState == .foregroundActive || $0.activationState == .foregroundInactive
+            }
             .map { $0.screen.scale }
             .max() ?? 0
         let screenScale = UIScreen.main.scale


### PR DESCRIPTION
## Headline

Sharper, more reliable share-card images when sheets change scene state, with stricter bitmap checks.

## User impact

Share exports are less likely to look soft or low-resolution when a sheet leaves the main window scene in a foreground-inactive state. The renderer also refuses images that lack a usable backing bitmap, avoiding odd or empty-looking shares.

## What changed

The share card bitmap path now requires a non-nil CGImage with positive pixel dimensions, instead of only validating dimensions when a CGImage happened to exist. Pixel scale selection for ImageRenderer now considers both foreground-active and foreground-inactive window scenes (still excluding background and unattached scenes), so a presented sheet does not cause the code to miss the on-screen Retina scale and fall back to weaker sources. Comments were updated to describe this behavior.

## Verification

On a Mac with Xcode and simulators, run `grace ci` (or `grace test` with the project’s default destination) and manually share a journal entry with a sheet presented so the main scene is foreground inactive; confirm the exported image looks sharp and sharing still succeeds.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
