### PR TITLE
Fix weekly review theme labels when themes span multiple sections

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregatesBuilder+ThemeSections.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregatesBuilder+ThemeSections.swift
@@ -28,6 +28,8 @@ extension WeeklyReviewAggregatesBuilder {
             forJournalCorpus: journalCorpus
         )
         var map: [String: DistilledThemeAccumulator] = [:]
+        /// Strongest section source seen for each canonical (drives `displayLabel`; `.people` enables person labels).
+        var displaySourceByCanonical: [String: ReviewThemeSourceCategory] = [:]
         var sequence = 0
 
         for entry in entries {
@@ -52,6 +54,14 @@ extension WeeklyReviewAggregatesBuilder {
                     .compactMap { _, candidates in candidates.max(by: { $0.score < $1.score }) }
 
                 for concept in uniqueConcepts {
+                    if let existing = displaySourceByCanonical[concept.canonicalConcept] {
+                        displaySourceByCanonical[concept.canonicalConcept] = strongerDisplaySourceForThemeLabel(
+                            existing,
+                            surface.source
+                        )
+                    } else {
+                        displaySourceByCanonical[concept.canonicalConcept] = surface.source
+                    }
                     let isFirstAppearance = map[concept.canonicalConcept] == nil
                     var accumulator = map[concept.canonicalConcept] ?? DistilledThemeAccumulator(
                         canonicalConcept: concept.canonicalConcept,
@@ -98,8 +108,12 @@ extension WeeklyReviewAggregatesBuilder {
 
         for canonical in Array(map.keys) {
             guard var accumulator = map[canonical] else { continue }
-            let source: ReviewThemeSourceCategory =
-                canonical == "mom" || canonical == "dad" ? .people : .gratitudes
+            let source: ReviewThemeSourceCategory
+            if canonical == "mom" || canonical == "dad" {
+                source = .people
+            } else {
+                source = displaySourceByCanonical[canonical] ?? .gratitudes
+            }
             accumulator.displayLabel = textNormalizer.displayLabel(
                 for: accumulator.canonicalConcept,
                 source: source,
@@ -306,9 +320,29 @@ extension WeeklyReviewAggregatesBuilder {
         return !themeTokens.isDisjoint(with: supportTokens)
     }
 
+    /// Picks the section whose `displayLabel` semantics should win when a theme appears in more than one chip type.
+    private func strongerDisplaySourceForThemeLabel(
+        _ lhs: ReviewThemeSourceCategory,
+        _ rhs: ReviewThemeSourceCategory
+    ) -> ReviewThemeSourceCategory {
+        func rank(_ source: ReviewThemeSourceCategory) -> Int {
+            switch source {
+            case .people:
+                return 3
+            case .needs:
+                return 2
+            case .gratitudes:
+                return 1
+            case .readingNotes, .reflections:
+                return 0
+            }
+        }
+        return rank(lhs) >= rank(rhs) ? lhs : rhs
+    }
+
     /// Whole-phrase / whole-word match for Latin script; avoids substring hits like "rest" inside "forest".
     private func latinPhraseHasWordBoundaryMatch(haystack: String, needle: String) -> Bool {
-        guard needle.count <= haystack.count else { return false }
+        guard !needle.isEmpty, needle.count <= haystack.count else { return false }
         let escaped = NSRegularExpression.escapedPattern(for: needle)
         let pattern = "\\b\(escaped)\\b"
         return haystack.range(of: pattern, options: .regularExpression) != nil


### PR DESCRIPTION
## Headline

Weekly review picks the right label style when the same theme appears across Gratitudes, Needs, or People.

## User impact

Most recurring and trending themes read with labels that match where you actually wrote about them, instead of almost always sounding like Gratitudes. That makes family- and needs-oriented phrasing show up when those sections are what drove the theme.

## What changed

Previously, final theme display labels were rebuilt using Gratitudes-style rules for nearly every canonical theme, with a narrow exception for “mom” and “dad.” That meant themes that really surfaced from Needs or People could still get the wrong label tone.

The builder now records which structured section types contributed each canonical theme while scanning entries, then chooses a single display source using a fixed priority (People, then Needs, then Gratitudes, then reading notes and reflections). That chosen source is what `displayLabel` uses, while the mom/dad shortcut still forces People.

Latin word-boundary matching for support text also bails out on an empty needle so we do not build a pointless regular expression in edge cases.

## Verification

On a Mac with Xcode and the project’s `grace` CLI installed, run `grace ci` from the repo root (lint plus simulator build; use `grace test` if you want the test target explicitly). Exercise Weekly Review with entries that repeat the same theme across Gratitudes, Needs, and People and confirm the theme title reads with the expected section-appropriate labeling.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
