### PR TITLE
Cancel superseded iCloud account status refresh tasks

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/ICloudAccountStatusModel.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/ICloudAccountStatusModel.swift
@@ -9,17 +9,21 @@ final class ICloudAccountStatusModel: ObservableObject {
     private let provider: any ICloudAccountStatusProviding
     /// Increments on each `refresh()` so a slower, older fetch cannot overwrite a newer result.
     private var refreshGeneration = 0
+    /// Superseded refreshes cancel the previous task so redundant CloudKit work is not started or finished needlessly.
+    private var refreshTask: Task<Void, Never>?
 
     init(provider: any ICloudAccountStatusProviding = ICloudAccountStatusService()) {
         self.provider = provider
     }
 
     func refresh() {
+        refreshTask?.cancel()
         refreshGeneration += 1
         let generation = refreshGeneration
         let provider = self.provider
-        Task { @MainActor [weak self] in
+        refreshTask = Task { @MainActor [weak self] in
             let bucket = await provider.fetchAccountBucket()
+            guard !Task.isCancelled else { return }
             guard let self else { return }
             guard generation == self.refreshGeneration else { return }
             self.displayedBucket = bucket


### PR DESCRIPTION
## Headline

Faster, lighter Settings refreshes when iCloud status is requested repeatedly.

## User impact

Rapid checks for iCloud account status (for example while opening Settings or retrying) no longer pile up background work. You still see a stable status line without flicker from out-of-order updates.

## What changed

The Settings model that loads the iCloud account bucket now keeps a handle on the in-flight refresh. Each new refresh cancels the previous task before starting another fetch.

After the async fetch returns, the task bails out if it was cancelled, so superseded work does not touch published UI state. The existing generation counter still blocks stale results if a slower response somehow completes later.

## Verification

On a Mac with Xcode and the Grace Notes dev CLI, run `grace ci` (or `grace test` if that matches your usual review profile) to lint and build against the simulator destinations in `gracenotes-dev.toml`. Manually open Settings and trigger repeated refreshes if you want to confirm no redundant CloudKit churn in Instruments or logs.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
