### PR TITLE
Show loading skeleton when Most Recurring refresh has empty cached themes

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewMostRecurringCard.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewMostRecurringCard.swift
@@ -44,7 +44,12 @@ struct ReviewMostRecurringCard: View {
         if isLoading, insights == nil {
             loadingSkeleton
         } else if let insights {
-            contentForInsights(insights)
+            // Avoid an empty panel under the title when a refresh still has a cached empty snapshot.
+            if isLoading, insights.weekStats.mostRecurringThemes.isEmpty {
+                loadingSkeleton
+            } else {
+                contentForInsights(insights)
+            }
         }
     }
 


### PR DESCRIPTION
## Headline

The Most Recurring review card no longer looks blank under the title while fresh insights load.

## User impact

During a refresh, the app could still show a cached snapshot with no recurring themes, which left the card title visible but the body empty and easy to mistake for missing data or a bug. The card now shows the same loading placeholders used elsewhere so the screen clearly signals that results are on the way.

## What changed

The Most Recurring card already stayed on screen while loading so the section title did not disappear with stale empty data. That behavior could still render an empty content area under the title when loading was true but the cached weekly stats had no themes. The view now treats that case like an in-progress load: it swaps the empty panel for the loading skeleton until non-empty themes arrive or loading finishes, matching the loading experience described for similar review insight cards and improving perceived reliability.

## Verification

On a Mac with Xcode and the project’s grace CLI, run `grace ci` (or `grace test` with the default simulator destination from gracenotes-dev.toml). Manually, open Review, trigger a refresh when the prior snapshot had no recurring themes, and confirm the Most Recurring card shows loading placeholders under the title instead of a blank panel.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
