### PR TITLE
Align weekly continuity prompt with the resurfacing headline insight

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyInsightRuleEngine.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyInsightRuleEngine.swift
@@ -48,13 +48,14 @@ struct WeeklyInsightRuleEngine {
 
         let narrativeSummary = candidateBuilder.narrativeSummary(from: selectedInsights)
         let starterReflection = String(localized: "review.insights.starterReflection")
-        let trimmedHeadline = Self.firstNonEmptyTrimmedHeadline(in: selectedInsights)
-        let resurfacingMessage = trimmedHeadline ?? starterReflection
+        let (headline, primaryInsight) = Self.headlineAndPrimaryInsight(from: selectedInsights)
+        let resurfacingMessage = headline ?? starterReflection
 
-        let continuityPrompt = selectedInsights.compactMap(\.action).map {
-            $0.trimmingCharacters(in: .whitespacesAndNewlines)
-        }.first(where: { !$0.isEmpty })
-            ?? candidateBuilder.defaultContinuityPrompt
+        let continuityPrompt = Self.continuityPrompt(
+            matching: primaryInsight,
+            in: selectedInsights,
+            defaultPrompt: candidateBuilder.defaultContinuityPrompt
+        )
 
         return WeeklyInsightAnalysis(
             weeklyInsights: selectedInsights,
@@ -69,20 +70,46 @@ struct WeeklyInsightRuleEngine {
         )
     }
 
+    /// Prefer a non-empty trimmed `action` from the same insight that drives the resurfacing headline
+    /// (first insight with a non-empty observation or `primaryTheme`), then any other insight’s action,
+    /// so the prompt stays aligned with the line the member actually sees.
+    private static func continuityPrompt(
+        matching primaryInsight: ReviewWeeklyInsight?,
+        in insights: [ReviewWeeklyInsight],
+        defaultPrompt: String
+    ) -> String {
+        if let primary = primaryInsight,
+           let action = primary.action,
+           let trimmed = Self.nonEmptyTrimmed(action) {
+            return trimmed
+        }
+        return insights.compactMap(\.action).map {
+            $0.trimmingCharacters(in: .whitespacesAndNewlines)
+        }.first(where: { !$0.isEmpty })
+            ?? defaultPrompt
+    }
+
+    private static func nonEmptyTrimmed(_ text: String) -> String? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
     /// Prefer the first non-empty trimmed `observation` across selected insights. If an observation is blank
     /// but `primaryTheme` is present (e.g. failed template substitution), use the trimmed theme so the
     /// resurfacing line still matches visible card context instead of the generic starter copy.
-    private static func firstNonEmptyTrimmedHeadline(in insights: [ReviewWeeklyInsight]) -> String? {
+    private static func headlineAndPrimaryInsight(
+        from insights: [ReviewWeeklyInsight]
+    ) -> (headline: String?, primaryInsight: ReviewWeeklyInsight?) {
         for insight in insights {
             let trimmedObservation = insight.observation.trimmingCharacters(in: .whitespacesAndNewlines)
             if !trimmedObservation.isEmpty {
-                return trimmedObservation
+                return (trimmedObservation, insight)
             }
             if let theme = insight.primaryTheme?.trimmingCharacters(in: .whitespacesAndNewlines),
                !theme.isEmpty {
-                return theme
+                return (theme, insight)
             }
         }
-        return nil
+        return (nil, nil)
     }
 }


### PR DESCRIPTION
## Headline

Weekly review follow-up prompts now stay tied to the same insight as the resurfacing line.

## User impact

When the weekly review shows a specific resurfacing line, the continuity prompt is more likely to match that same thread instead of jumping to a different insight’s action. That reduces confusing mismatches between what you read and what you are asked to reflect on next, and keeps the flow feeling intentional.

## What changed

The engine used to pick the resurfacing headline from the first insight with a usable observation or theme, but still chose the continuity prompt from whichever insight had the first non-empty action—often a different card. The change tracks which insight actually drives the headline and prefers that insight’s trimmed action for the continuity prompt, falling back to any other non-empty action and then the default only when needed. Small helpers centralize trimming and selection so the headline and prompt stay aligned by construction.

## Verification

On a Mac with the project dev tooling installed, run `grace ci` (or `grace test` with the repo’s default simulator destination) to lint and build; optionally exercise the weekly review UI with multiple insights to confirm the follow-up matches the highlighted resurfacing line.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
