### PR TITLE
Stabilize share card row identity and fix share card layout

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/JournalShareCardView.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/JournalShareCardView.swift
@@ -35,6 +35,16 @@ struct JournalShareCardView: View {
     }
 }
 
+private enum ShareLineRowID: Hashable {
+    case line(ShareLineIdentity)
+    case previewStub(section: ShareSectionKind, index: Int)
+}
+
+private struct IdentifiedShareLineRow: Identifiable {
+    let id: ShareLineRowID
+    let item: ShareLineDisplayItem
+}
+
 private extension JournalShareCardView {
     var surface: ShareCardSurface { payload.cardSurface }
 
@@ -73,7 +83,7 @@ private extension JournalShareCardView {
                 .padding(.bottom, 32)
 
             VStack(alignment: .leading, spacing: 24) {
-                ForEach(Array(payload.sections.enumerated()), id: \.offset) { index, section in
+                ForEach(Array(payload.sections.enumerated()), id: \.element.kind) { index, section in
                     if payload.style.showsSectionDividers, index > 0 {
                         Rectangle()
                             .fill(surface.sectionDividerColor)
@@ -125,9 +135,31 @@ private extension JournalShareCardView {
     func sectionBlock(_ section: ShareSectionRenderModel) -> some View {
         VStack(alignment: .leading, spacing: 6) {
             sectionHeader(section)
-            ForEach(Array(section.lines.enumerated()), id: \.offset) { _, item in
-                lineRow(item)
+            ForEach(identifiedLines(for: section)) { row in
+                lineRow(row.item)
             }
+        }
+    }
+
+    func identifiedLines(for section: ShareSectionRenderModel) -> [IdentifiedShareLineRow] {
+        section.lines.enumerated().map { index, item in
+            IdentifiedShareLineRow(
+                id: shareLineRowID(section: section, item: item, index: index),
+                item: item
+            )
+        }
+    }
+
+    func shareLineRowID(
+        section: ShareSectionRenderModel,
+        item: ShareLineDisplayItem,
+        index: Int
+    ) -> ShareLineRowID {
+        switch item {
+        case .visible(_, let identity), .redacted(let identity):
+            return .line(identity)
+        case .previewStub:
+            return .previewStub(section: section.kind, index: index)
         }
     }
 
@@ -164,6 +196,7 @@ private extension JournalShareCardView {
                 .font(style.sectionTitleFont(for: script))
                 .foregroundStyle(surface.sectionTitleInk)
                 .textCase(titleCase)
+                .fixedSize(horizontal: false, vertical: true)
         }
     }
 
@@ -202,6 +235,7 @@ private extension JournalShareCardView {
                 .lineSpacing(3)
                 .foregroundStyle(ink)
                 .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 


### PR DESCRIPTION
## Headline

Journal share cards identify rows and sections reliably so toggling content stays smooth and aligned.

## User impact

Using list position as the only identity made SwiftUI reuse the wrong views when sections or lines changed, which could cause flicker, odd animations, or taps hitting the wrong line. Section titles and read-only body text now lay out consistently with the rest of the card so shared previews look even and predictable.

## What changed

Sections in the share card ForEach are keyed by section kind instead of index. Each line row gets a stable id: visible and redacted lines use their share line identity, and preview placeholder lines use the section kind plus index so stubs stay distinct without colliding with real lines. The non-interactive section title path now allows vertical growth like the toggle variant, and non-tappable body text uses full-width leading alignment to match interactive lines.

## Verification

On macOS with Xcode and the iOS Simulator, run `grace ci` (or `grace test` with the repo’s default destination). In the app, open share preview and toggle sections and individual lines; confirm rows update without visual glitches, and that taps still target the intended line.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
