### PR TITLE
Use weak self for iCloud account refresh async work

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/ICloudAccountStatusModel.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/ICloudAccountStatusModel.swift
@@ -17,10 +17,12 @@ final class ICloudAccountStatusModel: ObservableObject {
     func refresh() {
         refreshGeneration += 1
         let generation = refreshGeneration
-        Task { @MainActor in
+        let provider = self.provider
+        Task { @MainActor [weak self] in
             let bucket = await provider.fetchAccountBucket()
-            guard generation == refreshGeneration else { return }
-            displayedBucket = bucket
+            guard let self else { return }
+            guard generation == self.refreshGeneration else { return }
+            self.displayedBucket = bucket
         }
     }
 }


### PR DESCRIPTION
## Headline

Settings iCloud status refreshes no longer keep the view model alive longer than needed.

## User impact

If you open Settings and the app refreshes iCloud account status in the background, the work no longer strongly retains that screen’s model for the whole fetch. That reduces unnecessary memory use and avoids applying updates after the model is gone, which keeps behavior predictable when you leave Settings quickly.

## What changed

The refresh path now captures the status provider once before starting the task, runs the async fetch against that capture, and uses a weak reference to the observable object inside the MainActor task. After the await, the code bails out if the object was deallocated, and only then compares the refresh generation and updates the displayed bucket. That keeps the existing “newer refresh wins” behavior while tying updates to a live instance.

## Verification

On a Mac with Xcode and the repo’s grace CLI installed, run `grace ci` from the repository root (or `grace test` with the project’s default simulator destination) to lint and build the GraceNotes scheme.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
