### PR TITLE
Harden journal history month grouping for calendar edge cases

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/HistoryEntryGrouping.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/HistoryEntryGrouping.swift
@@ -38,11 +38,15 @@ enum HistoryEntryGrouping {
     }
 
     /// When the active calendar cannot form a month start, anchor by Gregorian UTC year/month
-    /// so entries in the same month are not split by day. `startOfDay` is only used if even
-    /// this normalization fails.
+    /// so entries in the same month are not split by day. If direct month normalization fails
+    /// but year and month are known, derive the month from January 1; only then fall back to
+    /// `startOfDay(for:)` (which can still split one month across buckets when all else fails).
     private static func gregorianUTCMonthStart(for date: Date) -> Date {
         var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)
+            ?? TimeZone(identifier: "UTC")
+            ?? TimeZone(abbreviation: "GMT")
+            ?? .current
         var components = calendar.dateComponents([.year, .month], from: date)
         components.day = 1
         components.hour = 0
@@ -52,6 +56,23 @@ enum HistoryEntryGrouping {
         if let normalized = calendar.date(from: components) {
             return normalized
         }
-        return calendar.startOfDay(for: date)
+        guard let year = components.year, let month = components.month else {
+            return calendar.startOfDay(for: date)
+        }
+        let clampedMonth = min(max(month, 1), 12)
+        var yearStartComponents = DateComponents()
+        yearStartComponents.timeZone = calendar.timeZone
+        yearStartComponents.year = year
+        yearStartComponents.month = 1
+        yearStartComponents.day = 1
+        yearStartComponents.hour = 0
+        yearStartComponents.minute = 0
+        yearStartComponents.second = 0
+        yearStartComponents.nanosecond = 0
+        guard let januaryFirst = calendar.date(from: yearStartComponents) else {
+            return calendar.startOfDay(for: date)
+        }
+        return calendar.date(byAdding: .month, value: clampedMonth - 1, to: januaryFirst)
+            ?? calendar.startOfDay(for: date)
     }
 }


### PR DESCRIPTION
## Headline

Journal history stays grouped by month even when the system calendar cannot build a clean month start.

## User impact

Entries that belong in the same calendar month are less likely to appear under multiple month headers or get scattered by day. The change also avoids a fragile assumption about UTC time zone construction, which keeps month-key logic reliable across environments.

## What changed

The Gregorian UTC fallback used when the active calendar cannot form a month start now picks a UTC-like time zone with safe fallbacks instead of force-unwrapping. When building the first day of the month from components fails but year and month are still known, the code derives that month from January 1 by adding months, and only then falls back to start-of-day. That reduces cases where the previous fallback split one month across several buckets. Documentation comments were updated to describe this ordering and the remaining last-resort behavior.

## Verification

On a Mac with the repo’s grace CLI installed, run `grace ci` (or `grace test` with the project’s default simulator destination) to lint and build; optionally open Journal history and confirm entries for unusual dates or calendar settings still appear under a single month section.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
