### PR TITLE
Use full SHA-256 for journal search match field IDs

### DIFF
--- a/GraceNotes/GraceNotes/Data/JournalSearchMatch.swift
+++ b/GraceNotes/GraceNotes/Data/JournalSearchMatch.swift
@@ -29,7 +29,8 @@ struct JournalSearchMatch: Identifiable, Equatable, Sendable {
         content: String
     ) -> String {
         let digest = SHA256.hash(data: Data(content.utf8))
-        let fingerprint = digest.prefix(8).map { String(format: "%02x", $0) }.joined()
+        // Use the full digest so truncated-hash collisions cannot map two different bodies of text to one `id`.
+        let fingerprint = digest.map { String(format: "%02x", $0) }.joined()
         return "\(journalEntryId.uuidString)|\(source.rawValue)|\(fingerprint)"
     }
 }


### PR DESCRIPTION
## Headline

Past search results stay correctly tied to the right note text, even in rare collision cases.

## User impact

Search matches for whole fields (for example reading notes and reflections) identify rows by a compact fingerprint of the text. A too-short fingerprint could theoretically make two different pieces of text share one identity, which could confuse selection, scrolling, or updates in Past search. Using the full digest makes those IDs effectively unique for practical purposes so the right row stays stable as you search and interact.

## What changed

The helper that builds stable IDs for whole-field matches no longer uses only the first eight bytes of the SHA-256 hash of the content. It now encodes the entire digest into the fingerprint string, with a short comment explaining that this avoids truncated-hash collisions mapping different bodies of text to the same `id`. Other initializers that key off entry item UUIDs are unchanged.

## Verification

On a Mac with Xcode and the project’s `grace` CLI installed, run `swiftlint lint` from the repo root and `grace ci` (or `grace test` with the usual simulator destination from `gracenotes-dev.toml`) to confirm the project still lints and builds; exercise Past search on whole-field content if you want to sanity-check behavior in the Simulator.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
