### PR TITLE
Compare journal UUIDs directly for same-day history ordering

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/HistoryEntryGrouping.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/HistoryEntryGrouping.swift
@@ -13,7 +13,7 @@ enum HistoryEntryGrouping {
                 if $0.entryDate != $1.entryDate {
                     return $0.entryDate > $1.entryDate
                 }
-                return $0.id.uuidString < $1.id.uuidString
+                return $0.id < $1.id
             }
             return (month, groupedEntries)
         }


### PR DESCRIPTION
## Headline

Journal history within a month now uses proper UUID ordering when dates match.

## User impact

When you have multiple entries on the same calendar day, their order in History stays stable and deterministic. The tie-breaker now uses Swift’s native UUID comparison instead of comparing string forms, which is clearer and avoids subtle ordering quirks.

## What changed

In History’s month grouping, entries are still sorted newest day first, then by UUID when two entries share the same `entryDate`. The only behavioral refinement is replacing lexicographic comparison of `uuidString` with direct `UUID` comparison (`<`) for that tie-break. That matches how UUIDs are meant to be ordered, is a bit cheaper (no string work for every pair comparison), and keeps ordering consistent for same-day entries.

## Verification

On a Mac with Xcode and the project’s dev tools installed, run `grace ci` from the repo root (or `grace test` with your usual simulator destination) to confirm lint and the GraceNotes scheme build still pass. In the app, open History, pick a month with several entries on one day, and confirm the list order looks sensible and stable when navigating away and back.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
