### PR TITLE
Stabilize journal completion info card bloom animation lifecycle

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/JournalCompletionInfoPresentation.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/JournalCompletionInfoPresentation.swift
@@ -39,6 +39,7 @@ final class JournalCompletionInfoPresentation {
     }
 
     func dismissInfoCard(reduceMotion: Bool) {
+        cancelInfoCardBloomAnimation(resetProgress: true)
         infoCardDismissTask?.cancel()
         infoCardDismissSequence += 1
         infoCardDismissTask = nil
@@ -67,11 +68,11 @@ final class JournalCompletionInfoPresentation {
         infoCardDismissTask?.cancel()
         infoCardDismissSequence += 1
         infoCardDismissTask = nil
-        infoCardBloomTask?.cancel()
-        infoCardBloomTask = nil
+        cancelInfoCardBloomAnimation(resetProgress: true)
     }
 
     private func scheduleInfoCardCloseThenReopenAfterDelay(reduceMotion: Bool) {
+        cancelInfoCardBloomAnimation(resetProgress: true)
         withAnimation(infoCardExitAnimation(reduceMotion: reduceMotion)) {
             isInfoCardPresented = false
         }
@@ -99,6 +100,7 @@ final class JournalCompletionInfoPresentation {
 
     private func triggerInfoCardBloomPulse(reduceMotion: Bool) {
         guard !reduceMotion else {
+            cancelInfoCardBloomAnimation(resetProgress: false)
             infoCardBloomProgress = 1
             return
         }
@@ -116,6 +118,14 @@ final class JournalCompletionInfoPresentation {
             withAnimation(.easeOut(duration: 0.35)) {
                 infoCardBloomProgress = 0
             }
+        }
+    }
+
+    private func cancelInfoCardBloomAnimation(resetProgress: Bool) {
+        infoCardBloomTask?.cancel()
+        infoCardBloomTask = nil
+        if resetProgress {
+            infoCardBloomProgress = 0
         }
     }
 


### PR DESCRIPTION
## Headline

Cancels the badge info “bloom” animation cleanly so dismissals and badge switches don’t leave stray motion or stuck visuals.

## User impact

Tapping completion badges or closing the info card should feel more predictable, with fewer odd flashes or half-finished highlight effects when you move quickly between badges or dismiss the sheet. Reduce Motion mode still shows a steady completed state without leftover animation work running in the background.

## What changed

The presentation model now routes bloom cancellation through a single helper that stops the bloom task, clears the task handle, and resets bloom progress when that makes sense (for example when the card is dismissed or the view goes away). Dismiss, close-then-reopen, and cleanup paths call this before other work so a delayed bloom step cannot fire after the UI has moved on. For Reduce Motion, the code clears the bloom task without forcing progress back to zero before setting the final value, so the accessibility path stays consistent.

## Verification

On a Mac with Xcode, run `grace ci` (or `grace test` with the project’s default simulator destination). Manually exercise the journal completion badges: open the info card, dismiss it quickly, switch between different badges while the card is open, and repeat with Reduce Motion enabled in Settings to confirm the highlight behaves calmly and does not flicker or stall.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
