### PR TITLE
Fix VoiceOver for redacted lines on journal share card

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/JournalShareCardView.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/JournalShareCardView.swift
@@ -211,13 +211,15 @@ private extension JournalShareCardView {
             Button {
                 onLineTap(identity)
             } label: {
-                redactionBar
+                redactionBarShape
+                    .accessibilityHidden(true)
             }
             .buttonStyle(.plain)
             .accessibilityLabel(String(localized: "sharing.a11y.lineRedacted"))
             .accessibilityHint(String(localized: "sharing.a11y.lineTapToShow"))
         } else {
-            redactionBar
+            redactionBarShape
+                .accessibilityLabel(String(localized: "sharing.a11y.lineRedacted"))
         }
     }
 
@@ -230,11 +232,10 @@ private extension JournalShareCardView {
             .accessibilityLabel(String(localized: "sharing.a11y.sectionStub"))
     }
 
-    var redactionBar: some View {
+    private var redactionBarShape: some View {
         RoundedRectangle(cornerRadius: 4, style: .continuous)
             .fill(surface.redactionBarColor)
             .frame(height: 18)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .accessibilityHidden(onLineTap == nil)
     }
 }


### PR DESCRIPTION
## Headline

Redacted placeholders now announce clearly in VoiceOver for both interactive and static share previews.

## User impact

People using VoiceOver no longer miss that a line is redacted when the share preview is not interactive, and they get a single clear announcement when tapping to show or hide a line instead of duplicate or confusing focus on the gray bar.

## What changed

The share card’s redacted line placeholder was refactored so the visual bar is a simple shape without tying accessibility visibility to whether line tap is available. When lines can be toggled, the bar is hidden from the accessibility tree so the button’s label and hint describe the action. When the preview is static, the bar is labeled so screen readers still say the line is redacted.

## Verification

On a Mac with Xcode, build and run the GraceNotes scheme, open the journal share flow with redacted lines, and use VoiceOver: confirm redacted rows are announced in both interactive preview and export-style (non-tappable) views. Run `grace ci` for lint and simulator build parity with CI.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
