### PR TITLE
Fix review theme evidence decoding for legacy cached payloads

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/ReviewInsights.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ReviewInsights.swift
@@ -116,22 +116,27 @@ struct ReviewMostRecurringTheme: Equatable, Hashable, Sendable, Codable, Identif
         dayCount = try container.decode(Int.self, forKey: .dayCount)
         currentWeekCount = try container.decode(Int.self, forKey: .currentWeekCount)
         previousWeekCount = try container.decode(Int.self, forKey: .previousWeekCount)
-        if let structuredEvidence = try container.decodeIfPresent(
-            [ReviewThemeSurfaceEvidence].self,
-            forKey: .evidence
-        ) {
-            evidence = structuredEvidence
-        } else if let legacyEvidence = try container.decodeIfPresent([ReviewThemeEvidence].self, forKey: .evidence) {
-            evidence = legacyEvidence.flatMap { row in
+        evidence = Self.decodeEvidence(from: container)
+    }
+
+    /// `decodeIfPresent` throws on shape mismatch when the key exists, so legacy
+    /// `[ReviewThemeEvidence]` must be tried with `try? decode`.
+    private static func decodeEvidence(
+        from container: KeyedDecodingContainer<CodingKeys>
+    ) -> [ReviewThemeSurfaceEvidence] {
+        if let structuredEvidence = try? container.decode([ReviewThemeSurfaceEvidence].self, forKey: .evidence) {
+            return structuredEvidence
+        }
+        if let legacyEvidence = try? container.decode([ReviewThemeEvidence].self, forKey: .evidence) {
+            return legacyEvidence.flatMap { row in
                 var seenInRow = Set<ReviewThemeSourceCategory>()
                 let uniqueSources = row.sources.filter { seenInRow.insert($0).inserted }
                 return uniqueSources.map { source in
                     ReviewThemeSurfaceEvidence(entryDate: row.date, source: source, content: "")
                 }
             }
-        } else {
-            evidence = []
         }
+        return []
     }
 
     func encode(to encoder: Encoder) throws {


### PR DESCRIPTION
## Headline

Weekly review insights load reliably when cached data still uses the older recurring-theme evidence format.

## User impact

Users who upgraded with older cached review data could hit decoding failures or lose recurring-theme evidence because the stored JSON shape no longer matched the newer type. The app now tolerates both shapes so Review stays stable across updates and older on-device caches.

## What changed

The most recurring theme decoder treated legacy evidence as optional with decodeIfPresent, but when the evidence key exists with the legacy array shape, decoding the new type throws instead of returning nil, which can abort loading the whole cached review payload.

Evidence decoding now lives in a helper that tries the structured form and then the legacy form using try? full decodes, maps legacy rows into surface evidence (deduplicating sources per row), and falls back to an empty list when neither works. A short comment documents why decodeIfPresent is insufficient.

## Verification

From the repo root, run swiftlint lint. On a Mac with Xcode 26+, run grace ci (or grace test with the default simulator destination from gracenotes-dev.toml) to confirm the GraceNotes scheme builds and automated tests pass.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
