### PR TITLE
Fix add-morph composer state when the last sentence slot is filled

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/SequentialSectionPrimaryColumn.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/SequentialSectionPrimaryColumn.swift
@@ -79,14 +79,6 @@ extension SequentialSectionPrimaryColumn {
         !isTransitioning && !isLockedByGuidance
     }
 
-    private var inputAccessibilityLabel: String {
-        String(
-            format: String(localized: "accessibility.sectionInputLabel"),
-            locale: Locale.current,
-            title
-        )
-    }
-
     private var ambientGuidanceOpacity: CGFloat {
         ambientInlineEditingActive ? SequentialSectionInlineLayout.ambientUnfocusedOpacity : 1
     }
@@ -188,7 +180,7 @@ extension SequentialSectionPrimaryColumn {
                 .onTapGesture {
                     if isInlineEditingActive {
                         commitInlineEditIfNeeded()
-                    } else if isAddMorphComposerVisible {
+                    } else if isAddMorphComposerVisible, showMorphAddSlot {
                         commitAddMorphFromHeaderTap()
                     }
                 }
@@ -268,6 +260,10 @@ extension SequentialSectionPrimaryColumn {
                 self.morphingItemID = nil
             }
             if itemIDs.isEmpty {
+                isAddMorphComposerVisible = false
+            } else if itemIDs.count >= slotCount {
+                // Filling the last slot can leave `isAddMorphComposerVisible` true while the morph is not shown;
+                // keep header tap / parent state (e.g. `JournalScreen`) consistent with the hidden composer.
                 isAddMorphComposerVisible = false
             }
         }


### PR DESCRIPTION
## Headline

Keeps the “add sentence” composer flag and header taps aligned when a section is full or the morph row is hidden.

## User impact

After adding the final item in a capped section, the UI no longer behaves as if the add composer were still open when it is not shown. Tapping the section header also avoids acting on a stale “composing” state when there is no add row.

## What changed

The change tightens when the section header treats an open add morph as real: the commit path runs only when the morph add slot is still available, not merely when a binding says the composer is visible.

When the list of entries changes and the section reaches its slot limit (or becomes empty), the add-morph visibility flag is cleared so it cannot stay true after the morph row disappears. That keeps local behavior and higher-level screen state (for example journal keyboard scroll targets) consistent.

An unused input accessibility label helper was removed as dead code.

## Verification

On a Mac with Xcode and the project’s grace CLI: run `grace ci` (or at least `grace test` with the default simulator destination from gracenotes-dev.toml). Manually: open a sequential section with a slot cap, expand the add morph, add entries until the section is full, then tap the section title and confirm nothing odd happens; confirm keyboard/scroll behavior still matches expectations when adding in non-full sections.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
