### PR TITLE
Refactor backup folder path resolution with explicit path kinds

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/Services/BackupFolderPickerResolution.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/Services/BackupFolderPickerResolution.swift
@@ -9,6 +9,20 @@ enum BackupFolderPickerResolution {
         case pathComponentIsNotDirectory(URL)
     }
 
+    private enum PathKind {
+        case missing
+        case directory
+        case notDirectory
+    }
+
+    private static func pathKind(at url: URL, fileManager: FileManager) -> PathKind {
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory) else {
+            return .missing
+        }
+        return isDirectory.boolValue ? .directory : .notDirectory
+    }
+
     static func resolvedFolderURL(
         userPicked: URL,
         fileManager: FileManager = .default
@@ -24,20 +38,23 @@ enum BackupFolderPickerResolution {
 
     /// Returns without error when nothing exists at `url` (caller may create a path below it).
     private static func requireDirectoryIfExists(at url: URL, fileManager: FileManager) throws {
-        var isDirectory: ObjCBool = false
-        guard fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory) else { return }
-        guard isDirectory.boolValue else {
+        switch pathKind(at: url, fileManager: fileManager) {
+        case .missing, .directory:
+            return
+        case .notDirectory:
             throw ResolutionError.pathComponentIsNotDirectory(url)
         }
     }
 
     private static func ensureDirectoryExistsOrCreate(at url: URL, fileManager: FileManager) throws -> URL {
-        try requireDirectoryIfExists(at: url, fileManager: fileManager)
-        var isDirectory: ObjCBool = false
-        if fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory) {
+        switch pathKind(at: url, fileManager: fileManager) {
+        case .notDirectory:
+            throw ResolutionError.pathComponentIsNotDirectory(url)
+        case .directory:
+            return url
+        case .missing:
+            try fileManager.createDirectory(at: url, withIntermediateDirectories: true)
             return url
         }
-        try fileManager.createDirectory(at: url, withIntermediateDirectories: true)
-        return url
     }
 }


### PR DESCRIPTION
## Headline

Backup folder picking now uses one clear check for whether each path is missing, a folder, or blocked by a file.

## User impact

Choosing a backup location should behave the same, with fewer chances for subtle inconsistencies when the Files app reports paths. If something is wrong at a path, you still get a clear failure instead of silent misbehavior.

## What changed

The backup folder resolver used repeated `fileExists` checks in a few places, which was easy to read wrong and could diverge over time. The change introduces a small `PathKind` (missing, directory, or not a directory) and a single helper that classifies a URL once per step. `requireDirectoryIfExists` and `ensureDirectoryExistsOrCreate` now branch on that classification with switches, so the rules for “allowed,” “create,” and “error” line up in one place.

## Verification

On a Mac with Xcode, run `swiftlint lint` from the repo root, then `grace ci` (or `grace test`) to confirm the project still builds and tests pass.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
