### PR TITLE
Centralize hosted unit-test detection in app delegate

### DIFF
--- a/GraceNotes/GraceNotes/Application/GraceNotesApp.swift
+++ b/GraceNotes/GraceNotes/Application/GraceNotesApp.swift
@@ -25,9 +25,8 @@ struct GraceNotesApp: App {
     init() {
         let startupTrace = PerformanceTrace.begin("App.init")
         let processInfo = ProcessInfo.processInfo
-        let isXCTestSession = processInfo.environment["XCTestConfigurationFilePath"] != nil
         isRunningUITests = ProcessInfo.graceNotesIsRunningUITests
-        isRunningUnitTests = isXCTestSession && !isRunningUITests
+        isRunningUnitTests = ProcessInfo.graceNotesIsRunningHostedUnitTests
 
         if !isRunningUnitTests {
             JournalTutorialStorageKeys.migrateLegacyKeysIfNeeded(using: .standard)

--- a/GraceNotes/GraceNotes/Application/GraceNotesAppDelegate.swift
+++ b/GraceNotes/GraceNotes/Application/GraceNotesAppDelegate.swift
@@ -9,8 +9,7 @@ final class GraceNotesAppDelegate: NSObject, UIApplicationDelegate {
     ) -> Bool {
         // Keep this aligned with `GraceNotesApp.init`: hosted unit tests use a blank root and should not
         // mutate global `UIAppearance`; UI tests and normal launches still get chrome.
-        let isXCTestSession = ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
-        if isXCTestSession, !ProcessInfo.graceNotesIsRunningUITests {
+        if ProcessInfo.graceNotesIsRunningHostedUnitTests {
             return true
         }
         AppInterfaceAppearance.configure()

--- a/GraceNotes/GraceNotes/Application/ProcessInfo+GraceNotesUITesting.swift
+++ b/GraceNotes/GraceNotes/Application/ProcessInfo+GraceNotesUITesting.swift
@@ -12,7 +12,17 @@ extension ProcessInfo {
         return isUITestBundle || hasUITestLaunchArgument
     }
 
-    /// True when UI tests request the wide Review rhythm seed (ignored unless `graceNotesIsRunningUITests` is also true).
+    /// True when XCTest hosts the app for **unit** tests (not UI tests): blank root and no global `UIAppearance`.
+    ///
+    /// Keep in sync with `GraceNotesApp.init` and `GraceNotesAppDelegate`—single definition of “hosted unit tests.”
+    static var graceNotesIsRunningHostedUnitTests: Bool {
+        let processInfo = Self.processInfo
+        let isXCTestSession = processInfo.environment["XCTestConfigurationFilePath"] != nil
+        return isXCTestSession && !graceNotesIsRunningUITests
+    }
+
+    /// True when UI tests request the wide Review rhythm seed (ignored unless
+    /// `graceNotesIsRunningUITests` is also true).
     static var graceNotesUITestWideReviewRhythmSeed: Bool {
         guard graceNotesIsRunningUITests else { return false }
         return Self.processInfo.arguments.contains(Self.graceNotesUITestWideReviewRhythmArgument)

--- a/Scripts/gracenotes-dev/src/gracenotes_dev/sentry/ci_fix.py
+++ b/Scripts/gracenotes-dev/src/gracenotes_dev/sentry/ci_fix.py
@@ -147,7 +147,9 @@ def _git_has_uncommitted_changes(git_root: Path) -> bool:
     return bool((st.stdout or "").strip())
 
 
-def _git_push_origin_head_to_branch(git_root: Path, remote_branch: str) -> subprocess.CompletedProcess[str]:
+def _git_push_origin_head_to_branch(
+    git_root: Path, remote_branch: str
+) -> subprocess.CompletedProcess[str]:
     """
     Push ``HEAD`` to ``origin``'s branch ``remote_branch`` (GitHub PR ``headRefName``).
 


### PR DESCRIPTION
## Headline

Global appearance setup now keys off the same hosted-unit-test signal as the rest of the app.

## User impact

Hosted unit tests keep a blank root and avoid changing global UIAppearance, which keeps tests predictable. Normal launches and UI tests still receive the standard chrome. The behavior is easier to keep correct because the condition matches `GraceNotesApp` instead of duplicating environment checks.

## What changed

Replaced the inline check for `XCTestConfigurationFilePath` plus a UI-test exclusion with `ProcessInfo.graceNotesIsRunningHostedUnitTests`, so the delegate skips `AppInterfaceAppearance.configure()` using the same definition of “hosted unit tests” as initialization. No change intended for production or UI-test appearance.

## Verification

On a Mac with Xcode and the project’s `grace` CLI, run `grace ci` (or `grace test` with your usual simulator destination) to confirm the app still builds and tests pass.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
