### PR TITLE
Resolve symlinks when checking files under scheduled backup folder

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/Services/ScheduledBackupPreferences.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/Services/ScheduledBackupPreferences.swift
@@ -195,10 +195,14 @@ enum ScheduledBackupPreferences {
     }
 
     /// Whether `fileURL` lies inside the bookmarked backup folder (for security-scoped reads via the folder bookmark).
+    ///
+    /// Resolves symlinks before comparing paths so a file under the chosen folder is still recognized when
+    /// path strings differ (e.g. `/var/...` vs `/private/var/...`); otherwise imports can incorrectly skip the folder access gate.
     static func fileURLIsUnderScheduledBackupFolder(_ fileURL: URL) -> Bool {
+        guard fileURL.isFileURL else { return false }
         guard let folderURL = try? resolveFolderURL() else { return false }
-        let folderPath = folderURL.standardizedFileURL.path
-        let path = fileURL.standardizedFileURL.path
+        let folderPath = folderURL.standardizedFileURL.resolvingSymlinksInPath().path
+        let path = fileURL.standardizedFileURL.resolvingSymlinksInPath().path
         return path != folderPath && path.hasPrefix(folderPath + "/")
     }
 


### PR DESCRIPTION
## Headline

Imports from your chosen backup folder stay authorized when macOS represents the same path in different ways.

## User impact

Some files under the folder you picked for scheduled backups can look like they are outside that folder when paths use different prefixes (for example, through /var versus /private/var). That mismatch could block the security-scoped access gate and make imports fail or skip when they should be allowed. This change makes the “is this file inside my backup folder?” check line up with how the filesystem actually resolves those paths.

## What changed

The helper that decides whether a file URL is under the bookmarked scheduled backup folder now requires a file URL and compares paths after resolving symlinks, not only after standardization. That aligns the folder and file paths so the containment check stays true when the only difference is an equivalent path form on disk. A short comment documents why that matters for the folder bookmark and import flow.

## Verification

On a Mac with Xcode and the project’s grace CLI installed, run `grace ci` from the repo root. For a deeper check, pick a scheduled backup folder, place or open a backup file whose resolved path uses a different string form than the folder (for example under /var), and confirm import or read paths that use `fileURLIsUnderScheduledBackupFolder` still pass the gate.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
