### PR TITLE
Block entry-chip switches when a full section cannot save a draft

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/JournalScreenEntryHandling.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/JournalScreenEntryHandling.swift
@@ -163,11 +163,16 @@ enum JournalScreenEntryHandling {
             } else {
                 canSwitch = false
             }
-        } else if !trimmed.isEmpty, operations.count < JournalViewModel.slotCount {
-            if let newIndex = operations.addImmediate(input.wrappedValue) {
-                input.wrappedValue = ""
-                _ = newIndex
+        } else if !trimmed.isEmpty {
+            if operations.count < JournalViewModel.slotCount {
+                if let newIndex = operations.addImmediate(input.wrappedValue) {
+                    input.wrappedValue = ""
+                    _ = newIndex
+                } else {
+                    canSwitch = false
+                }
             } else {
+                // At capacity with no row being edited: draft text cannot be saved before switching strips.
                 canSwitch = false
             }
         }


### PR DESCRIPTION
## Headline

Prevents losing unsaved composer text when a sequential section is at its slot limit.

## User impact

If you had text in the entry field while no row was being edited and the section already had the maximum number of items, tapping another chip could still move focus and replace the field, which dropped text you had not yet saved. The app now keeps you on the current draft until there is room to commit it or you clear it.

## What changed

The entry-tap handler now treats “draft text with nothing selected to update” the same as a failed save when the section is at capacity: it does not advance to the tapped row’s text. The logic is split so a full section sets switching off instead of falling through with switching still allowed, and failed immediate adds also block switching for consistency.

## Verification

On a Mac with Xcode, run `grace ci` (or `grace test` with the project’s default simulator). Manually fill a sequential section to the maximum slots, type new text without selecting a row, then tap another chip; the draft should remain and focus should not load the other row’s content over it.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
