### PR TITLE
Align sequential section progress dots with valid editing index

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/SequentialSectionView.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/SequentialSectionView.swift
@@ -127,13 +127,19 @@ struct SequentialSectionView: View {
         inputFocus?.wrappedValue ?? false
     }
 
+    /// Matches `SequentialSectionPrimaryColumn.activeEditingIndex`: ignore stale or out-of-bounds indices.
+    private var activeEditingIndex: Int? {
+        guard let editingIndex, items.indices.contains(editingIndex) else { return nil }
+        return editingIndex
+    }
+
     private var shouldAnimateEditingPulse: Bool {
         isInputFocused && !reduceMotion
     }
 
     private var slotStatuses: [SlotStatus] {
         (0..<slotCount).map { index in
-            if editingIndex == index {
+            if activeEditingIndex == index {
                 return .editing
             }
             if index < items.count {


### PR DESCRIPTION
## Headline

Keep the gratitude-style progress dots accurate when the editing index is stale or out of range.

## User impact

The small progress dots at the top of a sequential section can briefly disagree with what is actually being edited when the stored editing index no longer matches the current list (for example after items move or are removed). That mismatch is confusing and can make VoiceOver’s progress summary feel wrong. This change treats an invalid index like “no row is editing” for the dots, so the header matches the real editor state.

## What changed

The view already receives an optional `editingIndex` from the journal. The primary column ignores values that are out of bounds; the header progress dots did not, so they could still mark a slot as “editing” when nothing at that index existed. A small computed property now mirrors the primary column: it only uses the index when it falls within the current `items` array. Slot status for the dots uses that sanitized value, so edited versus editing versus pending counts stay consistent with the section body and the accessibility label built from those counts.

## Verification

On a Mac with the repo’s dev tooling, run `grace ci` (or `grace test` with the project’s usual simulator destination) to lint and build. Manually, open a sequential section, start editing a line, then delete or reorder so the old index would be invalid; confirm the dots and VoiceOver progress summary no longer claim a phantom “editing” slot.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
