### PR TITLE
Harden simplified-Chinese instruction locale detection

### DIFF
--- a/GraceNotes/GraceNotes/Application/AppInstructionLocale.swift
+++ b/GraceNotes/GraceNotes/Application/AppInstructionLocale.swift
@@ -19,14 +19,10 @@ enum AppInstructionLocale: Equatable, Sendable {
 
     /// Uses `Locale.Language` so legacy tags (`zh_CN`, `zh_Hans_CN`) and bare `zh` resolve like the system,
     /// instead of brittle `zh-hans` / `zh-hans-` string prefix checks that miss underscore forms.
+    private static let simplifiedChineseScript = Locale.Script("Hans")
+
     private static func isSimplifiedChineseUIIdentifier(_ identifier: String) -> Bool {
         let language = Locale.Language(identifier: identifier)
-        guard language.languageCode?.identifier == "zh" else {
-            return false
-        }
-        guard let script = language.script?.identifier else {
-            return false
-        }
-        return script.caseInsensitiveCompare("Hans") == .orderedSame
+        return language.languageCode == .chinese && language.script == simplifiedChineseScript
     }
 }


### PR DESCRIPTION
## Headline

LLM instruction language now keys off structured locale codes instead of string parsing.

## User impact

When your app UI is set to Simplified Chinese, cloud/LLM instructions and Review-style insights stay aligned with that choice. Fewer edge cases from odd locale tags mean fewer mistaken switches to English prompts.

## What changed

Detection of Simplified Chinese for instruction prompts no longer compares raw language and script strings. It uses `Locale.Language` components—Chinese language code plus the Hans script—so tags like legacy `zh_CN` or `zh_Hans_CN` resolve consistently with how the system represents locales. A single shared `Locale.Script("Hans")` constant keeps the check clear and avoids one-off string casing issues.

## Verification

On a Mac with Xcode, run `grace ci` (or at least `swiftlint lint` plus the usual simulator build/tests you use for this repo). Optionally set the app to a Simplified Chinese localization and confirm insight/instruction behavior still follows Chinese prompts.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
