### PR TITLE
Document streak refresher contract for full journal history

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/JournalStreakSummaryRefresher.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/JournalStreakSummaryRefresher.swift
@@ -2,7 +2,11 @@ import Foundation
 import SwiftData
 
 enum JournalStreakSummaryRefresher {
-    /// Computes streak summary from an entry list already loaded from the store (avoids a second full fetch).
+    /// Computes streak summary from a journal list already loaded from the store (avoids a second full fetch).
+    ///
+    /// - Parameter entries: Must include every journal row that could affect streak continuity—typically the same
+    ///   set as ``JournalRepository/fetchAllEntries(context:)``. Passing a filtered subset (for example only recent
+    ///   days) omits older days from the per-day map, so the streak length can be shorter than the user's real streak.
     static func loadSummary(
         calculator: StreakCalculator,
         entries: [Journal],
@@ -11,6 +15,8 @@ enum JournalStreakSummaryRefresher {
         calculator.summary(from: entries, now: now)
     }
 
+    /// Loads all journal rows via ``JournalRepository/fetchAllEntries(context:)`` and computes streak metadata.
+    /// Prefer ``loadSummary(calculator:entries:now:)`` when entries are already in memory.
     static func loadSummary(
         repository: JournalRepository,
         calculator: StreakCalculator,


### PR DESCRIPTION
## Headline

Streak math stays accurate when callers pass the right data—now the code says so.

## User impact

If streak summaries were ever computed from a partial list of days, the app could show a shorter streak than the user actually has. This change does not alter runtime behavior; it documents the requirement so maintainers avoid that mistake when reusing the in-memory path.

## What changed

The streak summary refresher’s documentation was tightened. The overload that takes journals already loaded from the store now states that callers must pass every journal row that could affect streak continuity—typically the same full set as the repository’s fetch-all method—and explains that filtering to only recent days can shrink the computed streak. The repository-based overload is documented as the path that loads all rows, with a note to prefer the in-memory overload when data is already available. Terminology was aligned (journal list vs. entry list) for clarity.

## Verification

Review the updated doc comments in JournalStreakSummaryRefresher.swift. On a Mac with Xcode, run `grace ci` (or `grace test`) to confirm the project still builds and tests as before; this change is documentation-only.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
