### PR TITLE
Treat empty fullText as missing when decoding journal entries

### DIFF
--- a/GraceNotes/GraceNotes/Data/Models/Entry.swift
+++ b/GraceNotes/GraceNotes/Data/Models/Entry.swift
@@ -15,10 +15,10 @@ struct JournalItem: Codable {
         id = try container.decodeIfPresent(UUID.self, forKey: .id) ?? UUID()
         let entryLabel = try container.decodeIfPresent(String.self, forKey: .entryLabel)
         let chipLabel = try container.decodeIfPresent(String.self, forKey: .chipLabel)
-        if let full = try container.decodeIfPresent(String.self, forKey: .fullText) {
+        if let full = try container.decodeIfPresent(String.self, forKey: .fullText), !full.isEmpty {
             fullText = full
         } else {
-            // Legacy rows may omit `fullText` but still carry `entryLabel` / `chipLabel` (see export import).
+            // Legacy rows may omit `fullText`, use empty `fullText`, or only carry legacy labels (see export import).
             fullText = entryLabel ?? chipLabel ?? ""
         }
         _ = try container.decodeIfPresent(Bool.self, forKey: .isTruncated)


### PR DESCRIPTION
## Headline

Imported or legacy journal lines no longer lose their text when fullText is empty but labels still hold the real content.

## User impact

Some exports or older data can store the visible line in legacy label fields while fullText is present but empty. Before this change, those lines could decode as blank. After the change, empty fullText is ignored so the stored labels are used and the line shows up as expected.

## What changed

Journal item decoding now treats a present but empty fullText the same as a missing fullText, so the decoder falls back to legacy entryLabel and chipLabel when they carry the real text. The comment was updated to describe that legacy rows may omit fullText, use an empty fullText, or only use the older label fields.

## Verification

On a Mac with Xcode and the project dev tools installed, run `grace ci` (or `grace test` with the usual simulator destination) to confirm the GraceNotes scheme still builds and tests pass.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
