### PR TITLE
Align daily reminder copy with streak logic when multiple journals share a day

### DIFF
--- a/GraceNotes/GraceNotes/Services/Reminders/ReminderNotificationBodyBuilder.swift
+++ b/GraceNotes/GraceNotes/Services/Reminders/ReminderNotificationBodyBuilder.swift
@@ -25,7 +25,6 @@ enum ReminderNotificationBodyBuilder {
         )
 
         if isLapse {
-            // `completion` / `streakBucket` are unused when `isLapse` is true (`localizationKey` returns early).
             let key = ReminderNotificationBodySelector.localizationKey(
                 isLapse: true,
                 completion: .empty,
@@ -35,9 +34,28 @@ enum ReminderNotificationBodyBuilder {
             return String(localized: String.LocalizationValue(key))
         }
 
+        return nonLapseLocalizedBody(
+            entries: entries,
+            todayStart: todayStart,
+            timeBucket: timeBucket,
+            now: now,
+            calendar: calendar
+        )
+    }
+
+    private static func nonLapseLocalizedBody(
+        entries: [Journal],
+        todayStart: Date,
+        timeBucket: ReminderNotificationBodySelector.TimeBucket,
+        now: Date,
+        calendar: Calendar
+    ) -> String {
         let calculator = StreakCalculator(calendar: calendar)
-        let todayEntry = try repository.fetchEntry(for: now, context: modelContext)
-        let completion = ReminderNotificationBodySelector.completionFamily(for: todayEntry)
+        let completion = completionFamilyForToday(
+            entries: entries,
+            todayStart: todayStart,
+            calendar: calendar
+        )
 
         let summary = JournalStreakSummaryRefresher.loadSummary(
             calculator: calculator,
@@ -63,5 +81,23 @@ enum ReminderNotificationBodyBuilder {
             streakBucket: streakBucket
         )
         return String(localized: String.LocalizationValue(key))
+    }
+
+    /// Aggregates completion across every journal row for ``todayStart`` so copy matches
+    /// the per-day OR semantics in ``StreakCalculator``. A single canonical row from
+    /// ``JournalRepository/fetchEntry`` can disagree when multiple rows exist for one calendar day.
+    private static func completionFamilyForToday(
+        entries: [Journal],
+        todayStart: Date,
+        calendar: Calendar
+    ) -> ReminderNotificationBodySelector.CompletionFamily {
+        let todayJournals = entries.filter { calendar.startOfDay(for: $0.entryDate) == todayStart }
+        if todayJournals.contains(where: { $0.hasReachedBloom }) {
+            return .complete
+        }
+        if todayJournals.contains(where: { $0.hasMeaningfulContent }) {
+            return .inProgress
+        }
+        return .empty
     }
 }


### PR DESCRIPTION
## Headline

Reminder text now reflects your real progress when more than one journal exists for today.

## User impact

If the same calendar day had multiple journal rows, the app could pick one row for notification wording while streak math treated the day differently. That mismatch could show confusing or discouraging reminder copy. After this change, completion for the notification matches the same “any row counts” idea the streak uses.

## What changed

The builder no longer derives “today’s completion” from a single fetch of one journal for the current moment. It looks at every journal whose day matches today and applies the same ordering as streak logic: bloom counts as complete, meaningful content counts as in progress, otherwise empty. Non-lapse reminder body building is split into a small helper so that path stays clear. A short doc comment explains why aggregation matters when duplicate day rows exist.

## Verification

On a Mac with Xcode and the project’s grace CLI, run `grace ci` (or `grace test` with the default simulator destination from gracenotes-dev.toml). Manually, trigger a daily reminder on a day where you have multiple journal entries and confirm the notification wording matches whether any entry is complete or in progress for that day.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
