### PR TITLE
Integrate Sentry review-fix branches (sentry-review-fix-*)

### DIFF
--- a/GraceNotes/GraceNotes/Application/AppInstructionLocale.swift
+++ b/GraceNotes/GraceNotes/Application/AppInstructionLocale.swift
@@ -18,8 +18,10 @@ enum AppInstructionLocale: Equatable, Sendable {
     }
 
     /// BCP 47 tags are case-insensitive; `Bundle` may return `zh-Hans` or `zh-hans`.
-    /// Require `zh-Hans` as a full tag or as the language-script prefix before the next subtag (`zh-Hans-CN`, …), not `zh-Hant`.
-    private static func isSimplifiedChineseUIIdentifier(_ identifier: String) -> Bool {
+    /// Require `zh-Hans` as a full tag or as the language-script prefix before the next subtag
+    /// (`zh-Hans-CN`, …), not `zh-Hant`.
+    /// - Note: Unit tests cover tag forms; production code should use ``preferred(bundle:)``.
+    static func isSimplifiedChineseUIIdentifier(_ identifier: String) -> Bool {
         let tag = identifier.lowercased()
         return tag == "zh-hans" || tag.hasPrefix("zh-hans-")
     }

--- a/GraceNotes/GraceNotes/Application/AppInstructionLocale.swift
+++ b/GraceNotes/GraceNotes/Application/AppInstructionLocale.swift
@@ -19,14 +19,10 @@ enum AppInstructionLocale: Equatable, Sendable {
 
     /// Uses `Locale.Language` so legacy tags (`zh_CN`, `zh_Hans_CN`) and bare `zh` resolve like the system,
     /// instead of brittle `zh-hans` / `zh-hans-` string prefix checks that miss underscore forms.
+    private static let simplifiedChineseScript = Locale.Script("Hans")
+
     private static func isSimplifiedChineseUIIdentifier(_ identifier: String) -> Bool {
         let language = Locale.Language(identifier: identifier)
-        guard language.languageCode?.identifier == "zh" else {
-            return false
-        }
-        guard let script = language.script?.identifier else {
-            return false
-        }
-        return script.caseInsensitiveCompare("Hans") == .orderedSame
+        return language.languageCode == .chinese && language.script == simplifiedChineseScript
     }
 }

--- a/GraceNotes/GraceNotes/Application/AppInstructionLocale.swift
+++ b/GraceNotes/GraceNotes/Application/AppInstructionLocale.swift
@@ -11,7 +11,12 @@ enum AppInstructionLocale: Equatable, Sendable {
         guard let preferred = bundle.preferredLocalizations.first else {
             return .english
         }
-        if isSimplifiedChineseUIIdentifier(preferred) {
+        return resolved(forPreferredLocalizationIdentifier: preferred)
+    }
+
+    /// Resolves a tag from `bundle.preferredLocalizations` (same strings as `bundle.preferredLocalizations.first`).
+    internal static func resolved(forPreferredLocalizationIdentifier identifier: String) -> AppInstructionLocale {
+        if isSimplifiedChineseUIIdentifier(identifier) {
             return .simplifiedChinese
         }
         return .english
@@ -19,10 +24,9 @@ enum AppInstructionLocale: Equatable, Sendable {
 
     /// Uses `Locale.Language` so legacy tags (`zh_CN`, `zh_Hans_CN`) and bare `zh` resolve like the system,
     /// instead of brittle `zh-hans` / `zh-hans-` string prefix checks that miss underscore forms.
-    private static let simplifiedChineseScript = Locale.Script("Hans")
-
     private static func isSimplifiedChineseUIIdentifier(_ identifier: String) -> Bool {
         let language = Locale.Language(identifier: identifier)
-        return language.languageCode == .chinese && language.script == simplifiedChineseScript
+        guard language.languageCode == .chinese else { return false }
+        return language.script?.identifier.caseInsensitiveCompare("Hans") == .orderedSame
     }
 }

--- a/GraceNotes/GraceNotes/Application/AppInstructionLocale.swift
+++ b/GraceNotes/GraceNotes/Application/AppInstructionLocale.swift
@@ -11,9 +11,16 @@ enum AppInstructionLocale: Equatable, Sendable {
         guard let preferred = bundle.preferredLocalizations.first else {
             return .english
         }
-        if preferred == "zh-Hans" || preferred.hasPrefix("zh-Hans") {
+        if isSimplifiedChineseUIIdentifier(preferred) {
             return .simplifiedChinese
         }
         return .english
+    }
+
+    /// BCP 47 tags are case-insensitive; `Bundle` may return `zh-Hans` or `zh-hans`.
+    /// Require `zh-Hans` as a full tag or as the language-script prefix before the next subtag (`zh-Hans-CN`, …), not `zh-Hant`.
+    private static func isSimplifiedChineseUIIdentifier(_ identifier: String) -> Bool {
+        let tag = identifier.lowercased()
+        return tag == "zh-hans" || tag.hasPrefix("zh-hans-")
     }
 }

--- a/GraceNotes/GraceNotes/Application/AppInstructionLocale.swift
+++ b/GraceNotes/GraceNotes/Application/AppInstructionLocale.swift
@@ -17,14 +17,22 @@ enum AppInstructionLocale: Equatable, Sendable {
         return .english
     }
 
-    /// Uses `Locale.Language` so legacy tags (`zh_CN`, `zh_Hans_CN`) and bare `zh` resolve like the system,
-    /// instead of brittle `zh-hans` / `zh-hans-` string prefix checks that miss underscore forms.
+    /// Uses `Locale.Language` so tags with explicit scripts (e.g. `zh-Hans`, `zh-Hant`, `zh_CN` when
+    /// Foundation infers a script) are handled without brittle `zh-hans` / `zh-hans-` string prefix checks.
+    ///
+    /// **Script inference:** When `Locale.Language(identifier:)` supplies a `script`, we treat
+    /// `Hans` as Simplified Chinese. Foundation does not infer Hans vs Hant from region alone for
+    /// scriptless identifiers—e.g. bare `zh` typically has no script and falls through to English
+    /// prompts here, matching the old `zh-hans` prefix behavior. If the product ever needs
+    /// “unspecified Chinese → follow region” (e.g. infer Hans from `CN`), add an explicit rule in
+    /// this function; do not rely on Foundation to do that in the guards below.
     private static func isSimplifiedChineseUIIdentifier(_ identifier: String) -> Bool {
         let language = Locale.Language(identifier: identifier)
         guard language.languageCode?.identifier == "zh" else {
             return false
         }
         guard let script = language.script?.identifier else {
+            // No script: bare `zh` / legacy forms Foundation leaves scriptless → English instructions.
             return false
         }
         return script.caseInsensitiveCompare("Hans") == .orderedSame

--- a/GraceNotes/GraceNotes/Application/AppInstructionLocale.swift
+++ b/GraceNotes/GraceNotes/Application/AppInstructionLocale.swift
@@ -17,10 +17,16 @@ enum AppInstructionLocale: Equatable, Sendable {
         return .english
     }
 
-    /// BCP 47 tags are case-insensitive; `Bundle` may return `zh-Hans` or `zh-hans`.
-    /// Require `zh-Hans` as a full tag or as the language-script prefix before the next subtag (`zh-Hans-CN`, …), not `zh-Hant`.
+    /// Uses `Locale.Language` so legacy tags (`zh_CN`, `zh_Hans_CN`) and bare `zh` resolve like the system,
+    /// instead of brittle `zh-hans` / `zh-hans-` string prefix checks that miss underscore forms.
     private static func isSimplifiedChineseUIIdentifier(_ identifier: String) -> Bool {
-        let tag = identifier.lowercased()
-        return tag == "zh-hans" || tag.hasPrefix("zh-hans-")
+        let language = Locale.Language(identifier: identifier)
+        guard language.languageCode?.identifier == "zh" else {
+            return false
+        }
+        guard let script = language.script?.identifier else {
+            return false
+        }
+        return script.caseInsensitiveCompare("Hans") == .orderedSame
     }
 }

--- a/GraceNotes/GraceNotes/Application/StartupCoordinator.swift
+++ b/GraceNotes/GraceNotes/Application/StartupCoordinator.swift
@@ -1,5 +1,11 @@
 import Combine
 import Foundation
+import os
+
+private let startupCoordinatorLogger = Logger(
+    subsystem: "com.gracenotes.GraceNotes",
+    category: "StartupCoordinator"
+)
 
 @MainActor
 final class StartupCoordinator: ObservableObject {
@@ -100,7 +106,7 @@ final class StartupCoordinator: ObservableObject {
                 let controller = try await runPersistence()
                 await MainActor.run { [weak self] in
                     guard let self else {
-                        PerformanceTrace.end("StartupCoordinator.startupAttempt.superseded", startedAt: trace)
+                        PerformanceTrace.end("StartupCoordinator.startupAttempt.teardown", startedAt: trace)
                         return
                     }
                     self.handleStartupSuccess(controller, attemptID: attemptID, traceStart: trace)
@@ -108,7 +114,7 @@ final class StartupCoordinator: ObservableObject {
             } catch {
                 await MainActor.run { [weak self] in
                     guard let self else {
-                        PerformanceTrace.end("StartupCoordinator.startupAttempt.superseded", startedAt: trace)
+                        PerformanceTrace.end("StartupCoordinator.startupAttempt.teardown", startedAt: trace)
                         return
                     }
                     self.handleStartupFailure(error, attemptID: attemptID, traceStart: trace)
@@ -228,11 +234,9 @@ final class StartupCoordinator: ObservableObject {
     }
 
     private func startupErrorMessage(from error: Error) -> String {
-        if let localizedError = error as? LocalizedError,
-           let message = localizedError.errorDescription,
-           !message.isEmpty {
-            return message
-        }
+        startupCoordinatorLogger.error(
+            "Persistence startup failed: \(String(reflecting: error), privacy: .public)"
+        )
         return String(localized: "startup.error.setupFailed")
     }
 }

--- a/GraceNotes/GraceNotes/Data/Models/Entry.swift
+++ b/GraceNotes/GraceNotes/Data/Models/Entry.swift
@@ -13,9 +13,14 @@ struct JournalItem: Codable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         id = try container.decodeIfPresent(UUID.self, forKey: .id) ?? UUID()
-        fullText = try container.decode(String.self, forKey: .fullText)
-        _ = try container.decodeIfPresent(String.self, forKey: .entryLabel)
-        _ = try container.decodeIfPresent(String.self, forKey: .chipLabel)
+        let entryLabel = try container.decodeIfPresent(String.self, forKey: .entryLabel)
+        let chipLabel = try container.decodeIfPresent(String.self, forKey: .chipLabel)
+        if let full = try container.decodeIfPresent(String.self, forKey: .fullText) {
+            fullText = full
+        } else {
+            // Legacy rows may omit `fullText` but still carry `entryLabel` / `chipLabel` (see export import).
+            fullText = entryLabel ?? chipLabel ?? ""
+        }
         _ = try container.decodeIfPresent(Bool.self, forKey: .isTruncated)
     }
 

--- a/GraceNotes/GraceNotes/Data/Models/Entry.swift
+++ b/GraceNotes/GraceNotes/Data/Models/Entry.swift
@@ -19,7 +19,7 @@ struct JournalItem: Codable {
             fullText = full
         } else {
             // Legacy rows may omit `fullText` but still carry `entryLabel` / `chipLabel` (see export import).
-            fullText = entryLabel ?? chipLabel ?? ""
+            fullText = Self.firstNonEmptyTrimmed(entryLabel, chipLabel)
         }
         _ = try container.decodeIfPresent(Bool.self, forKey: .isTruncated)
     }
@@ -28,6 +28,18 @@ struct JournalItem: Codable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(id, forKey: .id)
         try container.encode(fullText, forKey: .fullText)
+    }
+
+    /// First non-empty string after trimming; order matches legacy `JournalDataExportItem` preference (`entryLabel` then `chipLabel`).
+    private static func firstNonEmptyTrimmed(_ entryLabel: String?, _ chipLabel: String?) -> String {
+        for candidate in [entryLabel, chipLabel] {
+            guard let candidate else { continue }
+            let trimmed = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                return trimmed
+            }
+        }
+        return ""
     }
 
     private enum CodingKeys: String, CodingKey {

--- a/GraceNotes/GraceNotes/Data/Persistence/DemoDataSeeder.swift
+++ b/GraceNotes/GraceNotes/Data/Persistence/DemoDataSeeder.swift
@@ -16,9 +16,8 @@ enum DemoDataSeeder {
         }
 
         let today = calendar.startOfDay(for: now)
-        let entries = makeSeedEntries(today: today, now: now, calendar: calendar)
-        guard !entries.isEmpty else {
-            PerformanceTrace.end("DemoDataSeeder.seedIfNeeded.noEntries", startedAt: seedTrace)
+        guard let entries = makeSeedEntries(today: today, now: now, calendar: calendar) else {
+            PerformanceTrace.end("DemoDataSeeder.seedIfNeeded.noEntries.weekResolutionFailed", startedAt: seedTrace)
             return
         }
 
@@ -41,12 +40,12 @@ enum DemoDataSeeder {
         if savedVersion != seedVersion { return true }
 
         let today = calendar.startOfDay(for: now)
-        return fetchDemoJournalForDay(today, context: context, calendar: calendar) == nil
+        return fetchJournalForDayStart(today, context: context, calendar: calendar) == nil
     }
 
     private static func upsertEntry(_ payload: DemoEntryPayload, context: ModelContext, calendar: Calendar, now: Date) {
         let dayStart = calendar.startOfDay(for: payload.entryDate)
-        if let existing = fetchDemoJournalForDay(dayStart, context: context, calendar: calendar) {
+        if let existing = fetchJournalForDayStart(dayStart, context: context, calendar: calendar) {
             existing.gratitudes = payload.gratitudes
             existing.needs = payload.needs
             existing.people = payload.people
@@ -73,11 +72,11 @@ enum DemoDataSeeder {
         )
     }
 
-    private static func makeSeedEntries(today: Date, now: Date, calendar: Calendar) -> [DemoEntryPayload] {
+    private static func makeSeedEntries(today: Date, now: Date, calendar: Calendar) -> [DemoEntryPayload]? {
         guard let days = rollingWeekDayStarts(from: today, calendar: calendar)
             ?? fallbackWeekDayStarts(from: today, calendar: calendar) else {
             assertionFailure("DemoDataSeeder: could not resolve seven day starts for demo week")
-            return []
+            return nil
         }
 
         let week = [
@@ -262,23 +261,22 @@ enum DemoDataSeeder {
     private static func item(_ fullText: String) -> Entry {
         Entry(fullText: fullText)
     }
-}
 
-/// Uses `[dayStart, nextDay)` like ``JournalRepository/fetchEntry(dayStart:context:)``.
-private func fetchDemoJournalForDay(_ date: Date, context: ModelContext, calendar: Calendar) -> Journal? {
-    let dayStart = calendar.startOfDay(for: date)
-    guard let nextDay = calendar.date(byAdding: .day, value: 1, to: dayStart) else { return nil }
-    let descriptor = FetchDescriptor<Journal>(
-        predicate: #Predicate { entry in
-            entry.entryDate >= dayStart && entry.entryDate < nextDay
-        },
-        sortBy: [SortDescriptor(\.createdAt, order: .forward)]
-    )
-    do {
-        return try context.fetch(descriptor).first
-    } catch {
-        assertionFailure("DemoDataSeeder: failed to fetch journal for demo seeding: \(error)")
-        return nil
+    /// Resolves the journal for `[dayStart, nextDay)` using ``JournalRepository/fetchEntry(dayStart:context:)``
+    /// so duplicate rows for one calendar day match the app’s canonical choice. Only demo builds use this
+    /// (`USE_DEMO_DATABASE`); the store is not tagged separately from ordinary journal rows.
+    private static func fetchJournalForDayStart(
+        _ dayStart: Date,
+        context: ModelContext,
+        calendar: Calendar
+    ) -> Journal? {
+        let repository = JournalRepository(calendar: calendar)
+        do {
+            return try repository.fetchEntry(dayStart: dayStart, context: context)
+        } catch {
+            assertionFailure("DemoDataSeeder: failed to fetch journal for demo seeding: \(error)")
+            return nil
+        }
     }
 }
 

--- a/GraceNotes/GraceNotes/Data/Persistence/DemoDataSeeder.swift
+++ b/GraceNotes/GraceNotes/Data/Persistence/DemoDataSeeder.swift
@@ -4,17 +4,17 @@ import SwiftData
 
 @MainActor
 enum DemoDataSeeder {
-    private static let seedVersion = 5
+    private static let seedVersion = 6
     private static let seedVersionKey = "demoDataSeedVersion"
 
     static func seedIfNeeded(context: ModelContext, calendar: Calendar = .current) {
         let seedTrace = PerformanceTrace.begin("DemoDataSeeder.seedIfNeeded")
-        guard shouldSeed(context: context, calendar: calendar) else {
+        let now = Date.now
+        guard shouldSeed(context: context, calendar: calendar, now: now) else {
             PerformanceTrace.end("DemoDataSeeder.seedIfNeeded.skipped", startedAt: seedTrace)
             return
         }
 
-        let now = Date.now
         let today = calendar.startOfDay(for: now)
         let entries = makeSeedEntries(today: today, now: now, calendar: calendar)
 
@@ -32,11 +32,11 @@ enum DemoDataSeeder {
         }
     }
 
-    private static func shouldSeed(context: ModelContext, calendar: Calendar) -> Bool {
+    private static func shouldSeed(context: ModelContext, calendar: Calendar, now: Date) -> Bool {
         let savedVersion = UserDefaults.standard.integer(forKey: seedVersionKey)
         if savedVersion != seedVersion { return true }
 
-        let today = calendar.startOfDay(for: .now)
+        let today = calendar.startOfDay(for: now)
         return fetchEntry(for: today, context: context, calendar: calendar) == nil
     }
 
@@ -90,16 +90,25 @@ enum DemoDataSeeder {
         let fiveDaysAgo = calendar.date(byAdding: .day, value: -5, to: today) ?? today
         let sixDaysAgo = calendar.date(byAdding: .day, value: -6, to: today) ?? today
 
-        return [
+        let week = [
             makeTodayPayload(entryDate: today, completedAt: now),
             makeYesterdayPayload(entryDate: yesterday),
             makeBlankPayload(entryDate: twoDaysAgo),
             makeThreeDaysAgoPayload(entryDate: threeDaysAgo, completedAt: now),
             makeFourDaysAgoPayload(entryDate: fourDaysAgo),
             makeFiveDaysAgoPayload(entryDate: fiveDaysAgo),
-            makeSixDaysAgoPayload(entryDate: sixDaysAgo),
-            demoDecember2025Entry(calendar: calendar, now: now)
+            makeSixDaysAgoPayload(entryDate: sixDaysAgo)
         ]
+
+        // The anchored December row must not share a calendar day with the rolling week, or the
+        // later upsert would overwrite the intended demo for that day.
+        let anchored = demoDecember2025Entry(calendar: calendar, now: now)
+        let anchoredDay = calendar.startOfDay(for: anchored.entryDate)
+        let weekDays = Set(week.map { calendar.startOfDay(for: $0.entryDate) })
+        if weekDays.contains(anchoredDay) {
+            return week
+        }
+        return week + [anchored]
     }
 
     private static func makeTodayPayload(entryDate: Date, completedAt: Date) -> DemoEntryPayload {

--- a/GraceNotes/GraceNotes/Data/Persistence/DemoDataSeeder.swift
+++ b/GraceNotes/GraceNotes/Data/Persistence/DemoDataSeeder.swift
@@ -4,7 +4,7 @@ import SwiftData
 
 @MainActor
 enum DemoDataSeeder {
-    private static let seedVersion = 6
+    private static let seedVersion = 7
     private static let seedVersionKey = "demoDataSeedVersion"
 
     static func seedIfNeeded(context: ModelContext, calendar: Calendar = .current) {
@@ -17,6 +17,10 @@ enum DemoDataSeeder {
 
         let today = calendar.startOfDay(for: now)
         let entries = makeSeedEntries(today: today, now: now, calendar: calendar)
+        guard !entries.isEmpty else {
+            PerformanceTrace.end("DemoDataSeeder.seedIfNeeded.noEntries", startedAt: seedTrace)
+            return
+        }
 
         for payload in entries {
             upsertEntry(payload, context: context, calendar: calendar, now: now)
@@ -37,12 +41,12 @@ enum DemoDataSeeder {
         if savedVersion != seedVersion { return true }
 
         let today = calendar.startOfDay(for: now)
-        return fetchEntry(for: today, context: context, calendar: calendar) == nil
+        return fetchDemoJournalForDay(today, context: context, calendar: calendar) == nil
     }
 
     private static func upsertEntry(_ payload: DemoEntryPayload, context: ModelContext, calendar: Calendar, now: Date) {
         let dayStart = calendar.startOfDay(for: payload.entryDate)
-        if let existing = fetchEntry(for: dayStart, context: context, calendar: calendar) {
+        if let existing = fetchDemoJournalForDay(dayStart, context: context, calendar: calendar) {
             existing.gratitudes = payload.gratitudes
             existing.needs = payload.needs
             existing.people = payload.people
@@ -69,35 +73,21 @@ enum DemoDataSeeder {
         )
     }
 
-    /// Uses `[dayStart, nextDay)` like ``JournalRepository/fetchEntry(dayStart:context:)``.
-    private static func fetchEntry(for date: Date, context: ModelContext, calendar: Calendar) -> Journal? {
-        let dayStart = calendar.startOfDay(for: date)
-        guard let nextDay = calendar.date(byAdding: .day, value: 1, to: dayStart) else { return nil }
-        let descriptor = FetchDescriptor<Journal>(
-            predicate: #Predicate { entry in
-                entry.entryDate >= dayStart && entry.entryDate < nextDay
-            },
-            sortBy: [SortDescriptor(\.createdAt, order: .forward)]
-        )
-        return try? context.fetch(descriptor).first
-    }
-
     private static func makeSeedEntries(today: Date, now: Date, calendar: Calendar) -> [DemoEntryPayload] {
-        let yesterday = calendar.date(byAdding: .day, value: -1, to: today) ?? today
-        let twoDaysAgo = calendar.date(byAdding: .day, value: -2, to: today) ?? today
-        let threeDaysAgo = calendar.date(byAdding: .day, value: -3, to: today) ?? today
-        let fourDaysAgo = calendar.date(byAdding: .day, value: -4, to: today) ?? today
-        let fiveDaysAgo = calendar.date(byAdding: .day, value: -5, to: today) ?? today
-        let sixDaysAgo = calendar.date(byAdding: .day, value: -6, to: today) ?? today
+        guard let days = rollingWeekDayStarts(from: today, calendar: calendar)
+            ?? fallbackWeekDayStarts(from: today, calendar: calendar) else {
+            assertionFailure("DemoDataSeeder: could not resolve seven day starts for demo week")
+            return []
+        }
 
         let week = [
-            makeTodayPayload(entryDate: today, completedAt: now),
-            makeYesterdayPayload(entryDate: yesterday),
-            makeBlankPayload(entryDate: twoDaysAgo),
-            makeThreeDaysAgoPayload(entryDate: threeDaysAgo, completedAt: now),
-            makeFourDaysAgoPayload(entryDate: fourDaysAgo),
-            makeFiveDaysAgoPayload(entryDate: fiveDaysAgo),
-            makeSixDaysAgoPayload(entryDate: sixDaysAgo)
+            makeTodayPayload(entryDate: days[0], completedAt: now),
+            makeYesterdayPayload(entryDate: days[1]),
+            makeBlankPayload(entryDate: days[2]),
+            makeThreeDaysAgoPayload(entryDate: days[3], completedAt: now),
+            makeFourDaysAgoPayload(entryDate: days[4]),
+            makeFiveDaysAgoPayload(entryDate: days[5]),
+            makeSixDaysAgoPayload(entryDate: days[6])
         ]
 
         // The anchored December row must not share a calendar day with the rolling week, or the
@@ -274,13 +264,63 @@ enum DemoDataSeeder {
     }
 }
 
+/// Uses `[dayStart, nextDay)` like ``JournalRepository/fetchEntry(dayStart:context:)``.
+private func fetchDemoJournalForDay(_ date: Date, context: ModelContext, calendar: Calendar) -> Journal? {
+    let dayStart = calendar.startOfDay(for: date)
+    guard let nextDay = calendar.date(byAdding: .day, value: 1, to: dayStart) else { return nil }
+    let descriptor = FetchDescriptor<Journal>(
+        predicate: #Predicate { entry in
+            entry.entryDate >= dayStart && entry.entryDate < nextDay
+        },
+        sortBy: [SortDescriptor(\.createdAt, order: .forward)]
+    )
+    do {
+        return try context.fetch(descriptor).first
+    } catch {
+        assertionFailure("DemoDataSeeder: failed to fetch journal for demo seeding: \(error)")
+        return nil
+    }
+}
+
+/// Seven consecutive local calendar days ending at `today`, without collapsing failed `date(byAdding:)`
+/// steps to the same day.
+private func rollingWeekDayStarts(from today: Date, calendar: Calendar) -> [Date]? {
+    var result: [Date] = []
+    var cursor = today
+    for _ in 0..<7 {
+        result.append(calendar.startOfDay(for: cursor))
+        guard let prior = calendar.date(byAdding: .day, value: -1, to: cursor) else {
+            assertionFailure("DemoDataSeeder: calendar could not subtract one day from \(cursor)")
+            return nil
+        }
+        cursor = prior
+    }
+    return result
+}
+
+/// Fallback when the day-by-day chain fails (rare); avoids `?? today` collapsing multiple rows onto one day.
+private func fallbackWeekDayStarts(from today: Date, calendar: Calendar) -> [Date]? {
+    var result: [Date] = []
+    for offset in 0..<7 {
+        guard let offsetDate = calendar.date(byAdding: .day, value: -offset, to: today) else {
+            assertionFailure("DemoDataSeeder: calendar could not subtract \(offset) days from today")
+            return nil
+        }
+        result.append(calendar.startOfDay(for: offsetDate))
+    }
+    return result
+}
+
 /// Anchored historical row so Demo builds can sanity-check Past/review behavior across calendar years.
+/// Gregorian components avoid misinterpreting year/month/day when `Calendar.current` is not Gregorian.
 private func demoDecember2025Entry(calendar: Calendar, now: Date) -> DemoEntryPayload {
+    var gregorian = Calendar(identifier: .gregorian)
+    gregorian.timeZone = calendar.timeZone
     var parts = DateComponents()
     parts.year = 2025
     parts.month = 12
     parts.day = 10
-    let raw = calendar.date(from: parts) ?? calendar.startOfDay(for: now)
+    let raw = gregorian.date(from: parts) ?? calendar.startOfDay(for: now)
     let entryDate = calendar.startOfDay(for: raw)
     return DemoEntryPayload(
         entryDate: entryDate,

--- a/GraceNotes/GraceNotes/Data/Persistence/DemoDataSeeder.swift
+++ b/GraceNotes/GraceNotes/Data/Persistence/DemoDataSeeder.swift
@@ -4,7 +4,7 @@ import SwiftData
 
 @MainActor
 enum DemoDataSeeder {
-    private static let seedVersion = 6
+    private static let seedVersion = 7
     private static let seedVersionKey = "demoDataSeedVersion"
 
     static func seedIfNeeded(context: ModelContext, calendar: Calendar = .current) {
@@ -100,12 +100,9 @@ enum DemoDataSeeder {
             makeSixDaysAgoPayload(entryDate: sixDaysAgo)
         ]
 
-        // The anchored December row must not share a calendar day with the rolling week, or the
-        // later upsert would overwrite the intended demo for that day.
-        let anchored = demoDecember2025Entry(calendar: calendar, now: now)
-        let anchoredDay = calendar.startOfDay(for: anchored.entryDate)
-        let weekDays = Set(week.map { calendar.startOfDay(for: $0.entryDate) })
-        if weekDays.contains(anchoredDay) {
+        // Historical anchor uses the day before the oldest day in the rolling week (`today-6`), so it
+        // never shares a calendar day with the seven seeded rows (collision-proof without a runtime check).
+        guard let anchored = demoHistoricalAnchorEntry(today: today, calendar: calendar) else {
             return week
         }
         return week + [anchored]
@@ -274,31 +271,29 @@ enum DemoDataSeeder {
     }
 }
 
-/// Anchored historical row so Demo builds can sanity-check Past/review behavior across calendar years.
-private func demoDecember2025Entry(calendar: Calendar, now: Date) -> DemoEntryPayload {
-    var parts = DateComponents()
-    parts.year = 2025
-    parts.month = 12
-    parts.day = 10
-    let raw = calendar.date(from: parts) ?? calendar.startOfDay(for: now)
+/// Older-than-week row so Demo builds can sanity-check Past/review behavior
+/// (often crosses calendar years near January).
+private func demoHistoricalAnchorEntry(today: Date, calendar: Calendar) -> DemoEntryPayload? {
+    guard let raw = calendar.date(byAdding: .day, value: -7, to: today) else { return nil }
     let entryDate = calendar.startOfDay(for: raw)
     return DemoEntryPayload(
         entryDate: entryDate,
         gratitudes: [
-            demoLine("Grateful for closing out 2025 with calm routines"),
+            demoLine("Grateful for steady routines before this week"),
             demoLine("Thankful for friends who checked in"),
             demoLine("Quiet evening to reflect")
         ],
         needs: [
-            demoLine("Need margin before the new year"),
-            demoLine("Want to plan January lightly")
+            demoLine("Need margin as schedules shift"),
+            demoLine("Want to plan the week lightly")
         ],
         people: [
-            demoLine("Thinking of family gathering plans"),
+            demoLine("Thinking of family plans"),
             demoLine("Grateful for community support")
         ],
-        readingNotes: "Demo note dated in 2025 for Past-tab and rhythm checks.",
-        reflections: "This entry is intentionally in December 2025 to verify history outside the current week.",
+        readingNotes: "Demo note outside the rolling week for Past-tab and rhythm checks.",
+        reflections: "This entry is intentionally one day older than the seeded week "
+            + "to verify history outside the current seven days.",
         completedAt: nil
     )
 }

--- a/GraceNotes/GraceNotes/Data/Persistence/SwiftData/PersistenceController.swift
+++ b/GraceNotes/GraceNotes/Data/Persistence/SwiftData/PersistenceController.swift
@@ -56,6 +56,7 @@ final class PersistenceController {
 
     static func makeForUITesting() throws -> PersistenceController {
         resetUITestStoreIfRequested()
+        removeLegacyUITestStoreFiles()
         let startupTrace = PerformanceTrace.begin("PersistenceController.makeForUITesting")
         let schema = Schema([Journal.self])
         let configuration = ModelConfiguration(
@@ -74,7 +75,7 @@ final class PersistenceController {
             try seedUITestDataIfNeeded(in: container)
         } catch {
             PerformanceTrace.end("PersistenceController.makeForUITesting.failed", startedAt: startupTrace)
-            throw error
+            throw PersistenceControllerError.unableToSeedUITestData(error)
         }
         PerformanceTrace.end("PersistenceController.makeForUITesting", startedAt: startupTrace)
         let snapshot = PersistenceRuntimeSnapshot.forDiskLaunch(
@@ -170,7 +171,7 @@ final class PersistenceController {
         return "ui-test-\(hex).store"
     }
 
-    private static var uiTestStoreURL: URL {
+    private static var uiTestDirectoryURL: URL {
         let fileManager = FileManager.default
         let appSupportURL = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
             ?? URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
@@ -178,6 +179,41 @@ final class PersistenceController {
         if !fileManager.fileExists(atPath: uiTestDirectory.path) {
             try? fileManager.createDirectory(at: uiTestDirectory, withIntermediateDirectories: true)
         }
+        return uiTestDirectory
+    }
+
+    /// Removes pre-hashing `ui-test-*.store` files (session key embedded in the filename) so Application Support
+    /// does not accumulate orphaned stores after the SHA-256 naming change.
+    private static func removeLegacyUITestStoreFiles() {
+        let fileManager = FileManager.default
+        let uiTestDirectory = uiTestDirectoryURL
+        guard let contents = try? fileManager.contentsOfDirectory(
+            at: uiTestDirectory,
+            includingPropertiesForKeys: nil
+        ) else {
+            return
+        }
+        for url in contents {
+            let name = url.lastPathComponent
+            guard name.hasPrefix("ui-test-"), name.hasSuffix(".store") else { continue }
+            if isHashedUITestStoreFileName(name) {
+                continue
+            }
+            try? fileManager.removeItem(at: url)
+        }
+    }
+
+    /// `true` when `name` matches `^ui-test-[0-9a-f]{64}\.store$` (current on-disk naming).
+    private static func isHashedUITestStoreFileName(_ name: String) -> Bool {
+        guard name.hasPrefix("ui-test-"), name.hasSuffix(".store") else { return false }
+        let middle = name.dropFirst("ui-test-".count).dropLast(".store".count)
+        guard middle.count == 64 else { return false }
+        let hexDigits = CharacterSet(charactersIn: "0123456789abcdef")
+        return middle.unicodeScalars.allSatisfy { hexDigits.contains($0) }
+    }
+
+    private static var uiTestStoreURL: URL {
+        let uiTestDirectory = uiTestDirectoryURL
 
         // Prefer XCTest's config path so parallel runs stay isolated. After `terminate()` + `launch()`,
         // that env var is often missing in the app; reuse the last key so relaunch hits the same store.
@@ -279,6 +315,7 @@ final class PersistenceController {
 
 enum PersistenceControllerError: LocalizedError {
     case unableToCreateContainer(Error)
+    case unableToSeedUITestData(Error)
 
     var errorDescription: String? {
         String(localized: "startup.error.setupFailed")

--- a/GraceNotes/GraceNotes/DesignSystem/Color+Hex.swift
+++ b/GraceNotes/GraceNotes/DesignSystem/Color+Hex.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+extension Color {
+    /// 24-bit `RRGGBB`. High bits are masked so `AARRGGBB`-style literals still resolve to the same sRGB triplet.
+    init(hex: UInt) {
+        let rgb = hex & 0xFFFFFF
+        let red = Double((rgb >> 16) & 0xFF) / 255
+        let green = Double((rgb >> 8) & 0xFF) / 255
+        let blue = Double(rgb & 0xFF) / 255
+        self.init(.sRGB, red: red, green: green, blue: blue)
+    }
+}

--- a/GraceNotes/GraceNotes/DesignSystem/Theme.swift
+++ b/GraceNotes/GraceNotes/DesignSystem/Theme.swift
@@ -347,50 +347,14 @@ struct WarmPaperPressStyle: ButtonStyle {
     }
 }
 
-// MARK: - Adaptive color (hex parsing: `Color+Hex.swift`)
-
-/// Shared 24-bit `0xRRGGBB` parsing; masks to the low 24 bits so stray high bits cannot skew channels.
-private struct HexRGBComponents {
-    let red: CGFloat
-    let green: CGFloat
-    let blue: CGFloat
-
-    init(hex: UInt) {
-        let rgb = UInt32(truncatingIfNeeded: hex) & 0xFFFFFF
-        red = CGFloat((rgb >> 16) & 0xFF) / 255
-        green = CGFloat((rgb >> 8) & 0xFF) / 255
-        blue = CGFloat(rgb & 0xFF) / 255
-    }
-}
-
-private extension UIColor {
-    convenience init(hex: UInt) {
-        let rgb = HexRGBComponents(hex: hex)
-        self.init(red: rgb.red, green: rgb.green, blue: rgb.blue, alpha: 1)
-    }
-}
-
-extension UIColor {
-    /// 24-bit `RRGGBB`. High bits are masked so `AARRGGBB`-style literals still resolve to the same sRGB triplet.
-    convenience init(hex: UInt) {
-        let rgb = hex & 0xFFFFFF
-        let red = CGFloat((rgb >> 16) & 0xFF) / 255
-        let green = CGFloat((rgb >> 8) & 0xFF) / 255
-        let blue = CGFloat(rgb & 0xFF) / 255
-        self.init(red: red, green: green, blue: blue, alpha: 1)
-    }
-}
+// MARK: - Adaptive color (24-bit hex: `Color+Hex.swift`)
 
 extension Color {
-    init(hex: UInt) {
-        self.init(UIColor(hex: hex))
-    }
-
     static func adaptive(lightHex: UInt, darkHex: UInt) -> Color {
         Color(
             UIColor { traitCollection in
                 let colorHex = traitCollection.userInterfaceStyle == .dark ? darkHex : lightHex
-                return UIColor(hex: colorHex)
+                return UIColor(Color(hex: colorHex))
             }
         )
     }

--- a/GraceNotes/GraceNotes/DesignSystem/Theme.swift
+++ b/GraceNotes/GraceNotes/DesignSystem/Theme.swift
@@ -349,12 +349,18 @@ struct WarmPaperPressStyle: ButtonStyle {
 
 // MARK: - Color Hex Extension
 
+private extension UIColor {
+    convenience init(hex: UInt) {
+        let red = CGFloat((hex >> 16) & 0xFF) / 255
+        let green = CGFloat((hex >> 8) & 0xFF) / 255
+        let blue = CGFloat(hex & 0xFF) / 255
+        self.init(red: red, green: green, blue: blue, alpha: 1)
+    }
+}
+
 private extension Color {
     init(hex: UInt) {
-        let red = Double((hex >> 16) & 0xFF) / 255
-        let green = Double((hex >> 8) & 0xFF) / 255
-        let blue = Double(hex & 0xFF) / 255
-        self.init(red: red, green: green, blue: blue)
+        self.init(UIColor(hex: hex))
     }
 
     static func adaptive(lightHex: UInt, darkHex: UInt) -> Color {
@@ -364,14 +370,5 @@ private extension Color {
                 return UIColor(hex: colorHex)
             }
         )
-    }
-}
-
-private extension UIColor {
-    convenience init(hex: UInt) {
-        let red = CGFloat((hex >> 16) & 0xFF) / 255
-        let green = CGFloat((hex >> 8) & 0xFF) / 255
-        let blue = CGFloat(hex & 0xFF) / 255
-        self.init(red: red, green: green, blue: blue, alpha: 1)
     }
 }

--- a/GraceNotes/GraceNotes/DesignSystem/Theme.swift
+++ b/GraceNotes/GraceNotes/DesignSystem/Theme.swift
@@ -347,16 +347,9 @@ struct WarmPaperPressStyle: ButtonStyle {
     }
 }
 
-// MARK: - Color Hex Extension
+// MARK: - Adaptive color (hex parsing: `Color+Hex.swift`)
 
 private extension Color {
-    init(hex: UInt) {
-        let red = Double((hex >> 16) & 0xFF) / 255
-        let green = Double((hex >> 8) & 0xFF) / 255
-        let blue = Double(hex & 0xFF) / 255
-        self.init(red: red, green: green, blue: blue)
-    }
-
     static func adaptive(lightHex: UInt, darkHex: UInt) -> Color {
         Color(
             UIColor { traitCollection in
@@ -368,10 +361,12 @@ private extension Color {
 }
 
 private extension UIColor {
+    /// Matches `Color.init(hex:)` masking so light/dark adaptive pairs stay consistent with share-card hex colors.
     convenience init(hex: UInt) {
-        let red = CGFloat((hex >> 16) & 0xFF) / 255
-        let green = CGFloat((hex >> 8) & 0xFF) / 255
-        let blue = CGFloat(hex & 0xFF) / 255
+        let rgb = hex & 0xFFFFFF
+        let red = CGFloat((rgb >> 16) & 0xFF) / 255
+        let green = CGFloat((rgb >> 8) & 0xFF) / 255
+        let blue = CGFloat(rgb & 0xFF) / 255
         self.init(red: red, green: green, blue: blue, alpha: 1)
     }
 }

--- a/GraceNotes/GraceNotes/DesignSystem/Theme.swift
+++ b/GraceNotes/GraceNotes/DesignSystem/Theme.swift
@@ -349,16 +349,18 @@ struct WarmPaperPressStyle: ButtonStyle {
 
 // MARK: - Color Hex Extension
 
-private extension UIColor {
+extension UIColor {
+    /// 24-bit `RRGGBB`. High bits are masked so `AARRGGBB`-style literals still resolve to the same sRGB triplet.
     convenience init(hex: UInt) {
-        let red = CGFloat((hex >> 16) & 0xFF) / 255
-        let green = CGFloat((hex >> 8) & 0xFF) / 255
-        let blue = CGFloat(hex & 0xFF) / 255
+        let rgb = hex & 0xFFFFFF
+        let red = CGFloat((rgb >> 16) & 0xFF) / 255
+        let green = CGFloat((rgb >> 8) & 0xFF) / 255
+        let blue = CGFloat(rgb & 0xFF) / 255
         self.init(red: red, green: green, blue: blue, alpha: 1)
     }
 }
 
-private extension Color {
+extension Color {
     init(hex: UInt) {
         self.init(UIColor(hex: hex))
     }

--- a/GraceNotes/GraceNotes/Features/Journal/HistoryEntryGrouping.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/HistoryEntryGrouping.swift
@@ -59,6 +59,25 @@ enum HistoryEntryGrouping {
         guard let year = components.year, let month = components.month else {
             return calendar.startOfDay(for: date)
         }
+        return gregorianUTCMonthStartFromYearMonth(
+            year: year,
+            month: month,
+            calendar: calendar,
+            fallbackDate: date
+        )
+    }
+
+    /// When `date(from:)` cannot build the first of the month from normalized components but year and month
+    /// are still present, anchor at January 1 and add months so entries in the same calendar month share one bucket.
+    /// Exposed as `internal` for unit tests (`@testable`) because forcing the parent `date(from:)` failure in
+    /// `gregorianUTCMonthStart(for:)` is impractical to reproduce reliably across OS versions.
+    internal static func gregorianUTCMonthStartFromYearMonth(
+        year: Int,
+        month: Int,
+        calendar: Calendar,
+        fallbackDate: Date
+    ) -> Date {
+        // Ultra-defensive: if components ever produced garbage, avoid crashing and land in a plausible month.
         let clampedMonth = min(max(month, 1), 12)
         var yearStartComponents = DateComponents()
         yearStartComponents.timeZone = calendar.timeZone
@@ -70,9 +89,9 @@ enum HistoryEntryGrouping {
         yearStartComponents.second = 0
         yearStartComponents.nanosecond = 0
         guard let januaryFirst = calendar.date(from: yearStartComponents) else {
-            return calendar.startOfDay(for: date)
+            return calendar.startOfDay(for: fallbackDate)
         }
         return calendar.date(byAdding: .month, value: clampedMonth - 1, to: januaryFirst)
-            ?? calendar.startOfDay(for: date)
+            ?? calendar.startOfDay(for: fallbackDate)
     }
 }

--- a/GraceNotes/GraceNotes/Features/Journal/HistoryEntryGrouping.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/HistoryEntryGrouping.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SwiftData
 
 enum HistoryEntryGrouping {
     static func groupedByMonth(
@@ -10,7 +9,9 @@ enum HistoryEntryGrouping {
             monthKey(for: entry.entryDate, calendar: calendar)
         }
         return grouped.keys.sorted(by: >).map { month in
-            let groupedEntries = grouped[month] ?? []
+            let groupedEntries = (grouped[month] ?? []).sorted {
+                $0.entryDate > $1.entryDate
+            }
             return (month, groupedEntries)
         }
     }
@@ -21,6 +22,24 @@ enum HistoryEntryGrouping {
         if let intervalStart = calendar.dateInterval(of: .month, for: date)?.start {
             return intervalStart
         }
+        var components = calendar.dateComponents([.year, .month], from: date)
+        components.day = 1
+        components.hour = 0
+        components.minute = 0
+        components.second = 0
+        components.nanosecond = 0
+        if let normalized = calendar.date(from: components) {
+            return normalized
+        }
+        return gregorianUTCMonthStart(for: date)
+    }
+
+    /// When the active calendar cannot form a month start, anchor by Gregorian UTC year/month
+    /// so entries in the same month are not split by day. `startOfDay` is only used if even
+    /// this normalization fails.
+    private static func gregorianUTCMonthStart(for date: Date) -> Date {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
         var components = calendar.dateComponents([.year, .month], from: date)
         components.day = 1
         components.hour = 0

--- a/GraceNotes/GraceNotes/Features/Journal/HistoryEntryGrouping.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/HistoryEntryGrouping.swift
@@ -3,10 +3,17 @@ import Foundation
 enum HistoryEntryGrouping {
     static func groupedByMonth(
         entries: [Journal],
-        calendar: Calendar
+        calendar: Calendar,
+        monthKeyResolver: ((Date, Calendar) -> Date)? = nil
     ) -> [(key: Date, entries: [Journal])] {
+        let resolveMonthKey: (Date) -> Date = { date in
+            if let monthKeyResolver {
+                return monthKeyResolver(date, calendar)
+            }
+            return monthKey(for: date, calendar: calendar)
+        }
         let grouped = Dictionary(grouping: entries) { entry -> Date in
-            monthKey(for: entry.entryDate, calendar: calendar)
+            resolveMonthKey(entry.entryDate)
         }
         return grouped.keys.sorted(by: >).map { month in
             let groupedEntries = (grouped[month] ?? []).sorted {
@@ -19,8 +26,9 @@ enum HistoryEntryGrouping {
         }
     }
 
-    /// Start of the calendar month containing `date`. Used so a failed `date(from:)`
-    /// does not fall back to the raw entry timestamp (which would split one month into many buckets).
+    /// Returns the start of the calendar month containing `date` when possible.
+    /// If month normalization fails, falls back to the start of the day rather than the raw
+    /// entry timestamp, which still avoids splitting a single day into many buckets.
     private static func monthKey(for date: Date, calendar: Calendar) -> Date {
         if let intervalStart = calendar.dateInterval(of: .month, for: date)?.start {
             return intervalStart

--- a/GraceNotes/GraceNotes/Features/Journal/HistoryEntryGrouping.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/HistoryEntryGrouping.swift
@@ -39,7 +39,7 @@ enum HistoryEntryGrouping {
         if let normalized = calendar.date(from: components) {
             return normalized
         }
-        return gregorianMonthStart(for: date, timeZone: calendar.timeZone)
+        return gregorianUTCMonthStart(for: date)
     }
 
     /// When the active calendar cannot form a month start, anchor by Gregorian UTC year/month

--- a/GraceNotes/GraceNotes/Features/Journal/HistoryEntryGrouping.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/HistoryEntryGrouping.swift
@@ -38,11 +38,15 @@ enum HistoryEntryGrouping {
     }
 
     /// When the active calendar cannot form a month start, anchor by Gregorian UTC year/month
-    /// so entries in the same month are not split by day. `startOfDay` is only used if even
-    /// this normalization fails.
+    /// so entries in the same month are not split by day. If direct month normalization fails
+    /// but year and month are known, derive the month from January 1; only then fall back to
+    /// `startOfDay(for:)` (which can still split one month across buckets when all else fails).
     private static func gregorianUTCMonthStart(for date: Date) -> Date {
         var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)
+            ?? TimeZone(identifier: "UTC")
+            ?? TimeZone(abbreviation: "GMT")
+            ?? .current
         var components = calendar.dateComponents([.year, .month], from: date)
         components.day = 1
         components.hour = 0
@@ -52,6 +56,23 @@ enum HistoryEntryGrouping {
         if let normalized = calendar.date(from: components) {
             return normalized
         }
-        return calendar.startOfDay(for: date)
+        guard let year = components.year, let month = components.month else {
+            return calendar.startOfDay(for: date)
+        }
+        let clampedMonth = min(max(month, 1), 12)
+        var yearStartComponents = DateComponents()
+        yearStartComponents.timeZone = calendar.timeZone
+        yearStartComponents.year = year
+        yearStartComponents.month = 1
+        yearStartComponents.day = 1
+        yearStartComponents.hour = 0
+        yearStartComponents.minute = 0
+        yearStartComponents.second = 0
+        yearStartComponents.nanosecond = 0
+        guard let januaryFirst = calendar.date(from: yearStartComponents) else {
+            return calendar.startOfDay(for: date)
+        }
+        return calendar.date(byAdding: .month, value: clampedMonth - 1, to: januaryFirst)
+            ?? calendar.startOfDay(for: date)
     }
 }

--- a/GraceNotes/GraceNotes/Features/Journal/HistoryEntryGrouping.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/HistoryEntryGrouping.swift
@@ -31,15 +31,16 @@ enum HistoryEntryGrouping {
         if let normalized = calendar.date(from: components) {
             return normalized
         }
-        return gregorianUTCMonthStart(for: date)
+        return gregorianMonthStart(for: date, timeZone: calendar.timeZone)
     }
 
-    /// When the active calendar cannot form a month start, anchor by Gregorian UTC year/month
-    /// so entries in the same month are not split by day. `startOfDay` is only used if even
-    /// this normalization fails.
-    private static func gregorianUTCMonthStart(for date: Date) -> Date {
+    /// When the active calendar cannot form a month start, anchor by Gregorian year/month
+    /// in the caller's time zone so entries in the same month are not split by day and
+    /// the resulting key remains stable when later formatted locally. `startOfDay` is
+    /// only used if even this normalization fails.
+    private static func gregorianMonthStart(for date: Date, timeZone: TimeZone) -> Date {
         var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        calendar.timeZone = timeZone
         var components = calendar.dateComponents([.year, .month], from: date)
         components.day = 1
         components.hour = 0

--- a/GraceNotes/GraceNotes/Features/Journal/Services/JournalShareRenderer.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/JournalShareRenderer.swift
@@ -14,9 +14,8 @@ enum JournalShareRenderer {
         renderer.scale = Self.recommendedPixelScale()
         guard let image = renderer.uiImage else { return nil }
         guard image.size.width > 0, image.size.height > 0 else { return nil }
-        if let cgImage = image.cgImage {
-            guard cgImage.width > 0, cgImage.height > 0 else { return nil }
-        }
+        guard let cgImage = image.cgImage else { return nil }
+        guard cgImage.width > 0, cgImage.height > 0 else { return nil }
         return image
     }
 
@@ -28,15 +27,18 @@ enum JournalShareRenderer {
     }
 
     /// `ImageRenderer` runs without hosting in a window; `UITraitCollection.current.displayScale` can be
-    /// unset or 1× while the device screen is Retina. Prefer the foreground active window scene scale, then
-    /// trait, then screen, then a safe default. Ignores background scenes so multi-window layouts do not
-    /// pick an unrelated display’s scale.
+    /// unset or 1× while the device screen is Retina. Prefer the foreground window scene scale (active or
+    /// inactive — a presented sheet can leave the root scene inactive), then trait, then screen, then a
+    /// safe default. Ignores background/unattached scenes so multi-window layouts do not pick an unrelated
+    /// display’s scale.
     @MainActor
     private static func recommendedPixelScale() -> CGFloat {
         let traitScale = UITraitCollection.current.displayScale
         let sceneScale = UIApplication.shared.connectedScenes
             .compactMap { $0 as? UIWindowScene }
-            .filter { $0.activationState == .foregroundActive }
+            .filter {
+                $0.activationState == .foregroundActive || $0.activationState == .foregroundInactive
+            }
             .map { $0.screen.scale }
             .max() ?? 0
         let screenScale = UIScreen.main.scale

--- a/GraceNotes/GraceNotes/Features/Journal/Services/JournalShareRenderer.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/JournalShareRenderer.swift
@@ -1,26 +1,40 @@
 import SwiftUI
 import UIKit
 
+/// Layout metrics for fixed-width share export (`JournalShareCardView` with `usesFixedExportWidth == true`)
+/// and bitmap rendering (`JournalShareRenderer`). Keeps `ImageRenderer`'s proposed width aligned with the card.
+enum JournalShareExportMetrics {
+    static let cardContentWidth: CGFloat = 448
+    static let horizontalPadding: CGFloat = 24
+    /// Card column width plus horizontal padding (matches `JournalShareCardView` fixed export layout).
+    static var totalLayoutWidth: CGFloat { cardContentWidth + horizontalPadding * 2 }
+}
+
 enum JournalShareRenderer {
     /// Renders the share card to a bitmap.
     ///
     /// `ImageRenderer` proposes a size to the root view. If that size is effectively unbounded,
     /// flexible-width SwiftUI content can lay out poorly and `uiImage` may be nil or empty.
-    /// A concrete width matches typical phone layout and keeps the export stable across devices.
+    /// Use the same width as the fixed export card plus its horizontal padding so the bitmap matches
+    /// the composer export layout and is not clipped.
     @MainActor static func renderImage(from payload: ShareRenderPayload) -> UIImage? {
         let cardView = JournalShareCardView(payload: payload, onLineTap: nil)
         let renderer = ImageRenderer(content: cardView)
-        renderer.proposedSize = ProposedViewSize(width: Self.proposedLayoutWidth, height: nil)
+        renderer.proposedSize = ProposedViewSize(width: JournalShareExportMetrics.totalLayoutWidth, height: nil)
         renderer.scale = Self.pixelScale
         return renderer.uiImage
     }
 
-    private static let proposedLayoutWidth: CGFloat = 390
-
     private static var pixelScale: CGFloat {
+        let screenScale = UIScreen.main.scale
+
         if #available(iOS 17.0, *) {
-            return UITraitCollection.current.displayScale
+            let traitScale = UITraitCollection.current.displayScale
+            if traitScale > 0 {
+                return traitScale
+            }
         }
-        return UIScreen.main.scale
+
+        return screenScale > 0 ? screenScale : 1
     }
 }

--- a/GraceNotes/GraceNotes/Features/Journal/Services/JournalShareRenderer.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/JournalShareRenderer.swift
@@ -14,8 +14,9 @@ enum JournalShareRenderer {
         renderer.scale = Self.recommendedPixelScale()
         guard let image = renderer.uiImage else { return nil }
         guard image.size.width > 0, image.size.height > 0 else { return nil }
-        guard let cgImage = image.cgImage else { return nil }
-        guard cgImage.width > 0, cgImage.height > 0 else { return nil }
+        if let cgImage = image.cgImage {
+            guard cgImage.width > 0, cgImage.height > 0 else { return nil }
+        }
         return image
     }
 
@@ -27,13 +28,15 @@ enum JournalShareRenderer {
     }
 
     /// `ImageRenderer` runs without hosting in a window; `UITraitCollection.current.displayScale` can be
-    /// unset or 1× while the device screen is Retina. Prefer the foreground window scene scale (active or
-    /// inactive — a presented sheet can leave the root scene inactive), then trait, then screen, then a
-    /// safe default. Ignores background/unattached scenes so multi-window layouts do not pick an unrelated
-    /// display’s scale.
+    /// unset or 1× while the device screen is Retina. Uses the highest positive scale available from any
+    /// foreground window scene (active or inactive — a presented sheet can leave the root scene inactive),
+    /// the current trait collection, or the main screen, then clamps to a safe supported range. Ignores
+    /// background/unattached scenes so multi-window layouts do not pick an unrelated display’s scale.
     @MainActor
     private static func recommendedPixelScale() -> CGFloat {
         let traitScale = UITraitCollection.current.displayScale
+        // Deliberately take the maximum across foreground scenes so export matches the sharpest attached
+        // screen when multiple windows are visible.
         let sceneScale = UIApplication.shared.connectedScenes
             .compactMap { $0 as? UIWindowScene }
             .filter {

--- a/GraceNotes/GraceNotes/Features/Journal/Services/JournalShareRenderer.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/JournalShareRenderer.swift
@@ -14,9 +14,8 @@ enum JournalShareRenderer {
         renderer.scale = Self.recommendedPixelScale()
         guard let image = renderer.uiImage else { return nil }
         guard image.size.width > 0, image.size.height > 0 else { return nil }
-        if let cgImage = image.cgImage {
-            guard cgImage.width > 0, cgImage.height > 0 else { return nil }
-        }
+        guard let cgImage = image.cgImage else { return nil }
+        guard cgImage.width > 0, cgImage.height > 0 else { return nil }
         return image
     }
 
@@ -24,8 +23,9 @@ enum JournalShareRenderer {
     private static let proposedLayoutWidth: CGFloat = 448 + 24 * 2
 
     /// `ImageRenderer` runs without hosting in a window; `UITraitCollection.current.displayScale` can be
-    /// unset or 1× while the device screen is Retina. Prefer an active window scene scale, then trait, then
-    /// screen, then a safe default.
+    /// unset or 1× while the device screen is Retina. Use the highest positive scale reported by the current
+    /// trait collection, any connected window scene's screen, or the main screen, then fall back to a safe
+    /// default.
     @MainActor
     private static func recommendedPixelScale() -> CGFloat {
         let traitScale = UITraitCollection.current.displayScale

--- a/GraceNotes/GraceNotes/Features/Journal/Services/JournalShareRenderer.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/JournalShareRenderer.swift
@@ -11,9 +11,12 @@ enum JournalShareRenderer {
         let cardView = JournalShareCardView(payload: payload, onLineTap: nil)
         let renderer = ImageRenderer(content: cardView)
         renderer.proposedSize = ProposedViewSize(width: Self.proposedLayoutWidth, height: nil)
-        renderer.scale = Self.pixelScale
+        renderer.scale = Self.recommendedPixelScale()
         guard let image = renderer.uiImage else { return nil }
         guard image.size.width > 0, image.size.height > 0 else { return nil }
+        if let cgImage = image.cgImage {
+            guard cgImage.width > 0, cgImage.height > 0 else { return nil }
+        }
         return image
     }
 
@@ -21,11 +24,21 @@ enum JournalShareRenderer {
     private static let proposedLayoutWidth: CGFloat = 448 + 24 * 2
 
     /// `ImageRenderer` runs without hosting in a window; `UITraitCollection.current.displayScale` can be
-    /// unset or 1× while the device screen is Retina. Take the best positive value between trait and screen.
-    private static var pixelScale: CGFloat {
+    /// unset or 1× while the device screen is Retina. Prefer an active window scene scale, then trait, then
+    /// screen, then a safe default.
+    @MainActor
+    private static func recommendedPixelScale() -> CGFloat {
         let traitScale = UITraitCollection.current.displayScale
+        let sceneScale = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .map { $0.screen.scale }
+            .max() ?? 0
         let screenScale = UIScreen.main.scale
-        let best = max(traitScale > 0 ? traitScale : 0, screenScale > 0 ? screenScale : 0)
+        let best = max(
+            traitScale > 0 ? traitScale : 0,
+            sceneScale > 0 ? sceneScale : 0,
+            screenScale > 0 ? screenScale : 0
+        )
         return best > 0 ? best : 3
     }
 }

--- a/GraceNotes/GraceNotes/Features/Journal/Services/JournalShareRenderer.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/JournalShareRenderer.swift
@@ -19,7 +19,7 @@ enum JournalShareRenderer {
     @MainActor static func renderImage(from payload: ShareRenderPayload) -> UIImage? {
         let cardView = JournalShareCardView(payload: payload, onLineTap: nil)
         let renderer = ImageRenderer(content: cardView)
-        renderer.proposedSize = ProposedViewSize(width: Self.proposedLayoutWidth, height: nil)
+        renderer.proposedSize = ProposedViewSize(width: JournalShareExportMetrics.totalLayoutWidth, height: nil)
         renderer.scale = Self.recommendedPixelScale()
         guard let image = renderer.uiImage else { return nil }
         guard image.size.width > 0, image.size.height > 0 else { return nil }

--- a/GraceNotes/GraceNotes/Features/Journal/Services/JournalShareRenderer.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/JournalShareRenderer.swift
@@ -2,10 +2,25 @@ import SwiftUI
 import UIKit
 
 enum JournalShareRenderer {
+    /// Renders the share card to a bitmap.
+    ///
+    /// `ImageRenderer` proposes a size to the root view. If that size is effectively unbounded,
+    /// flexible-width SwiftUI content can lay out poorly and `uiImage` may be nil or empty.
+    /// A concrete width matches typical phone layout and keeps the export stable across devices.
     @MainActor static func renderImage(from payload: ShareRenderPayload) -> UIImage? {
         let cardView = JournalShareCardView(payload: payload, onLineTap: nil)
         let renderer = ImageRenderer(content: cardView)
-        renderer.scale = UIScreen.main.scale
+        renderer.proposedSize = ProposedViewSize(width: Self.proposedLayoutWidth, height: nil)
+        renderer.scale = Self.pixelScale
         return renderer.uiImage
+    }
+
+    private static let proposedLayoutWidth: CGFloat = 390
+
+    private static var pixelScale: CGFloat {
+        if #available(iOS 17.0, *) {
+            return UITraitCollection.current.displayScale
+        }
+        return UIScreen.main.scale
     }
 }

--- a/GraceNotes/GraceNotes/Features/Journal/Services/PastStatisticsIntervalPreference.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/PastStatisticsIntervalPreference.swift
@@ -152,6 +152,11 @@ enum PastStatisticsIntervalPreference {
     static let appStorageKey = "pastStatisticsInterval.selection.v1"
     private static let legacyBrowseWindowsKey = "GraceNotes.mostRecurringBrowseWindowWeeks"
 
+    /// Encoded string for ``appStorageKey``, matching `@AppStorage` string resolution when the default is `""`.
+    static func appStorageRawValue(defaults: UserDefaults = .standard) -> String {
+        defaults.string(forKey: appStorageKey) ?? ""
+    }
+
     static func selection(fromAppStorage raw: String) -> PastStatisticsIntervalSelection {
         PastStatisticsIntervalSelection.decode(from: raw)
     }

--- a/GraceNotes/GraceNotes/Features/Journal/Services/ReviewInsights.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ReviewInsights.swift
@@ -116,14 +116,19 @@ struct ReviewMostRecurringTheme: Equatable, Hashable, Sendable, Codable, Identif
         dayCount = try container.decode(Int.self, forKey: .dayCount)
         currentWeekCount = try container.decode(Int.self, forKey: .currentWeekCount)
         previousWeekCount = try container.decode(Int.self, forKey: .previousWeekCount)
-        evidence = Self.decodeEvidence(from: container)
+        evidence = try Self.decodeEvidence(from: container)
     }
 
-    /// `decodeIfPresent` throws on shape mismatch when the key exists, so legacy
-    /// `[ReviewThemeEvidence]` must be tried with `try? decode`.
+    /// When the `evidence` key is absent, decoding defaults to `[]`. When the key is present,
+    /// `decodeIfPresent` throws on type mismatch, so we try structured `[ReviewThemeSurfaceEvidence]`
+    /// then legacy `[ReviewThemeEvidence]` with `try? decode`; if both fail, decoding throws instead
+    /// of silently producing empty evidence.
     private static func decodeEvidence(
         from container: KeyedDecodingContainer<CodingKeys>
-    ) -> [ReviewThemeSurfaceEvidence] {
+    ) throws -> [ReviewThemeSurfaceEvidence] {
+        guard container.contains(.evidence) else {
+            return []
+        }
         if let structuredEvidence = try? container.decode([ReviewThemeSurfaceEvidence].self, forKey: .evidence) {
             return structuredEvidence
         }
@@ -136,7 +141,13 @@ struct ReviewMostRecurringTheme: Equatable, Hashable, Sendable, Codable, Identif
                 }
             }
         }
-        return []
+        throw DecodingError.dataCorrupted(
+            DecodingError.Context(
+                codingPath: container.codingPath + [CodingKeys.evidence],
+                debugDescription: "Invalid evidence: expected [ReviewThemeSurfaceEvidence] "
+                    + "or legacy [ReviewThemeEvidence]."
+            )
+        )
     }
 
     func encode(to encoder: Encoder) throws {

--- a/GraceNotes/GraceNotes/Features/Journal/Services/ReviewInsightsPeriod.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ReviewInsightsPeriod.swift
@@ -7,12 +7,29 @@ enum ReviewInsightsPeriod {
     /// The calendar week containing `referenceDate`, as half-open `[lower, upper)` where
     /// `lower` is the start of the week’s first day and `upper` is the start of the day after
     /// the week’s last day (exactly seven local days).
-    static func currentPeriod(containing referenceDate: Date, calendar: Calendar) -> Range<Date> {
-        guard let interval = calendar.dateInterval(of: .weekOfYear, for: referenceDate) else {
+    static func currentPeriod(
+        containing referenceDate: Date,
+        calendar: Calendar,
+        weekExclusiveEnd: ((Date) -> Date?)? = nil,
+        weekIntervalForReference: ((Date) -> DateInterval?)? = nil
+    ) -> Range<Date> {
+        let interval: DateInterval?
+        if let override = weekIntervalForReference {
+            interval = override(referenceDate)
+        } else {
+            interval = calendar.dateInterval(of: .weekOfYear, for: referenceDate)
+        }
+        guard let interval else {
             return rollingSevenDayFallback(containing: referenceDate, calendar: calendar)
         }
         let weekStart = calendar.startOfDay(for: interval.start)
-        if let exclusiveEnd = calendar.date(byAdding: .day, value: 7, to: weekStart), exclusiveEnd > weekStart {
+        let exclusiveEnd: Date?
+        if let override = weekExclusiveEnd {
+            exclusiveEnd = override(weekStart)
+        } else {
+            exclusiveEnd = calendar.date(byAdding: .day, value: 7, to: weekStart)
+        }
+        if let exclusiveEnd, exclusiveEnd > weekStart {
             return weekStart..<exclusiveEnd
         }
         if interval.end > weekStart {
@@ -23,9 +40,19 @@ enum ReviewInsightsPeriod {
 
     /// The calendar week immediately before `current` (the seven local days whose end abuts
     /// `current.lowerBound`).
-    static func previousPeriod(before current: Range<Date>, calendar: Calendar) -> Range<Date> {
-        let previousStart = calendar.date(byAdding: .day, value: -7, to: current.lowerBound)
-            ?? current.lowerBound.addingTimeInterval(-604_800)
+    static func previousPeriod(
+        before current: Range<Date>,
+        calendar: Calendar,
+        subtractSevenDaysFromLowerBound: ((Date) -> Date?)? = nil
+    ) -> Range<Date> {
+        let span = current.upperBound.timeIntervalSince(current.lowerBound)
+        let previousStart: Date
+        if let override = subtractSevenDaysFromLowerBound {
+            previousStart = override(current.lowerBound) ?? current.lowerBound.addingTimeInterval(-span)
+        } else {
+            previousStart = calendar.date(byAdding: .day, value: -7, to: current.lowerBound)
+                ?? current.lowerBound.addingTimeInterval(-span)
+        }
         return previousStart..<current.lowerBound
     }
 

--- a/GraceNotes/GraceNotes/Features/Journal/Services/ReviewInsightsPeriod.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ReviewInsightsPeriod.swift
@@ -24,8 +24,12 @@ enum ReviewInsightsPeriod {
     /// The calendar week immediately before `current` (the seven local days whose end abuts
     /// `current.lowerBound`).
     static func previousPeriod(before current: Range<Date>, calendar: Calendar) -> Range<Date> {
-        let previousStart = calendar.date(byAdding: .day, value: -7, to: current.lowerBound)
-            ?? current.lowerBound.addingTimeInterval(-604_800)
+        // Anchor on the last instant before the current week so `startOfDay` + day offsets match
+        // local week boundaries (including across DST). A fixed −604_800s stride is not seven
+        // local days when offset changes break the SI-second count between week starts.
+        let lastInstantBeforeCurrent = current.lowerBound.addingTimeInterval(-1)
+        let lastDayStart = calendar.startOfDay(for: lastInstantBeforeCurrent)
+        let previousStart = calendar.date(byAdding: .day, value: -6, to: lastDayStart) ?? lastDayStart
         return previousStart..<current.lowerBound
     }
 

--- a/GraceNotes/GraceNotes/Features/Journal/Services/ReviewInsightsPeriod.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ReviewInsightsPeriod.swift
@@ -29,7 +29,10 @@ enum ReviewInsightsPeriod {
         // local days when offset changes break the SI-second count between week starts.
         let lastInstantBeforeCurrent = current.lowerBound.addingTimeInterval(-1)
         let lastDayStart = calendar.startOfDay(for: lastInstantBeforeCurrent)
-        let previousStart = calendar.date(byAdding: .day, value: -6, to: lastDayStart) ?? lastDayStart
+        guard let previousStart = calendar.date(byAdding: .day, value: -6, to: lastDayStart) else {
+            let fallback = rollingSevenDayFallback(containing: lastInstantBeforeCurrent, calendar: calendar)
+            return fallback.lowerBound..<current.lowerBound
+        }
         return previousStart..<current.lowerBound
     }
 

--- a/GraceNotes/GraceNotes/Features/Journal/Services/ReviewInsightsPeriod.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ReviewInsightsPeriod.swift
@@ -12,17 +12,20 @@ enum ReviewInsightsPeriod {
             return rollingSevenDayFallback(containing: referenceDate, calendar: calendar)
         }
         let weekStart = calendar.startOfDay(for: interval.start)
-        guard let periodEndExclusive = calendar.date(byAdding: .day, value: 7, to: weekStart) else {
+        if let exclusiveEnd = calendar.date(byAdding: .day, value: 7, to: weekStart), exclusiveEnd > weekStart {
+            return weekStart..<exclusiveEnd
+        }
+        if interval.end > weekStart {
             return weekStart..<interval.end
         }
-        return weekStart..<periodEndExclusive
+        return rollingSevenDayFallback(containing: referenceDate, calendar: calendar)
     }
 
     /// The calendar week immediately before `current` (the seven local days whose end abuts
     /// `current.lowerBound`).
     static func previousPeriod(before current: Range<Date>, calendar: Calendar) -> Range<Date> {
         let previousStart = calendar.date(byAdding: .day, value: -7, to: current.lowerBound)
-            ?? current.lowerBound
+            ?? current.lowerBound.addingTimeInterval(-604_800)
         return previousStart..<current.lowerBound
     }
 

--- a/GraceNotes/GraceNotes/Features/Journal/Services/ReviewInsightsProvider.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ReviewInsightsProvider.swift
@@ -54,9 +54,15 @@ struct ReviewInsightsProvider: Sendable {
             )
         } catch {
             if !(error is CancellationError) {
+                let nsError = error as NSError
                 let detail = error.localizedDescription
+                let errorTypeName = String(describing: type(of: error))
                 reviewInsightsProviderLogger.error(
-                    "Sparse fallback after generator failure. \(detail, privacy: .public)"
+                    """
+                    Sparse fallback after generator failure. \
+                    type: \(errorTypeName, privacy: .public), domain: \(nsError.domain, privacy: .public), \
+                    code: \(nsError.code, privacy: .public), detail: \(detail, privacy: .private)
+                    """
                 )
             }
             return sparseFallbackInsights(

--- a/GraceNotes/GraceNotes/Features/Journal/Services/ReviewJournalThemeLanguageResolver.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ReviewJournalThemeLanguageResolver.swift
@@ -14,8 +14,12 @@ struct ReviewJournalThemeLanguageResolver: ReviewJournalThemeLanguageResolving {
     private let confidenceThreshold: Double
 
     init(minimumMeaningfulGraphemes: Int = 24, confidenceThreshold: Double = 0.55) {
-        self.minimumMeaningfulGraphemes = minimumMeaningfulGraphemes
-        self.confidenceThreshold = confidenceThreshold
+        self.minimumMeaningfulGraphemes = max(0, minimumMeaningfulGraphemes)
+        if confidenceThreshold.isNaN {
+            self.confidenceThreshold = 0.55
+        } else {
+            self.confidenceThreshold = min(max(confidenceThreshold, 0), 1)
+        }
     }
 
     func resolvedDisplayLocale(forJournalCorpus corpus: String) -> Locale {
@@ -55,6 +59,7 @@ struct ReviewJournalThemeLanguageResolver: ReviewJournalThemeLanguageResolving {
     }
 
     /// When hypotheses are ambiguous, count Han vs Latin letters and pick a side. Equal counts → English.
+    /// Latin includes common accented letters (Latin-1 + Extended-A) so tie-break matches mixed European text.
     private static func scriptTieBreakLocale(trimmed: String) -> Locale {
         var han = 0
         var latin = 0
@@ -70,7 +75,9 @@ struct ReviewJournalThemeLanguageResolver: ReviewJournalThemeLanguageResolving {
                  0x2CEB0...0x2EBEF,
                  0x2F800...0x2FA1F:
                 han += 1
-            case 0x41...0x5A, 0x61...0x7A:
+            case 0x41...0x5A, 0x61...0x7A,
+                 0x00C0...0x00D6, 0x00D8...0x00F6, 0x00F8...0x00FF,
+                 0x0100...0x017F:
                 latin += 1
             default:
                 break

--- a/GraceNotes/GraceNotes/Features/Journal/Services/ReviewJournalThemeLanguageResolver.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ReviewJournalThemeLanguageResolver.swift
@@ -55,6 +55,9 @@ struct ReviewJournalThemeLanguageResolver: ReviewJournalThemeLanguageResolving {
     private static let maximumAnalysisGraphemes = 50_000
 
     private static func hasEnoughMeaningfulGraphemes(_ text: String, minimum: Int) -> Bool {
+        if minimum <= 0 {
+            return true
+        }
         var count = 0
         for character in text where !character.isWhitespace {
             count += 1
@@ -62,7 +65,7 @@ struct ReviewJournalThemeLanguageResolver: ReviewJournalThemeLanguageResolving {
                 return true
             }
         }
-        return count >= minimum
+        return false
     }
 
     /// Keeps language detection and script scanning bounded on pathologically long corpora without scanning `count`.

--- a/GraceNotes/GraceNotes/Features/Journal/Services/ReviewJournalThemeLanguageResolver.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ReviewJournalThemeLanguageResolver.swift
@@ -29,13 +29,14 @@ struct ReviewJournalThemeLanguageResolver: ReviewJournalThemeLanguageResolving {
             return Self.englishCatalogLocale
         }
 
-        let meaningfulCount = trimmed.filter { !$0.isWhitespace }.count
-        guard meaningfulCount >= minimumMeaningfulGraphemes else {
+        guard Self.hasEnoughMeaningfulGraphemes(trimmed, minimum: minimumMeaningfulGraphemes) else {
             return Self.englishCatalogLocale
         }
 
+        let analysisText = Self.analysisSample(from: trimmed)
+
         let recognizer = NLLanguageRecognizer()
-        recognizer.processString(trimmed)
+        recognizer.processString(analysisText)
 
         if let dominant = recognizer.dominantLanguage {
             let hypotheses = recognizer.languageHypotheses(withMaximum: 5)
@@ -45,10 +46,29 @@ struct ReviewJournalThemeLanguageResolver: ReviewJournalThemeLanguageResolving {
             }
         }
 
-        return Self.scriptTieBreakLocale(trimmed: trimmed)
+        return Self.scriptTieBreakLocale(trimmed: analysisText)
     }
 
     private static let englishCatalogLocale = Locale(identifier: "en")
+
+    /// Upper bound on text fed to `NLLanguageRecognizer` and script tie-break (prefix by extended grapheme cluster).
+    private static let maximumAnalysisGraphemes = 50_000
+
+    private static func hasEnoughMeaningfulGraphemes(_ text: String, minimum: Int) -> Bool {
+        var count = 0
+        for character in text where !character.isWhitespace {
+            count += 1
+            if count >= minimum {
+                return true
+            }
+        }
+        return count >= minimum
+    }
+
+    /// Keeps language detection and script scanning bounded on pathologically long corpora without scanning `count`.
+    private static func analysisSample(from trimmed: String) -> String {
+        String(trimmed.prefix(maximumAnalysisGraphemes))
+    }
 
     /// Maps recognizer output to a locale that exists in `Localizable.xcstrings` (we ship `en` + `zh-Hans`).
     private static func catalogLocale(for language: NLLanguage) -> Locale {

--- a/GraceNotes/GraceNotes/Features/Journal/Services/ReviewJournalThemeLanguageResolver.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ReviewJournalThemeLanguageResolver.swift
@@ -8,15 +8,17 @@ protocol ReviewJournalThemeLanguageResolving: Sendable {
 }
 
 struct ReviewJournalThemeLanguageResolver: ReviewJournalThemeLanguageResolving {
+    private static let defaultConfidenceThreshold = 0.55
+
     /// Ignore language detection until the corpus has at least this many non-whitespace graphemes.
     private let minimumMeaningfulGraphemes: Int
     /// If the top `NLLanguageRecognizer` hypothesis is weaker than this, fall back to script share.
     private let confidenceThreshold: Double
 
-    init(minimumMeaningfulGraphemes: Int = 24, confidenceThreshold: Double = 0.55) {
+    init(minimumMeaningfulGraphemes: Int = 24, confidenceThreshold: Double = Self.defaultConfidenceThreshold) {
         self.minimumMeaningfulGraphemes = max(0, minimumMeaningfulGraphemes)
         if confidenceThreshold.isNaN {
-            self.confidenceThreshold = 0.55
+            self.confidenceThreshold = Self.defaultConfidenceThreshold
         } else {
             self.confidenceThreshold = min(max(confidenceThreshold, 0), 1)
         }
@@ -60,10 +62,12 @@ struct ReviewJournalThemeLanguageResolver: ReviewJournalThemeLanguageResolving {
 
     /// When hypotheses are ambiguous, count Han vs Latin letters and pick a side. Equal counts → English.
     /// Latin includes common accented letters (Latin-1 + Extended-A) so tie-break matches mixed European text.
+    /// Uses NFC so NFD text (e.g. `e` + combining acute) counts the same as precomposed `é`.
     private static func scriptTieBreakLocale(trimmed: String) -> Locale {
+        let normalized = trimmed.precomposedStringWithCanonicalMapping
         var han = 0
         var latin = 0
-        for scalar in trimmed.unicodeScalars {
+        for scalar in normalized.unicodeScalars {
             switch scalar.value {
             case 0x3400...0x4DBF,
                  0x4E00...0x9FFF,

--- a/GraceNotes/GraceNotes/Features/Journal/Services/ReviewJournalThemeLanguageResolver.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ReviewJournalThemeLanguageResolver.swift
@@ -8,6 +8,8 @@ protocol ReviewJournalThemeLanguageResolving: Sendable {
 }
 
 struct ReviewJournalThemeLanguageResolver: ReviewJournalThemeLanguageResolving {
+    private static let defaultConfidenceThreshold = 0.55
+
     /// Ignore language detection until the corpus has at least this many non-whitespace graphemes in the
     /// **analysis prefix** (the first 50,000 extended grapheme clusters—the same capped sample used for
     /// `NLLanguageRecognizer`), not the entire trimmed corpus. Dense text after that prefix does not count.
@@ -34,7 +36,7 @@ struct ReviewJournalThemeLanguageResolver: ReviewJournalThemeLanguageResolving {
             return Self.englishCatalogLocale
         }
 
-        let analysisText = Self.analysisSample(from: trimmed)
+        let analysisText = Self.normalizedAnalysisSample(from: trimmed)
 
         let recognizer = NLLanguageRecognizer()
         recognizer.processString(analysisText)
@@ -47,7 +49,7 @@ struct ReviewJournalThemeLanguageResolver: ReviewJournalThemeLanguageResolving {
             }
         }
 
-        return Self.scriptTieBreakLocale(trimmed: analysisText)
+        return Self.scriptTieBreakLocale(analysisText: analysisText)
     }
 
     private static let englishCatalogLocale = Locale(identifier: "en")

--- a/GraceNotes/GraceNotes/Features/Journal/Services/ReviewJournalThemeLanguageResolver.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ReviewJournalThemeLanguageResolver.swift
@@ -8,7 +8,9 @@ protocol ReviewJournalThemeLanguageResolving: Sendable {
 }
 
 struct ReviewJournalThemeLanguageResolver: ReviewJournalThemeLanguageResolving {
-    /// Ignore language detection until the corpus has at least this many non-whitespace graphemes.
+    /// Ignore language detection until the corpus has at least this many non-whitespace graphemes in the
+    /// **analysis prefix** (the first 50,000 extended grapheme clusters—the same capped sample used for
+    /// `NLLanguageRecognizer`), not the entire trimmed corpus. Dense text after that prefix does not count.
     private let minimumMeaningfulGraphemes: Int
     /// If the top `NLLanguageRecognizer` hypothesis is weaker than this, fall back to script share.
     private let confidenceThreshold: Double

--- a/GraceNotes/GraceNotes/Features/Journal/Services/ReviewJournalThemeLanguageResolver.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ReviewJournalThemeLanguageResolver.swift
@@ -53,18 +53,26 @@ struct ReviewJournalThemeLanguageResolver: ReviewJournalThemeLanguageResolving {
     /// Upper bound on text fed to `NLLanguageRecognizer` and script tie-break (prefix by extended grapheme cluster).
     private static let maximumAnalysisGraphemes = 50_000
 
+    /// Counts non-whitespace graphemes only in the same prefix we analyze, so the threshold matches
+    /// `normalizedAnalysisSample` and pathological corpora cannot spend unbounded time here.
     private static func hasEnoughMeaningfulGraphemes(_ text: String, minimum: Int) -> Bool {
+        if minimum <= 0 {
+            return true
+        }
+
+        let prefix = text.prefix(maximumAnalysisGraphemes)
         var count = 0
-        for character in text where !character.isWhitespace {
+        for character in prefix where !character.isWhitespace {
             count += 1
             if count >= minimum {
                 return true
             }
         }
-        return count >= minimum
+        return false
     }
 
-    /// Collapses whitespace runs only inside the analysis prefix so pathological corpora never run a full-string regex replace.
+    /// Collapses whitespace runs only inside the analysis prefix so pathological corpora never run a full-string
+    /// regex replace.
     private static func normalizedAnalysisSample(from trimmed: String) -> String {
         let head = String(trimmed.prefix(maximumAnalysisGraphemes))
         return collapseWhitespaceRuns(head)

--- a/GraceNotes/GraceNotes/Features/Journal/Services/ReviewWeekBoundaryPreference.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ReviewWeekBoundaryPreference.swift
@@ -29,8 +29,12 @@ enum ReviewWeekBoundaryPreference: String, CaseIterable, Equatable, Sendable {
         ReviewWeekBoundaryPreference(rawValue: rawValue) ?? defaultValue
     }
 
-    /// Uses Gregorian weekday numbering (1 = Sunday … 7 = Saturday) regardless of the user’s primary
-    /// calendar, while keeping their time zone and locale for local day boundaries and formatting.
+    /// Returns a **Gregorian** calendar for review week boundaries, independent of `base`’s identifier.
+    ///
+    /// Only `timeZone` and `locale` are read from `base`; other properties (for example
+    /// `minimumDaysInFirstWeek`) are not copied. Weekday numbering follows Gregorian convention
+    /// (1 = Sunday … 7 = Saturday) for `firstWeekday`, using the same time zone and locale for local
+    /// day boundaries and formatting.
     func configuredCalendar(base: Calendar = .current) -> Calendar {
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = base.timeZone

--- a/GraceNotes/GraceNotes/Features/Journal/Services/ReviewWeekTrendPolicy.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ReviewWeekTrendPolicy.swift
@@ -32,8 +32,7 @@ enum ReviewWeekTrendPolicy {
     static func rawTrend(current: Int, previous: Int) -> ReviewThemeTrend {
         guard current >= 0, previous >= 0 else {
             reviewWeekTrendPolicyLogger.warning(
-                "Negative mention counts in rawTrend (current=\(current, privacy: .public), "
-                    + "previous=\(previous, privacy: .public))"
+                "Negative mention counts in rawTrend (current=\(current, privacy: .public), previous=\(previous, privacy: .public))"
             )
             return .stable
         }

--- a/GraceNotes/GraceNotes/Features/Journal/Services/ReviewWeekTrendPolicy.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ReviewWeekTrendPolicy.swift
@@ -1,4 +1,10 @@
 import Foundation
+import os
+
+private let reviewWeekTrendPolicyLogger = Logger(
+    subsystem: Bundle(for: PersistenceController.self).bundleIdentifier ?? "GraceNotes",
+    category: "ReviewWeekTrendPolicy"
+)
 
 /// Calendar-week trend surfacing: warm-up (first two local days of the week) plus balanced floors.
 enum ReviewWeekTrendPolicy {
@@ -25,6 +31,10 @@ enum ReviewWeekTrendPolicy {
     /// Raw week-over-week direction from mention counts (before confidence / floors).
     static func rawTrend(current: Int, previous: Int) -> ReviewThemeTrend {
         guard current >= 0, previous >= 0 else {
+            reviewWeekTrendPolicyLogger.warning(
+                "Negative mention counts in rawTrend (current=\(current, privacy: .public), "
+                    + "previous=\(previous, privacy: .public))"
+            )
             return .stable
         }
         if previous == 0, current > 0 {

--- a/GraceNotes/GraceNotes/Features/Journal/Services/ShareCardDraft.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ShareCardDraft.swift
@@ -111,15 +111,27 @@ struct ShareCardDraft: Equatable, Sendable {
     mutating func toggleRedaction(for identity: ShareLineIdentity) {
         switch identity {
         case .gratitude(let index):
-            redactedGratitudeIndices.formSymmetricDifference([index])
+            redactedGratitudeIndices.toggleMembership(index)
         case .need(let index):
-            redactedNeedIndices.formSymmetricDifference([index])
+            redactedNeedIndices.toggleMembership(index)
         case .person(let index):
-            redactedPersonIndices.formSymmetricDifference([index])
+            redactedPersonIndices.toggleMembership(index)
         case .readingLine(let index):
-            redactedReadingLineIndices.formSymmetricDifference([index])
+            redactedReadingLineIndices.toggleMembership(index)
         case .reflectionLine(let index):
-            redactedReflectionLineIndices.formSymmetricDifference([index])
+            redactedReflectionLineIndices.toggleMembership(index)
+        }
+    }
+}
+
+// MARK: - Set helpers
+
+private extension Set where Element == Int {
+    mutating func toggleMembership(_ index: Int) {
+        if contains(index) {
+            remove(index)
+        } else {
+            insert(index)
         }
     }
 }

--- a/GraceNotes/GraceNotes/Features/Journal/Services/ShareCardHexColor.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ShareCardHexColor.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+extension Color {
+    /// 24-bit `RRGGBB`. High bits are masked so `AARRGGBB`-style literals still resolve to the same sRGB triplet.
+    init(hexSRGB hex: UInt) {
+        let rgb = hex & 0xFFFFFF
+        let red = Double((rgb >> 16) & 0xFF) / 255
+        let green = Double((rgb >> 8) & 0xFF) / 255
+        let blue = Double(rgb & 0xFF) / 255
+        self.init(.sRGB, red: red, green: green, blue: blue)
+    }
+}

--- a/GraceNotes/GraceNotes/Features/Journal/Services/ShareCardStyle+Typography.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ShareCardStyle+Typography.swift
@@ -8,21 +8,21 @@ extension ShareCardStyle {
             switch script {
             case .latin:
                 Font.custom("Cormorant Garamond", size: 24, relativeTo: .title2).weight(.semibold)
-            case .chinese:
+            case .cjk:
                 Font.system(size: 24, weight: .semibold, design: .serif)
             }
         case .editorialMist:
             switch script {
             case .latin:
                 Font.custom("Inter", size: 20, relativeTo: .title3).weight(.semibold)
-            case .chinese:
+            case .cjk:
                 Font.system(size: 20, weight: .semibold, design: .default)
             }
         case .sunriseGradient:
             switch script {
             case .latin:
                 Font.custom("Bebas Neue", size: 42, relativeTo: .largeTitle).weight(.regular)
-            case .chinese:
+            case .cjk:
                 Font.system(size: 28, weight: .semibold, design: .rounded)
             }
         }
@@ -34,21 +34,21 @@ extension ShareCardStyle {
             switch script {
             case .latin:
                 Font.custom("Crimson Text", size: 16, relativeTo: .headline).weight(.semibold)
-            case .chinese:
+            case .cjk:
                 Font.system(size: 16, weight: .semibold, design: .serif)
             }
         case .editorialMist:
             switch script {
             case .latin:
                 Font.custom("Inter", size: 13, relativeTo: .subheadline).weight(.semibold)
-            case .chinese:
+            case .cjk:
                 Font.system(size: 13, weight: .semibold, design: .default)
             }
         case .sunriseGradient:
             switch script {
             case .latin:
                 Font.custom("Bebas Neue", size: 22, relativeTo: .title3).weight(.regular)
-            case .chinese:
+            case .cjk:
                 Font.system(size: 19, weight: .semibold, design: .rounded)
             }
         }
@@ -60,21 +60,21 @@ extension ShareCardStyle {
             switch script {
             case .latin:
                 Font.custom("Crimson Text", size: 15, relativeTo: .body)
-            case .chinese:
+            case .cjk:
                 Font.system(size: 15, weight: .regular, design: .serif)
             }
         case .editorialMist:
             switch script {
             case .latin:
                 Font.custom("Spectral", size: 15, relativeTo: .body)
-            case .chinese:
+            case .cjk:
                 Font.system(size: 15, weight: .regular, design: .serif)
             }
         case .sunriseGradient:
             switch script {
             case .latin:
                 Font.custom("Bodoni Moda", size: 15, relativeTo: .body)
-            case .chinese:
+            case .cjk:
                 Font.system(size: 16, weight: .medium, design: .rounded)
             }
         }
@@ -86,21 +86,21 @@ extension ShareCardStyle {
             switch script {
             case .latin:
                 Font.custom("Crimson Text", size: 11, relativeTo: .caption2)
-            case .chinese:
+            case .cjk:
                 Font.system(size: 11, weight: .regular, design: .serif)
             }
         case .editorialMist:
             switch script {
             case .latin:
                 Font.custom("Inter", size: 10, relativeTo: .caption2)
-            case .chinese:
+            case .cjk:
                 Font.system(size: 10, weight: .regular, design: .default)
             }
         case .sunriseGradient:
             switch script {
             case .latin:
                 Font.custom("Bodoni Moda", size: 9, relativeTo: .caption2)
-            case .chinese:
+            case .cjk:
                 Font.system(size: 10, weight: .regular, design: .rounded)
             }
         }
@@ -108,7 +108,7 @@ extension ShareCardStyle {
 
     func sectionTitleTextCase(for script: ShareTypographyScript) -> Text.Case? {
         switch script {
-        case .chinese:
+        case .cjk:
             return nil
         case .latin:
             return .uppercase

--- a/GraceNotes/GraceNotes/Features/Journal/Services/ShareCardStyle.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ShareCardStyle.swift
@@ -1,11 +1,13 @@
 import SwiftUI
 
 private extension Color {
+    /// 24-bit `RRGGBB`. High bits are masked so `AARRGGBB`-style literals still resolve to the same sRGB triplet.
     init(hex: UInt) {
-        let red = Double((hex >> 16) & 0xFF) / 255
-        let green = Double((hex >> 8) & 0xFF) / 255
-        let blue = Double(hex & 0xFF) / 255
-        self.init(red: red, green: green, blue: blue)
+        let rgb = hex & 0xFFFFFF
+        let red = Double((rgb >> 16) & 0xFF) / 255
+        let green = Double((rgb >> 8) & 0xFF) / 255
+        let blue = Double(rgb & 0xFF) / 255
+        self.init(.sRGB, red: red, green: green, blue: blue)
     }
 }
 
@@ -92,14 +94,7 @@ enum ShareCardStyle: String, CaseIterable, Identifiable, Sendable {
     }
 
     var completionChipTextColor: Color {
-        switch self {
-        case .paperWarm:
-            Color(hex: 0x7A6F68)
-        case .editorialMist:
-            Color(hex: 0x737373)
-        case .sunriseGradient:
-            Color(hex: 0x9B8A7E)
-        }
+        footerInk
     }
 
     @ViewBuilder

--- a/GraceNotes/GraceNotes/Features/Journal/Services/ShareCardStyle.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ShareCardStyle.swift
@@ -25,15 +25,15 @@ enum ShareCardStyle: String, CaseIterable, Identifiable, Sendable {
     func cardBackgroundLayer() -> some View {
         switch self {
         case .paperWarm:
-            Color(hex: 0xF5EDE4)
+            Color(hexSRGB: 0xF5EDE4)
         case .editorialMist:
-            Color(hex: 0xFAFAF9)
+            Color(hexSRGB: 0xFAFAF9)
         case .sunriseGradient:
             LinearGradient(
                 colors: [
-                    Color(hex: 0xF8F4F0),
-                    Color(hex: 0xFBF7F3),
-                    Color(hex: 0xF5EEE8)
+                    Color(hexSRGB: 0xF8F4F0),
+                    Color(hexSRGB: 0xFBF7F3),
+                    Color(hexSRGB: 0xF5EEE8)
                 ],
                 startPoint: .topLeading,
                 endPoint: .bottomTrailing
@@ -45,11 +45,11 @@ enum ShareCardStyle: String, CaseIterable, Identifiable, Sendable {
     var bodyInk: Color {
         switch self {
         case .paperWarm:
-            Color(hex: 0x2B2520)
+            Color(hexSRGB: 0x2B2520)
         case .editorialMist:
-            Color(hex: 0x1A1A1A)
+            Color(hexSRGB: 0x1A1A1A)
         case .sunriseGradient:
-            Color(hex: 0x1F1B18)
+            Color(hexSRGB: 0x1F1B18)
         }
     }
 
@@ -61,11 +61,11 @@ enum ShareCardStyle: String, CaseIterable, Identifiable, Sendable {
     var footerInk: Color {
         switch self {
         case .paperWarm:
-            Color(hex: 0x7A6F68)
+            Color(hexSRGB: 0x7A6F68)
         case .editorialMist:
-            Color(hex: 0x737373)
+            Color(hexSRGB: 0x737373)
         case .sunriseGradient:
-            Color(hex: 0x9B8A7E)
+            Color(hexSRGB: 0x9B8A7E)
         }
     }
 
@@ -90,12 +90,12 @@ enum ShareCardStyle: String, CaseIterable, Identifiable, Sendable {
     func completionChipBackgroundView() -> some View {
         switch self {
         case .paperWarm:
-            Color(hex: 0xE8DED2)
+            Color(hexSRGB: 0xE8DED2)
         case .editorialMist:
-            Color(hex: 0xE5E5E5)
+            Color(hexSRGB: 0xE5E5E5)
         case .sunriseGradient:
             LinearGradient(
-                colors: [Color(hex: 0xE8DDD4), Color(hex: 0xEDE3DA)],
+                colors: [Color(hexSRGB: 0xE8DDD4), Color(hexSRGB: 0xEDE3DA)],
                 startPoint: .leading,
                 endPoint: .trailing
             )
@@ -103,11 +103,11 @@ enum ShareCardStyle: String, CaseIterable, Identifiable, Sendable {
     }
 
     var sectionDividerColor: Color {
-        Color(hex: 0xE5E5E5)
+        Color(hexSRGB: 0xE5E5E5)
     }
 
     var redactionBarColor: Color {
-        Color(hex: 0xD4CEC7)
+        Color(hexSRGB: 0xD4CEC7)
     }
 
     // MARK: - Chrome
@@ -128,22 +128,22 @@ enum ShareCardStyle: String, CaseIterable, Identifiable, Sendable {
         switch self {
         case .paperWarm:
             LinearGradient(
-                colors: [Color(hex: 0xD97757), Color(hex: 0xE88B6F)],
+                colors: [Color(hexSRGB: 0xD97757), Color(hexSRGB: 0xE88B6F)],
                 startPoint: .leading,
                 endPoint: .trailing
             )
         case .editorialMist:
             LinearGradient(
-                colors: [Color(hex: 0xB8968E), Color(hex: 0xC4A59E)],
+                colors: [Color(hexSRGB: 0xB8968E), Color(hexSRGB: 0xC4A59E)],
                 startPoint: .leading,
                 endPoint: .trailing
             )
         case .sunriseGradient:
             LinearGradient(
                 colors: [
-                    Color(hex: 0xC17B5B),
-                    Color(hex: 0xD4916F),
-                    Color(hex: 0xC17B5B)
+                    Color(hexSRGB: 0xC17B5B),
+                    Color(hexSRGB: 0xD4916F),
+                    Color(hexSRGB: 0xC17B5B)
                 ],
                 startPoint: .leading,
                 endPoint: .trailing

--- a/GraceNotes/GraceNotes/Features/Journal/Services/ShareCardStyle.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ShareCardStyle.swift
@@ -1,16 +1,5 @@
 import SwiftUI
 
-private extension Color {
-    /// 24-bit `RRGGBB`. High bits are masked so `AARRGGBB`-style literals still resolve to the same sRGB triplet.
-    init(hex: UInt) {
-        let rgb = hex & 0xFFFFFF
-        let red = Double((rgb >> 16) & 0xFF) / 255
-        let green = Double((rgb >> 8) & 0xFF) / 255
-        let blue = Double(rgb & 0xFF) / 255
-        self.init(.sRGB, red: red, green: green, blue: blue)
-    }
-}
-
 /// Named presets for the exported share card bitmap (Figma Make: grace-notes / editorial / embellished).
 enum ShareCardStyle: String, CaseIterable, Identifiable, Sendable {
     case paperWarm

--- a/GraceNotes/GraceNotes/Features/Journal/Services/ShareCardSurface.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ShareCardSurface.swift
@@ -14,14 +14,14 @@ struct ShareCardSurface: Sendable {
 
     var bodyInk: Color {
         guard usesDarkTheme else { return style.bodyInk }
-        return Color(hex: 0xF2E8DE)
+        return Color(hexSRGB: 0xF2E8DE)
     }
 
     var sectionTitleInk: Color { bodyInk }
 
     var footerInk: Color {
         guard usesDarkTheme else { return style.footerInk }
-        return Color(hex: 0xC5B7A8)
+        return Color(hexSRGB: 0xC5B7A8)
     }
 
     var stubInk: Color { footerInk }
@@ -29,12 +29,12 @@ struct ShareCardSurface: Sendable {
 
     var sectionDividerColor: Color {
         guard usesDarkTheme else { return style.sectionDividerColor }
-        return Color(hex: 0x3D3834)
+        return Color(hexSRGB: 0x3D3834)
     }
 
     var redactionBarColor: Color {
         guard usesDarkTheme else { return style.redactionBarColor }
-        return Color(hex: 0x4A423A)
+        return Color(hexSRGB: 0x4A423A)
     }
 
     var cardShadowColor: Color {
@@ -44,7 +44,7 @@ struct ShareCardSurface: Sendable {
 
     var completionChipTextColor: Color {
         guard usesDarkTheme else { return style.completionChipTextColor }
-        return Color(hex: 0xD4C4B6)
+        return Color(hexSRGB: 0xD4C4B6)
     }
 
     @ViewBuilder
@@ -78,15 +78,15 @@ extension ShareRenderPayload {
 private func darkCardBackground(style: ShareCardStyle) -> some View {
     switch style {
     case .paperWarm:
-        Color(hex: 0x2A241F)
+        Color(hexSRGB: 0x2A241F)
     case .editorialMist:
-        Color(hex: 0x1C1C1C)
+        Color(hexSRGB: 0x1C1C1C)
     case .sunriseGradient:
         LinearGradient(
             colors: [
-                Color(hex: 0x2A1F1A),
-                Color(hex: 0x302820),
-                Color(hex: 0x261C18)
+                Color(hexSRGB: 0x2A1F1A),
+                Color(hexSRGB: 0x302820),
+                Color(hexSRGB: 0x261C18)
             ],
             startPoint: .topLeading,
             endPoint: .bottomTrailing
@@ -98,12 +98,12 @@ private func darkCardBackground(style: ShareCardStyle) -> some View {
 private func darkCompletionChipBackground(style: ShareCardStyle) -> some View {
     switch style {
     case .paperWarm:
-        Color(hex: 0x3A322C)
+        Color(hexSRGB: 0x3A322C)
     case .editorialMist:
-        Color(hex: 0x333333)
+        Color(hexSRGB: 0x333333)
     case .sunriseGradient:
         LinearGradient(
-            colors: [Color(hex: 0x3D322C), Color(hex: 0x453D36)],
+            colors: [Color(hexSRGB: 0x3D322C), Color(hexSRGB: 0x453D36)],
             startPoint: .leading,
             endPoint: .trailing
         )

--- a/GraceNotes/GraceNotes/Features/Journal/Services/ShareCardSurface.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ShareCardSurface.swift
@@ -109,12 +109,3 @@ private func darkCompletionChipBackground(style: ShareCardStyle) -> some View {
         )
     }
 }
-
-private extension Color {
-    init(hex: UInt) {
-        let red = Double((hex >> 16) & 0xFF) / 255
-        let green = Double((hex >> 8) & 0xFF) / 255
-        let blue = Double(hex & 0xFF) / 255
-        self.init(red: red, green: green, blue: blue)
-    }
-}

--- a/GraceNotes/GraceNotes/Features/Journal/Services/ShareTypographyScript.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ShareTypographyScript.swift
@@ -31,9 +31,19 @@ extension ShareTypographyScript {
         }
         languages.append(systemLanguage)
         for language in languages where isCJK(language) {
-            return .chinese
+            return .cjk
         }
         return .latin
+    }
+
+    /// Maps a concrete locale’s base language code (for tests and direct locale-driven layout).
+    static func forLocale(_ locale: Locale) -> ShareTypographyScript {
+        switch locale.language.languageCode?.identifier {
+        case "zh", "ja", "ko":
+            return .cjk
+        default:
+            return .latin
+        }
     }
 
     private static func isCJK(_ language: Locale.Language) -> Bool {

--- a/GraceNotes/GraceNotes/Features/Journal/Services/ShareTypographyScript.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ShareTypographyScript.swift
@@ -4,16 +4,21 @@ import Foundation
 /// Figma uses Noto for zh; we approximate CJK with system serif/sans to avoid multi‑MB font bundles.
 enum ShareTypographyScript: Equatable, Sendable {
     case latin
-    case chinese
+    /// System CJK typography path for zh / ja / ko share cards (not “Chinese-only”).
+    case cjk
 }
 
 extension ShareTypographyScript {
-    static func current() -> ShareTypographyScript {
-        switch Locale.current.language.languageCode?.identifier {
+    static func forLocale(_ locale: Locale) -> ShareTypographyScript {
+        switch locale.language.languageCode?.identifier {
         case "zh", "ja", "ko":
-            return .chinese
+            return .cjk
         default:
             return .latin
         }
+    }
+
+    static func current() -> ShareTypographyScript {
+        forLocale(.current)
     }
 }

--- a/GraceNotes/GraceNotes/Features/Journal/Services/ShareTypographyScript.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ShareTypographyScript.swift
@@ -8,12 +8,17 @@ enum ShareTypographyScript: Equatable, Sendable {
 }
 
 extension ShareTypographyScript {
-    static func current() -> ShareTypographyScript {
-        switch Locale.current.language.languageCode {
+    /// Pure CJK vs Latin selection for unit tests and stable behavior vs `Locale.current`.
+    static func forLanguageCode(_ languageCode: Locale.LanguageCode?) -> ShareTypographyScript {
+        switch languageCode {
         case .some(.chinese), .some(.japanese), .some(.korean):
             return .chinese
         default:
             return .latin
         }
+    }
+
+    static func current() -> ShareTypographyScript {
+        forLanguageCode(Locale.current.language.languageCode)
     }
 }

--- a/GraceNotes/GraceNotes/Features/Journal/Services/ShareTypographyScript.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ShareTypographyScript.swift
@@ -9,8 +9,8 @@ enum ShareTypographyScript: Equatable, Sendable {
 
 extension ShareTypographyScript {
     static func current() -> ShareTypographyScript {
-        switch Locale.current.language.languageCode?.identifier {
-        case "zh", "ja", "ko":
+        switch Locale.current.language.languageCode {
+        case .some(.chinese), .some(.japanese), .some(.korean):
             return .chinese
         default:
             return .latin

--- a/GraceNotes/GraceNotes/Features/Journal/Services/ShareTypographyScript.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ShareTypographyScript.swift
@@ -8,12 +8,23 @@ enum ShareTypographyScript: Equatable, Sendable {
 }
 
 extension ShareTypographyScript {
-    static func current() -> ShareTypographyScript {
-        switch Locale.current.language.languageCode {
-        case .some(.chinese), .some(.japanese), .some(.korean):
+    /// Consults the app bundle’s active UI language before the system locale, so CJK typography
+    /// applies when the app is localized to Chinese/Japanese/Korean even if the device language is English.
+    static func current(bundle: Bundle = .main) -> ShareTypographyScript {
+        let languages: [Locale.Language] = bundle.preferredLocalizations.map { Locale.Language(identifier: $0) }
+            + [Locale.current.language]
+        for language in languages where isCJK(language.languageCode) {
             return .chinese
+        }
+        return .latin
+    }
+
+    private static func isCJK(_ code: Locale.LanguageCode?) -> Bool {
+        switch code?.identifier {
+        case "zh", "ja", "ko":
+            return true
         default:
-            return .latin
+            return false
         }
     }
 }

--- a/GraceNotes/GraceNotes/Features/Journal/Services/ShareTypographyScript.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ShareTypographyScript.swift
@@ -10,21 +10,54 @@ enum ShareTypographyScript: Equatable, Sendable {
 extension ShareTypographyScript {
     /// Consults the app bundle’s active UI language before the system locale, so CJK typography
     /// applies when the app is localized to Chinese/Japanese/Korean even if the device language is English.
-    static func current(bundle: Bundle = .main) -> ShareTypographyScript {
-        let languages: [Locale.Language] = bundle.preferredLocalizations.map { Locale.Language(identifier: $0) }
-            + [Locale.current.language]
-        for language in languages where isCJK(language.languageCode) {
+    ///
+    /// Uses only the bundle’s first preferred localization (the active UI language), not the full
+    /// `preferredLocalizations` list, which can include additional user languages that are not the app UI.
+    /// - Parameters:
+    ///   - bundle: App bundle (or another bundle in extensions).
+    ///   - preferredUILocalizationIdentifier: Overrides `bundle.preferredLocalizations.first` for tests
+    ///     or custom bundle resolution; pass `nil` for production.
+    ///   - systemLanguage: Device/system language; override in tests instead of relying on `Locale.current`.
+    static func current(
+        bundle: Bundle = .main,
+        preferredUILocalizationIdentifier: String? = nil,
+        systemLanguage: Locale.Language = Locale.current.language
+    ) -> ShareTypographyScript {
+        let uiIdentifier = preferredUILocalizationIdentifier ?? bundle.preferredLocalizations.first
+        var languages: [Locale.Language] = []
+        if let uiIdentifier {
+            languages.append(Locale.Language(identifier: uiIdentifier))
+        }
+        languages.append(systemLanguage)
+        for language in languages where isCJK(language) {
             return .chinese
         }
         return .latin
     }
 
-    private static func isCJK(_ code: Locale.LanguageCode?) -> Bool {
-        switch code?.identifier {
+    private static func isCJK(_ language: Locale.Language) -> Bool {
+        switch resolvedBaseLanguageCode(for: language) {
         case "zh", "ja", "ko":
             return true
         default:
             return false
         }
+    }
+
+    /// Prefer `Locale.Language.languageCode`, then the same derived from a `Locale` wrapper, then the
+    /// leading BCP‑47 tag (covers rare cases where `languageCode` is nil but the identifier is still CJK).
+    private static func resolvedBaseLanguageCode(for language: Locale.Language) -> String? {
+        if let code = language.languageCode?.identifier {
+            return code
+        }
+        let viaLocale = Locale(identifier: language.maximalIdentifier).language.languageCode?.identifier
+        if let viaLocale {
+            return viaLocale
+        }
+        return language.maximalIdentifier
+            .split { $0 == "-" || $0 == "_" }
+            .first
+            .map(String.init)?
+            .lowercased()
     }
 }

--- a/GraceNotes/GraceNotes/Features/Journal/Services/ShareTypographyScript.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ShareTypographyScript.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Latin vs Chinese typography for share cards.
+/// Latin vs system CJK typography for share cards (`zh` / `ja` / `ko` locale languages).
 /// Figma uses Noto for zh; we approximate CJK with system serif/sans to avoid multi‑MB font bundles.
 enum ShareTypographyScript: Equatable, Sendable {
     case latin
@@ -9,9 +9,11 @@ enum ShareTypographyScript: Equatable, Sendable {
 
 extension ShareTypographyScript {
     static func current() -> ShareTypographyScript {
-        if Locale.current.identifier.hasPrefix("zh") {
+        switch Locale.current.language.languageCode?.identifier {
+        case "zh", "ja", "ko":
             return .chinese
+        default:
+            return .latin
         }
-        return .latin
     }
 }

--- a/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyInsightCandidateBuilder.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyInsightCandidateBuilder.swift
@@ -117,6 +117,8 @@ struct WeeklyInsightCandidateBuilder {
                     secondTheme
                 )
                 return nonEmptyTrimmed(combined)
+                    ?? nonEmptyTrimmed(insights[0].observation)
+                    ?? nonEmptyTrimmed(insights[1].observation)
             }
             return nonEmptyTrimmed(second) ?? nonEmptyTrimmed(first)
         }

--- a/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyInsightRuleEngine.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyInsightRuleEngine.swift
@@ -48,13 +48,14 @@ struct WeeklyInsightRuleEngine {
 
         let narrativeSummary = candidateBuilder.narrativeSummary(from: selectedInsights)
         let starterReflection = String(localized: "review.insights.starterReflection")
-        let trimmedHeadline = Self.firstNonEmptyTrimmedHeadline(in: selectedInsights)
-        let resurfacingMessage = trimmedHeadline ?? starterReflection
+        let (headline, primaryInsight) = Self.headlineAndPrimaryInsight(from: selectedInsights)
+        let resurfacingMessage = headline ?? starterReflection
 
-        let continuityPrompt = selectedInsights.compactMap(\.action).map {
-            $0.trimmingCharacters(in: .whitespacesAndNewlines)
-        }.first(where: { !$0.isEmpty })
-            ?? candidateBuilder.defaultContinuityPrompt
+        let continuityPrompt = Self.continuityPrompt(
+            matching: primaryInsight,
+            in: selectedInsights,
+            defaultPrompt: candidateBuilder.defaultContinuityPrompt
+        )
 
         return WeeklyInsightAnalysis(
             weeklyInsights: selectedInsights,
@@ -69,20 +70,46 @@ struct WeeklyInsightRuleEngine {
         )
     }
 
+    /// Prefer a non-empty trimmed `action` from the same insight that drives the resurfacing headline
+    /// (first insight with a non-empty observation or `primaryTheme`), then any other insight’s action,
+    /// so the prompt stays aligned with the line the member actually sees.
+    private static func continuityPrompt(
+        matching primaryInsight: ReviewWeeklyInsight?,
+        in insights: [ReviewWeeklyInsight],
+        defaultPrompt: String
+    ) -> String {
+        if let primary = primaryInsight,
+           let action = primary.action,
+           let trimmed = Self.nonEmptyTrimmed(action) {
+            return trimmed
+        }
+        return insights.compactMap(\.action).map {
+            $0.trimmingCharacters(in: .whitespacesAndNewlines)
+        }.first(where: { !$0.isEmpty })
+            ?? defaultPrompt
+    }
+
+    private static func nonEmptyTrimmed(_ text: String) -> String? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
     /// Prefer the first non-empty trimmed `observation` across selected insights. If an observation is blank
     /// but `primaryTheme` is present (e.g. failed template substitution), use the trimmed theme so the
     /// resurfacing line still matches visible card context instead of the generic starter copy.
-    private static func firstNonEmptyTrimmedHeadline(in insights: [ReviewWeeklyInsight]) -> String? {
+    private static func headlineAndPrimaryInsight(
+        from insights: [ReviewWeeklyInsight]
+    ) -> (headline: String?, primaryInsight: ReviewWeeklyInsight?) {
         for insight in insights {
             let trimmedObservation = insight.observation.trimmingCharacters(in: .whitespacesAndNewlines)
             if !trimmedObservation.isEmpty {
-                return trimmedObservation
+                return (trimmedObservation, insight)
             }
             if let theme = insight.primaryTheme?.trimmingCharacters(in: .whitespacesAndNewlines),
                !theme.isEmpty {
-                return theme
+                return (theme, insight)
             }
         }
-        return nil
+        return (nil, nil)
     }
 }

--- a/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyInsightRuleEngine.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyInsightRuleEngine.swift
@@ -73,7 +73,7 @@ struct WeeklyInsightRuleEngine {
     /// Prefer a non-empty trimmed `action` from the same insight that drives the resurfacing headline
     /// (first insight with a non-empty observation or `primaryTheme`), then any other insight’s action,
     /// so the prompt stays aligned with the line the member actually sees.
-    private static func continuityPrompt(
+    static func continuityPrompt(
         matching primaryInsight: ReviewWeeklyInsight?,
         in insights: [ReviewWeeklyInsight],
         defaultPrompt: String
@@ -83,13 +83,14 @@ struct WeeklyInsightRuleEngine {
            let trimmed = Self.nonEmptyTrimmed(action) {
             return trimmed
         }
-        return insights.compactMap(\.action).map {
-            $0.trimmingCharacters(in: .whitespacesAndNewlines)
-        }.first(where: { !$0.isEmpty })
+        return insights
+            .compactMap(\.action)
+            .compactMap(Self.nonEmptyTrimmed)
+            .first
             ?? defaultPrompt
     }
 
-    private static func nonEmptyTrimmed(_ text: String) -> String? {
+    static func nonEmptyTrimmed(_ text: String) -> String? {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
     }
@@ -97,16 +98,14 @@ struct WeeklyInsightRuleEngine {
     /// Prefer the first non-empty trimmed `observation` across selected insights. If an observation is blank
     /// but `primaryTheme` is present (e.g. failed template substitution), use the trimmed theme so the
     /// resurfacing line still matches visible card context instead of the generic starter copy.
-    private static func headlineAndPrimaryInsight(
+    static func headlineAndPrimaryInsight(
         from insights: [ReviewWeeklyInsight]
     ) -> (headline: String?, primaryInsight: ReviewWeeklyInsight?) {
         for insight in insights {
-            let trimmedObservation = insight.observation.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !trimmedObservation.isEmpty {
+            if let trimmedObservation = Self.nonEmptyTrimmed(insight.observation) {
                 return (trimmedObservation, insight)
             }
-            if let theme = insight.primaryTheme?.trimmingCharacters(in: .whitespacesAndNewlines),
-               !theme.isEmpty {
+            if let theme = insight.primaryTheme.flatMap(Self.nonEmptyTrimmed) {
                 return (theme, insight)
             }
         }

--- a/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyInsightRuleEngine.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyInsightRuleEngine.swift
@@ -48,7 +48,7 @@ struct WeeklyInsightRuleEngine {
 
         let narrativeSummary = candidateBuilder.narrativeSummary(from: selectedInsights)
         let starterReflection = String(localized: "review.insights.starterReflection")
-        let trimmedHeadline = Self.firstNonEmptyTrimmedObservation(in: selectedInsights)
+        let trimmedHeadline = Self.firstNonEmptyTrimmedHeadline(in: selectedInsights)
         let resurfacingMessage = trimmedHeadline ?? starterReflection
 
         let continuityPrompt = selectedInsights.compactMap(\.action).map {
@@ -69,13 +69,18 @@ struct WeeklyInsightRuleEngine {
         )
     }
 
-    /// Prefer the first non-empty observation line across selected insights. The first card can be
-    /// blank in pathological cases while a second selected insight still carries the visible headline.
-    private static func firstNonEmptyTrimmedObservation(in insights: [ReviewWeeklyInsight]) -> String? {
+    /// Prefer the first non-empty trimmed `observation` across selected insights. If an observation is blank
+    /// but `primaryTheme` is present (e.g. failed template substitution), use the trimmed theme so the
+    /// resurfacing line still matches visible card context instead of the generic starter copy.
+    private static func firstNonEmptyTrimmedHeadline(in insights: [ReviewWeeklyInsight]) -> String? {
         for insight in insights {
-            let trimmed = insight.observation.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !trimmed.isEmpty {
-                return trimmed
+            let trimmedObservation = insight.observation.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmedObservation.isEmpty {
+                return trimmedObservation
+            }
+            if let theme = insight.primaryTheme?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !theme.isEmpty {
+                return theme
             }
         }
         return nil

--- a/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyInsightRuleEngine.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyInsightRuleEngine.swift
@@ -46,23 +46,19 @@ struct WeeklyInsightRuleEngine {
             )
         )
 
-        let narrativeSummary = candidateBuilder.narrativeSummary(from: selectedInsights)
-        let trimmedHeadline = selectedInsights.first?.observation
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        let resurfacingMessage: String
-        if let trimmedHeadline, !trimmedHeadline.isEmpty {
-            resurfacingMessage = trimmedHeadline
-        } else {
-            resurfacingMessage = String(localized: "review.insights.starterReflection")
-        }
-
-        let continuityPrompt = selectedInsights.compactMap(\.action).map {
-            $0.trimmingCharacters(in: .whitespacesAndNewlines)
-        }.first(where: { !$0.isEmpty })
-            ?? candidateBuilder.defaultContinuityPrompt
+        let normalizedInsights = Self.normalizedWeeklyInsights(selectedInsights)
+        let narrativeSummary = candidateBuilder.narrativeSummary(from: normalizedInsights)
+        let resurfacingMessage = Self.resurfacingMessage(
+            for: normalizedInsights,
+            emptyObservationFallback: String(localized: "review.insights.starterReflection")
+        )
+        let continuityPrompt = Self.continuityPrompt(
+            for: normalizedInsights,
+            defaultPrompt: candidateBuilder.defaultContinuityPrompt
+        )
 
         return WeeklyInsightAnalysis(
-            weeklyInsights: selectedInsights,
+            weeklyInsights: normalizedInsights,
             recurringGratitudes: aggregates.recurringGratitudes,
             recurringNeeds: aggregates.recurringNeeds,
             recurringPeople: aggregates.recurringPeople,
@@ -72,5 +68,44 @@ struct WeeklyInsightRuleEngine {
             weekStats: aggregates.stats,
             presentationMode: aggregates.supportsInsightNarrative ? .insight : .statsFirst
         )
+    }
+}
+
+extension WeeklyInsightRuleEngine {
+    /// Trims insight copy so `weeklyInsights` matches `resurfacingMessage` / `continuityPrompt`.
+    static func normalizedWeeklyInsights(_ insights: [ReviewWeeklyInsight]) -> [ReviewWeeklyInsight] {
+        insights.map { insight in
+            let trimmedObservation = insight.observation.trimmingCharacters(in: .whitespacesAndNewlines)
+            let trimmedAction = insight.action?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let action: String? = {
+                guard let trimmedAction, !trimmedAction.isEmpty else { return nil }
+                return trimmedAction
+            }()
+            return ReviewWeeklyInsight(
+                pattern: insight.pattern,
+                observation: trimmedObservation,
+                action: action,
+                primaryTheme: insight.primaryTheme,
+                mentionCount: insight.mentionCount,
+                dayCount: insight.dayCount
+            )
+        }
+    }
+
+    static func resurfacingMessage(
+        for insights: [ReviewWeeklyInsight],
+        emptyObservationFallback: String
+    ) -> String {
+        guard let headline = insights.first?.observation, !headline.isEmpty else {
+            return emptyObservationFallback
+        }
+        return headline
+    }
+
+    static func continuityPrompt(
+        for insights: [ReviewWeeklyInsight],
+        defaultPrompt: String
+    ) -> String {
+        insights.compactMap(\.action).first ?? defaultPrompt
     }
 }

--- a/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyInsightRuleEngine.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyInsightRuleEngine.swift
@@ -69,15 +69,18 @@ struct WeeklyInsightRuleEngine {
         )
     }
 
-    /// Prefer the first non-empty trimmed `observation` across selected insights. If an observation is blank
-    /// but `primaryTheme` is present (e.g. failed template substitution), use the trimmed theme so the
-    /// resurfacing line still matches visible card context instead of the generic starter copy.
-    private static func firstNonEmptyTrimmedHeadline(in insights: [ReviewWeeklyInsight]) -> String? {
+    /// Prefer the first non-empty trimmed `observation` across selected insights (scanning every insight
+    /// before any theme). If no observation is available but `primaryTheme` is present (e.g. failed template
+    /// substitution), use the first non-empty trimmed theme so the resurfacing line still matches visible
+    /// card context instead of the generic starter copy.
+    static func firstNonEmptyTrimmedHeadline(in insights: [ReviewWeeklyInsight]) -> String? {
         for insight in insights {
             let trimmedObservation = insight.observation.trimmingCharacters(in: .whitespacesAndNewlines)
             if !trimmedObservation.isEmpty {
                 return trimmedObservation
             }
+        }
+        for insight in insights {
             if let theme = insight.primaryTheme?.trimmingCharacters(in: .whitespacesAndNewlines),
                !theme.isEmpty {
                 return theme

--- a/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyInsightRuleEngine.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyInsightRuleEngine.swift
@@ -47,9 +47,18 @@ struct WeeklyInsightRuleEngine {
         )
 
         let narrativeSummary = candidateBuilder.narrativeSummary(from: selectedInsights)
-        let resurfacingMessage = selectedInsights.first?.observation
-            ?? String(localized: "review.insights.starterReflection")
-        let continuityPrompt = selectedInsights.compactMap(\.action).first
+        let trimmedHeadline = selectedInsights.first?.observation
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let resurfacingMessage: String
+        if let trimmedHeadline, !trimmedHeadline.isEmpty {
+            resurfacingMessage = trimmedHeadline
+        } else {
+            resurfacingMessage = String(localized: "review.insights.starterReflection")
+        }
+
+        let continuityPrompt = selectedInsights.compactMap(\.action).map {
+            $0.trimmingCharacters(in: .whitespacesAndNewlines)
+        }.first(where: { !$0.isEmpty })
             ?? candidateBuilder.defaultContinuityPrompt
 
         return WeeklyInsightAnalysis(

--- a/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyInsightRuleEngine.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyInsightRuleEngine.swift
@@ -46,14 +46,16 @@ struct WeeklyInsightRuleEngine {
             )
         )
 
-        let narrativeSummary = candidateBuilder.narrativeSummary(from: selectedInsights)
+        let normalizedInsights = Self.normalizedWeeklyInsights(selectedInsights)
+
+        let narrativeSummary = candidateBuilder.narrativeSummary(from: normalizedInsights)
         let starterReflection = String(localized: "review.insights.starterReflection")
-        let (headline, primaryInsight) = Self.headlineAndPrimaryInsight(from: selectedInsights)
+        let (headline, primaryInsight) = Self.headlineAndPrimaryInsight(from: normalizedInsights)
         let resurfacingMessage = headline ?? starterReflection
 
         let continuityPrompt = Self.continuityPrompt(
             matching: primaryInsight,
-            in: selectedInsights,
+            in: normalizedInsights,
             defaultPrompt: candidateBuilder.defaultContinuityPrompt
         )
 
@@ -95,6 +97,22 @@ struct WeeklyInsightRuleEngine {
         return trimmed.isEmpty ? nil : trimmed
     }
 
+    /// Scans all insights for a non-empty trimmed `observation` first, then any `primaryTheme`, so a later
+    /// observation wins over an earlier blank observation + theme (used by headline tests).
+    static func firstNonEmptyTrimmedHeadline(in insights: [ReviewWeeklyInsight]) -> String {
+        for insight in insights {
+            if let trimmed = Self.nonEmptyTrimmed(insight.observation) {
+                return trimmed
+            }
+        }
+        for insight in insights {
+            if let theme = insight.primaryTheme.flatMap(Self.nonEmptyTrimmed) {
+                return theme
+            }
+        }
+        return ""
+    }
+
     /// Prefer the first non-empty trimmed `observation` across selected insights. If an observation is blank
     /// but `primaryTheme` is present (e.g. failed template substitution), use the trimmed theme so the
     /// resurfacing line still matches visible card context instead of the generic starter copy.
@@ -110,5 +128,44 @@ struct WeeklyInsightRuleEngine {
             }
         }
         return (nil, nil)
+    }
+}
+
+extension WeeklyInsightRuleEngine {
+    /// Trims insight copy so `weeklyInsights` matches `resurfacingMessage` / `continuityPrompt`.
+    static func normalizedWeeklyInsights(_ insights: [ReviewWeeklyInsight]) -> [ReviewWeeklyInsight] {
+        insights.map { insight in
+            let trimmedObservation = insight.observation.trimmingCharacters(in: .whitespacesAndNewlines)
+            let trimmedAction = insight.action?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let action: String? = {
+                guard let trimmedAction, !trimmedAction.isEmpty else { return nil }
+                return trimmedAction
+            }()
+            return ReviewWeeklyInsight(
+                pattern: insight.pattern,
+                observation: trimmedObservation,
+                action: action,
+                primaryTheme: insight.primaryTheme,
+                mentionCount: insight.mentionCount,
+                dayCount: insight.dayCount
+            )
+        }
+    }
+
+    static func resurfacingMessage(
+        for insights: [ReviewWeeklyInsight],
+        emptyObservationFallback: String
+    ) -> String {
+        guard let headline = insights.first?.observation, !headline.isEmpty else {
+            return emptyObservationFallback
+        }
+        return headline
+    }
+
+    static func continuityPrompt(
+        for insights: [ReviewWeeklyInsight],
+        defaultPrompt: String
+    ) -> String {
+        insights.compactMap(\.action).first ?? defaultPrompt
     }
 }

--- a/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregates.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregates.swift
@@ -223,6 +223,9 @@ private extension WeeklyReviewAggregatesBuilder {
         return sortedThemeSummaries(from: themeMap)
     }
 
+    /// Recurring chips sort by mention/day; further ties use scan order (`firstSeenOrder`) before label,
+    /// matching ``sortedThemeSummaries`` for chip-only aggregates (narrative paths can still differ when text
+    /// themes mix in).
     func topThemes(from summaries: [ThemeSummary]) -> [ReviewInsightTheme] {
         summaries
             .sorted {
@@ -258,21 +261,25 @@ private extension WeeklyReviewAggregatesBuilder {
         let normalized = textNormalizer.normalizeThemeLabel(trimmedLabel)
         guard !normalized.isEmpty else { return }
 
-        if var existing = map[normalized] {
-            existing.mentionCount += 1
-            existing.weightedScore += weight
-            existing.days.insert(day)
-            map[normalized] = existing
+        let isNew = map[normalized] == nil
+        var accumulator = map[normalized] ?? ThemeAccumulator(
+            normalizedLabel: normalized,
+            displayLabel: trimmedLabel,
+            mentionCount: 0,
+            weightedScore: 0,
+            days: [],
+            firstSeenOrder: sequence
+        )
+        if isNew {
+            accumulator.mentionCount = 1
+            accumulator.weightedScore = weight
+            accumulator.days = [day]
         } else {
-            map[normalized] = ThemeAccumulator(
-                normalizedLabel: normalized,
-                displayLabel: trimmedLabel,
-                mentionCount: 1,
-                weightedScore: weight,
-                days: [day],
-                firstSeenOrder: sequence
-            )
+            accumulator.mentionCount += 1
+            accumulator.weightedScore += weight
+            accumulator.days.insert(day)
         }
+        map[normalized] = accumulator
     }
 
     func sortedThemeSummaries(from map: [String: ThemeAccumulator]) -> [ThemeSummary] {

--- a/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregates.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregates.swift
@@ -1,5 +1,13 @@
 import Foundation
 
+/// Caps how far back ``WeeklyReviewAggregatesBuilder/buildRhythmHistory`` materializes
+/// calendar-day rows so multi-year journals cannot allocate unbounded ``ReviewDayActivity`` arrays.
+/// Custom Past statistics windows already clip via ``PastStatisticsIntervalSelection/resolvedHistoryRange``.
+private enum RhythmHistoryLimits {
+    /// Maximum inclusive number of local calendar days in the rhythm strip (about two years).
+    static let maxInclusiveCalendarDays = 731
+}
+
 struct ThemeSummary {
     let normalizedLabel: String
     let displayLabel: String
@@ -315,21 +323,22 @@ private extension WeeklyReviewAggregatesBuilder {
             strongestCompletionByDay: weekStrongestByDay,
             calendar: calendar
         )
+        let historyRange = pastStatisticsInterval.validated.resolvedHistoryRange(
+            referenceDate: referenceDate,
+            calendar: calendar,
+            allEntries: allEntries
+        )
         let rhythmHistory = buildRhythmHistory(
             allEntries: allEntries,
             currentPeriod: currentPeriod,
             calendar: calendar,
-            referenceDate: referenceDate
+            referenceDate: referenceDate,
+            pastStatisticsHistoryLowerBound: historyRange.lowerBound
         )
         let sectionTotals = ReviewWeekSectionTotals(
             gratitudeMentions: entries.reduce(0) { $0 + ($1.gratitudes ?? []).count },
             needMentions: entries.reduce(0) { $0 + ($1.needs ?? []).count },
             peopleMentions: entries.reduce(0) { $0 + ($1.people ?? []).count }
-        )
-        let historyRange = pastStatisticsInterval.validated.resolvedHistoryRange(
-            referenceDate: referenceDate,
-            calendar: calendar,
-            allEntries: allEntries
         )
         let entriesInHistoryRange = ReviewHistoryWindowing.entriesInValidatedHistoryWindow(
             allEntries: allEntries,
@@ -370,13 +379,16 @@ private extension WeeklyReviewAggregatesBuilder {
         )
     }
 
-    /// Builds a dense oldest-to-newest activity sequence from the earliest journal day through
-    /// ``min(lastDayOfReviewWeek, startOfReferenceDay)`` (one row per calendar day, including hollow days).
+    /// Builds a dense oldest-to-newest activity sequence through ``min(lastDayOfReviewWeek, startOfReferenceDay)``
+    /// (one row per calendar day, including hollow days). Starts no earlier than the Past statistics window
+    /// (``pastStatisticsHistoryLowerBound``) and applies ``RhythmHistoryLimits`` so multi-year journals cannot
+    /// allocate an unbounded number of rows.
     func buildRhythmHistory(
         allEntries: [Journal],
         currentPeriod: Range<Date>,
         calendar: Calendar,
-        referenceDate: Date
+        referenceDate: Date,
+        pastStatisticsHistoryLowerBound: Date
     ) -> [ReviewDayActivity]? {
         guard !allEntries.isEmpty else { return nil }
 
@@ -393,7 +405,21 @@ private extension WeeklyReviewAggregatesBuilder {
         guard let entryMinRaw = allEntries.map({ calendar.startOfDay(for: $0.entryDate) }).min() else {
             return nil
         }
-        let startDay = entryMinRaw
+        let pastWindowStart = calendar.startOfDay(for: pastStatisticsHistoryLowerBound)
+        let windowClampedStart = max(entryMinRaw, pastWindowStart)
+        let horizonCappedStart: Date = {
+            guard
+                let capped = calendar.date(
+                    byAdding: .day,
+                    value: -(RhythmHistoryLimits.maxInclusiveCalendarDays - 1),
+                    to: endDayInclusive
+                )
+            else {
+                return windowClampedStart
+            }
+            return max(windowClampedStart, calendar.startOfDay(for: capped))
+        }()
+        let startDay = horizonCappedStart
         guard startDay <= endDayInclusive else { return nil }
 
         guard let rangeEndExclusive = calendar.date(byAdding: .day, value: 1, to: endDayInclusive) else {

--- a/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregatesBuilder+ThemeSections.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregatesBuilder+ThemeSections.swift
@@ -280,11 +280,20 @@ extension WeeklyReviewAggregatesBuilder {
         let normalizedSupport = textNormalizer.normalizeThemeLabel(supportText)
         let normalizedTheme = textNormalizer.normalizeThemeLabel(themeConcept)
         guard !normalizedSupport.isEmpty, !normalizedTheme.isEmpty else { return false }
-        // CJK: word boundaries and Latin token overlap do not apply; substring match either direction.
-        if containsHanCharacters(themeConcept) || containsHanCharacters(supportText) {
+        // Substring matching is for CJK themes where `\b` and token overlap do not apply. If the theme is
+        // Latin-only, substring matching whenever the support text also contains CJK would reintroduce
+        // Latin-in-word hits (e.g. "rest" inside "forest") in mixed-language passages.
+        if containsHanCharacters(themeConcept) {
             return normalizedSupport.contains(normalizedTheme) || normalizedTheme.contains(normalizedSupport)
         }
-        // Latin: naive `contains` matches inside other words (e.g. "rest" in "forest"); require word boundaries.
+        return latinNormalizedThemeMatchesSupport(
+            normalizedTheme: normalizedTheme,
+            normalizedSupport: normalizedSupport
+        )
+    }
+
+    /// Latin-safe matching after normalization: word boundaries, then multi-character token overlap.
+    private func latinNormalizedThemeMatchesSupport(normalizedTheme: String, normalizedSupport: String) -> Bool {
         if latinPhraseHasWordBoundaryMatch(haystack: normalizedSupport, needle: normalizedTheme)
             || latinPhraseHasWordBoundaryMatch(haystack: normalizedTheme, needle: normalizedSupport) {
             return true

--- a/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregatesBuilder+ThemeSections.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregatesBuilder+ThemeSections.swift
@@ -123,6 +123,7 @@ extension WeeklyReviewAggregatesBuilder {
 
         let mostRecurringSorted = map.values
             .filter { $0.totalCount >= minimumMostRecurringSignalCount }
+            .filter { passesPenalizedThemeMostRecurringFloor($0) }
             .sorted {
                 if $0.totalCount != $1.totalCount {
                     return $0.totalCount > $1.totalCount
@@ -171,6 +172,15 @@ extension WeeklyReviewAggregatesBuilder {
         )
 
         return (mostRecurring, trending)
+    }
+
+    /// Penalized generic labels (see ``ReviewCuratedThemeMap/penalizedConcepts``) need more than the
+    /// bare minimum recurrence to appear in Most Recurring; two sparse chips are not enough context.
+    private func passesPenalizedThemeMostRecurringFloor(_ value: DistilledThemeAccumulator) -> Bool {
+        guard ReviewCuratedThemeMap.defaultMap.penalizedConcepts.contains(value.canonicalConcept) else {
+            return true
+        }
+        return value.totalCount >= 3 || value.days.count >= 3
     }
 
     /// Picks the highest-scoring `ReviewDistilledConcept` per canonical label while preserving the order of

--- a/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregatesBuilder+ThemeSections.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregatesBuilder+ThemeSections.swift
@@ -280,7 +280,8 @@ extension WeeklyReviewAggregatesBuilder {
         let normalizedSupport = textNormalizer.normalizeThemeLabel(supportText)
         let normalizedTheme = textNormalizer.normalizeThemeLabel(themeConcept)
         guard !normalizedSupport.isEmpty, !normalizedTheme.isEmpty else { return false }
-        if containsHanCharacters(themeConcept) {
+        // CJK: word boundaries and Latin token overlap do not apply; substring match either direction.
+        if containsHanCharacters(themeConcept) || containsHanCharacters(supportText) {
             return normalizedSupport.contains(normalizedTheme) || normalizedTheme.contains(normalizedSupport)
         }
         // Latin: naive `contains` matches inside other words (e.g. "rest" in "forest"); require word boundaries.

--- a/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregatesBuilder+ThemeSections.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregatesBuilder+ThemeSections.swift
@@ -28,7 +28,7 @@ extension WeeklyReviewAggregatesBuilder {
             forJournalCorpus: journalCorpus
         )
         var map: [String: DistilledThemeAccumulator] = [:]
-        /// Strongest section source seen for each canonical (drives `displayLabel`; `.people` enables person labels).
+        // Strongest section source seen for each canonical (drives `displayLabel`; `.people` enables person labels).
         var displaySourceByCanonical: [String: ReviewThemeSourceCategory] = [:]
         var sequence = 0
 
@@ -337,6 +337,7 @@ extension WeeklyReviewAggregatesBuilder {
                 return 0
             }
         }
+        // When ranks tie, keep lhs (the category already stored for this canonical).
         return rank(lhs) >= rank(rhs) ? lhs : rhs
     }
 

--- a/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregatesBuilder+ThemeSections.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregatesBuilder+ThemeSections.swift
@@ -280,13 +280,30 @@ extension WeeklyReviewAggregatesBuilder {
         let normalizedSupport = textNormalizer.normalizeThemeLabel(supportText)
         let normalizedTheme = textNormalizer.normalizeThemeLabel(themeConcept)
         guard !normalizedSupport.isEmpty, !normalizedTheme.isEmpty else { return false }
-        if containsHanCharacters(themeConcept) {
+        // Drive script routing from the same normalized label we compare; `normalizeThemeLabel` does not strip Han.
+        if containsHanCharacters(normalizedTheme) || containsHanCharacters(themeConcept) {
             return normalizedSupport.contains(normalizedTheme) || normalizedTheme.contains(normalizedSupport)
         }
-        // Latin: naive `contains` matches inside other words (e.g. "rest" in "forest"); require word boundaries.
-        if latinPhraseHasWordBoundaryMatch(haystack: normalizedSupport, needle: normalizedTheme)
-            || latinPhraseHasWordBoundaryMatch(haystack: normalizedTheme, needle: normalizedSupport) {
-            return true
+        let latinPairSafeForRegexWordBoundaries =
+            isLatinWhitespaceDelimitedForRegexWordBoundaries(normalizedTheme)
+            && isLatinWhitespaceDelimitedForRegexWordBoundaries(normalizedSupport)
+        if latinPairSafeForRegexWordBoundaries {
+            // `\b` aligns with whitespace-delimited Latin words; skip for kana, Cyrillic, emoji-mixed text, etc.
+            if latinPhraseHasWordBoundaryMatch(haystack: normalizedSupport, needle: normalizedTheme)
+                || latinPhraseHasWordBoundaryMatch(haystack: normalizedTheme, needle: normalizedSupport) {
+                return true
+            }
+        } else {
+            if phraseMatchesUsingEnumeratedWords(haystack: normalizedSupport, needle: normalizedTheme)
+                || phraseMatchesUsingEnumeratedWords(haystack: normalizedTheme, needle: normalizedSupport) {
+                return true
+            }
+            // Avoid naive substring matching when ASCII Latin appears (e.g. "rest" inside "forest").
+            if !hasASCIILatinLetters(normalizedTheme), !hasASCIILatinLetters(normalizedSupport) {
+                if normalizedSupport.contains(normalizedTheme) || normalizedTheme.contains(normalizedSupport) {
+                    return true
+                }
+            }
         }
         let themeTokens = Set(normalizedTheme.split(separator: " ").map(String.init).filter { $0.count >= 3 })
         let supportTokens = Set(normalizedSupport.split(separator: " ").map(String.init).filter { $0.count >= 3 })
@@ -296,7 +313,62 @@ extension WeeklyReviewAggregatesBuilder {
         return !themeTokens.isDisjoint(with: supportTokens)
     }
 
-    /// Whole-phrase / whole-word match for Latin script; avoids substring hits like "rest" inside "forest".
+    /// True when the string is only Latin letters/digits/whitespace — safe for regex `\\b` word boundaries.
+    private func isLatinWhitespaceDelimitedForRegexWordBoundaries(_ text: String) -> Bool {
+        let range = NSRange(text.startIndex..., in: text)
+        return Self.latinWhitespaceDelimitedRegex.firstMatch(in: text, options: [], range: range) != nil
+    }
+
+    private static let latinWhitespaceDelimitedRegex: NSRegularExpression = {
+        // swiftlint:disable:next force_try
+        try! NSRegularExpression(pattern: "^[\\p{Latin}\\p{Nd}\\s]*$", options: [])
+    }()
+
+    private func hasASCIILatinLetters(_ text: String) -> Bool {
+        text.contains { character in
+            character.isLetter && character.isASCII
+        }
+    }
+
+    /// Whole-word / phrase match via `enumerateSubstrings(.byWords)` when regex `\\b` is unreliable.
+    private func phraseMatchesUsingEnumeratedWords(haystack: String, needle: String) -> Bool {
+        let needleWords = needle.split(whereSeparator: { $0.isWhitespace }).map(String.init).filter { !$0.isEmpty }
+        guard !needleWords.isEmpty else { return false }
+        if needleWords.count == 1 {
+            return wordMatchesUsingEnumeratedWords(haystack: haystack, word: needleWords[0])
+        }
+        var haystackWords: [String] = []
+        haystack.enumerateSubstrings(in: haystack.startIndex..., options: [.byWords]) { substring, _, _, _ in
+            if let substring, !substring.isEmpty {
+                haystackWords.append(substring)
+            }
+        }
+        let loweredNeedle = needleWords.map { $0.lowercased() }
+        let loweredHaystack = haystackWords.map { $0.lowercased() }
+        guard loweredNeedle.count <= loweredHaystack.count else { return false }
+        for start in 0...(loweredHaystack.count - loweredNeedle.count) {
+            let end = start + loweredNeedle.count
+            let window = Array(loweredHaystack[start..<end])
+            if window == loweredNeedle {
+                return true
+            }
+        }
+        return false
+    }
+
+    private func wordMatchesUsingEnumeratedWords(haystack: String, word: String) -> Bool {
+        let target = word.lowercased()
+        var found = false
+        haystack.enumerateSubstrings(in: haystack.startIndex..., options: [.byWords]) { substring, _, _, _ in
+            guard let substring, !substring.isEmpty else { return }
+            if substring.lowercased() == target {
+                found = true
+            }
+        }
+        return found
+    }
+
+    /// Whole-phrase / whole-word match for Latin-only strings; avoids substring hits like "rest" inside "forest".
     private func latinPhraseHasWordBoundaryMatch(haystack: String, needle: String) -> Bool {
         guard needle.count <= haystack.count else { return false }
         let escaped = NSRegularExpression.escapedPattern(for: needle)

--- a/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregatesBuilder+ThemeSections.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregatesBuilder+ThemeSections.swift
@@ -278,19 +278,30 @@ extension WeeklyReviewAggregatesBuilder {
 
     func moderateSurfaceSemanticMatch(themeConcept: String, supportText: String) -> Bool {
         let normalizedSupport = textNormalizer.normalizeThemeLabel(supportText)
-        guard !normalizedSupport.isEmpty else { return false }
-        if normalizedSupport.contains(themeConcept) || themeConcept.contains(normalizedSupport) {
+        let normalizedTheme = textNormalizer.normalizeThemeLabel(themeConcept)
+        guard !normalizedSupport.isEmpty, !normalizedTheme.isEmpty else { return false }
+        if containsHanCharacters(themeConcept) {
+            return normalizedSupport.contains(normalizedTheme) || normalizedTheme.contains(normalizedSupport)
+        }
+        // Latin: naive `contains` matches inside other words (e.g. "rest" in "forest"); require word boundaries.
+        if latinPhraseHasWordBoundaryMatch(haystack: normalizedSupport, needle: normalizedTheme)
+            || latinPhraseHasWordBoundaryMatch(haystack: normalizedTheme, needle: normalizedSupport) {
             return true
         }
-        if containsHanCharacters(themeConcept) {
-            return normalizedSupport.contains(themeConcept)
-        }
-        let themeTokens = Set(themeConcept.split(separator: " ").map(String.init).filter { $0.count >= 3 })
+        let themeTokens = Set(normalizedTheme.split(separator: " ").map(String.init).filter { $0.count >= 3 })
         let supportTokens = Set(normalizedSupport.split(separator: " ").map(String.init).filter { $0.count >= 3 })
         if themeTokens.isEmpty || supportTokens.isEmpty {
             return false
         }
         return !themeTokens.isDisjoint(with: supportTokens)
+    }
+
+    /// Whole-phrase / whole-word match for Latin script; avoids substring hits like "rest" inside "forest".
+    private func latinPhraseHasWordBoundaryMatch(haystack: String, needle: String) -> Bool {
+        guard needle.count <= haystack.count else { return false }
+        let escaped = NSRegularExpression.escapedPattern(for: needle)
+        let pattern = "\\b\(escaped)\\b"
+        return haystack.range(of: pattern, options: .regularExpression) != nil
     }
 
     func containsHanCharacters(_ text: String) -> Bool {

--- a/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregatesBuilder+ThemeSections.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregatesBuilder+ThemeSections.swift
@@ -50,8 +50,7 @@ extension WeeklyReviewAggregatesBuilder {
                     highConfidenceOnly: false,
                     journalThemeDisplayLocale: journalThemeDisplayLocale
                 )
-                let uniqueConcepts = Dictionary(grouping: concepts, by: \.canonicalConcept)
-                    .compactMap { _, candidates in candidates.max(by: { $0.score < $1.score }) }
+                let uniqueConcepts = Self.bestUniqueDistilledConceptsPreservingConceptOrder(concepts)
 
                 for concept in uniqueConcepts {
                     if let existing = displaySourceByCanonical[concept.canonicalConcept] {
@@ -172,6 +171,27 @@ extension WeeklyReviewAggregatesBuilder {
         )
 
         return (mostRecurring, trending)
+    }
+
+    /// Picks the highest-scoring `ReviewDistilledConcept` per canonical label while preserving the order of
+    /// first encounter in `concepts` (the extractor’s emitted order), avoiding nondeterministic `Dictionary` key
+    /// iteration when assigning `firstSeenOrder` for themes that debut on the same structured surface.
+    private static func bestUniqueDistilledConceptsPreservingConceptOrder(
+        _ concepts: [ReviewDistilledConcept]
+    ) -> [ReviewDistilledConcept] {
+        var bestByCanonical: [String: ReviewDistilledConcept] = [:]
+        var firstSeenCanonicals: [String] = []
+        for concept in concepts {
+            if let existing = bestByCanonical[concept.canonicalConcept] {
+                if concept.score > existing.score {
+                    bestByCanonical[concept.canonicalConcept] = concept
+                }
+            } else {
+                bestByCanonical[concept.canonicalConcept] = concept
+                firstSeenCanonicals.append(concept.canonicalConcept)
+            }
+        }
+        return firstSeenCanonicals.compactMap { bestByCanonical[$0] }
     }
 
     func appendSupportingEvidence(

--- a/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregatesBuilder+ThemeSections.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregatesBuilder+ThemeSections.swift
@@ -280,11 +280,39 @@ extension WeeklyReviewAggregatesBuilder {
         let normalizedSupport = textNormalizer.normalizeThemeLabel(supportText)
         let normalizedTheme = textNormalizer.normalizeThemeLabel(themeConcept)
         guard !normalizedSupport.isEmpty, !normalizedTheme.isEmpty else { return false }
-        // CJK: word boundaries and Latin token overlap do not apply; substring match either direction.
-        if containsHanCharacters(themeConcept) || containsHanCharacters(supportText) {
+
+        let hasHanInRaw = containsHanCharacters(themeConcept) || containsHanCharacters(supportText)
+        let bothNormalizedHaveLatin = containsLatinLetters(normalizedTheme) && containsLatinLetters(normalizedSupport)
+        let latinWordOrTokenMatch = latinWordBoundaryOrTokenOverlap(
+            normalizedTheme: normalizedTheme,
+            normalizedSupport: normalizedSupport
+        )
+
+        if !hasHanInRaw {
+            return latinWordOrTokenMatch
+        }
+
+        if !bothNormalizedHaveLatin {
+            // Han/kanji (or one side lacks Latin letters): `\b` and Latin token overlap are unreliable;
+            // substring either way.
             return normalizedSupport.contains(normalizedTheme) || normalizedTheme.contains(normalizedSupport)
         }
-        // Latin: naive `contains` matches inside other words (e.g. "rest" in "forest"); require word boundaries.
+
+        if latinWordOrTokenMatch {
+            return true
+        }
+
+        // Both normalized strings include Latin letters; Latin checks already ran. Substring fallback only when both
+        // sides also include Han characters (Han/kanji adjacency), avoiding pure Latin substring hits like "rest"
+        // inside "forest …" when a Han character triggers the Han path.
+        let bidirectionalSubstring =
+            normalizedSupport.contains(normalizedTheme) || normalizedTheme.contains(normalizedSupport)
+        return bidirectionalSubstring
+            && containsHanCharacters(normalizedTheme)
+            && containsHanCharacters(normalizedSupport)
+    }
+
+    private func latinWordBoundaryOrTokenOverlap(normalizedTheme: String, normalizedSupport: String) -> Bool {
         if latinPhraseHasWordBoundaryMatch(haystack: normalizedSupport, needle: normalizedTheme)
             || latinPhraseHasWordBoundaryMatch(haystack: normalizedTheme, needle: normalizedSupport) {
             return true
@@ -303,6 +331,10 @@ extension WeeklyReviewAggregatesBuilder {
         let escaped = NSRegularExpression.escapedPattern(for: needle)
         let pattern = "\\b\(escaped)\\b"
         return haystack.range(of: pattern, options: .regularExpression) != nil
+    }
+
+    private func containsLatinLetters(_ normalized: String) -> Bool {
+        normalized.range(of: "\\p{Latin}", options: .regularExpression) != nil
     }
 
     func containsHanCharacters(_ text: String) -> Bool {

--- a/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregatesBuilder+ThemeSections.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregatesBuilder+ThemeSections.swift
@@ -28,6 +28,8 @@ extension WeeklyReviewAggregatesBuilder {
             forJournalCorpus: journalCorpus
         )
         var map: [String: DistilledThemeAccumulator] = [:]
+        /// Strongest section source seen for each canonical (drives `displayLabel`; `.people` enables person labels).
+        var displaySourceByCanonical: [String: ReviewThemeSourceCategory] = [:]
         var sequence = 0
 
         for entry in entries {
@@ -52,6 +54,14 @@ extension WeeklyReviewAggregatesBuilder {
                     .compactMap { _, candidates in candidates.max(by: { $0.score < $1.score }) }
 
                 for concept in uniqueConcepts {
+                    if let existing = displaySourceByCanonical[concept.canonicalConcept] {
+                        displaySourceByCanonical[concept.canonicalConcept] = strongerDisplaySourceForThemeLabel(
+                            existing,
+                            surface.source
+                        )
+                    } else {
+                        displaySourceByCanonical[concept.canonicalConcept] = surface.source
+                    }
                     let isFirstAppearance = map[concept.canonicalConcept] == nil
                     var accumulator = map[concept.canonicalConcept] ?? DistilledThemeAccumulator(
                         canonicalConcept: concept.canonicalConcept,
@@ -98,8 +108,12 @@ extension WeeklyReviewAggregatesBuilder {
 
         for canonical in Array(map.keys) {
             guard var accumulator = map[canonical] else { continue }
-            let source: ReviewThemeSourceCategory =
-                canonical == "mom" || canonical == "dad" ? .people : .gratitudes
+            let source: ReviewThemeSourceCategory
+            if canonical == "mom" || canonical == "dad" {
+                source = .people
+            } else {
+                source = displaySourceByCanonical[canonical] ?? .gratitudes
+            }
             accumulator.displayLabel = textNormalizer.displayLabel(
                 for: accumulator.canonicalConcept,
                 source: source,
@@ -306,9 +320,29 @@ extension WeeklyReviewAggregatesBuilder {
         return !themeTokens.isDisjoint(with: supportTokens)
     }
 
+    /// Picks the section whose `displayLabel` semantics should win when a theme appears in more than one chip type.
+    private func strongerDisplaySourceForThemeLabel(
+        _ lhs: ReviewThemeSourceCategory,
+        _ rhs: ReviewThemeSourceCategory
+    ) -> ReviewThemeSourceCategory {
+        func rank(_ source: ReviewThemeSourceCategory) -> Int {
+            switch source {
+            case .people:
+                return 3
+            case .needs:
+                return 2
+            case .gratitudes:
+                return 1
+            case .readingNotes, .reflections:
+                return 0
+            }
+        }
+        return rank(lhs) >= rank(rhs) ? lhs : rhs
+    }
+
     /// Whole-phrase / whole-word match for Latin script; avoids substring hits like "rest" inside "forest".
     private func latinPhraseHasWordBoundaryMatch(haystack: String, needle: String) -> Bool {
-        guard needle.count <= haystack.count else { return false }
+        guard !needle.isEmpty, needle.count <= haystack.count else { return false }
         let escaped = NSRegularExpression.escapedPattern(for: needle)
         let pattern = "\\b\(escaped)\\b"
         return haystack.range(of: pattern, options: .regularExpression) != nil

--- a/GraceNotes/GraceNotes/Features/Journal/Tutorial/AppTourView.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Tutorial/AppTourView.swift
@@ -345,12 +345,12 @@ struct AppTourInsightsPreview: View {
     /// Shows roughly the source row + upper ~4/5 of the Reflection rhythm panel, then fades before Observation.
     private static let previewClipHeight: CGFloat = 360
 
-    /// Built once so the panel does not rebuild identical preview data on every SwiftUI body pass.
-    private static let sampleInsights = ReviewInsights.appTourTutorialPreview()
+    /// Built once per view instance so the panel does not rebuild identical preview data on every SwiftUI body pass.
+    @State private var sampleInsights = ReviewInsights.appTourTutorialPreview()
 
     var body: some View {
         ReviewDaysYouWrotePanel(
-            insights: Self.sampleInsights,
+            insights: sampleInsights,
             isLoading: false
         )
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalOnboardingFlowEvaluator.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalOnboardingFlowEvaluator.swift
@@ -6,6 +6,20 @@ enum JournalOnboardingStep: Equatable {
     case person
 }
 
+private extension JournalOnboardingStep {
+    /// Section whose row hosts the onboarding banner for this linear step.
+    var bannerSection: JournalOnboardingSection {
+        switch self {
+        case .gratitude:
+            .gratitude
+        case .need:
+            .need
+        case .person:
+            .person
+        }
+    }
+}
+
 enum JournalOnboardingSection: Hashable {
     case gratitude
     case need
@@ -58,23 +72,20 @@ struct JournalOnboardingPresentation: Equatable {
 
     /// Per-section placement: linear steps use the active row.
     func sectionGuidance(for section: JournalOnboardingSection) -> JournalOnboardingSectionGuidance? {
-        guard let title, let message, let step else { return nil }
-        let bannerSection: JournalOnboardingSection = switch step {
-        case .gratitude:
-            .gratitude
-        case .need:
-            .need
-        case .person:
-            .person
-        }
-        guard section == bannerSection else { return nil }
+        guard let message, let step else { return nil }
+        guard !message.isEmpty else { return nil }
+        guard section == step.bannerSection else { return nil }
         let secondary: String? = switch step {
         case .gratitude:
             String(localized: "journal.onboarding.keyboardFinishHint")
         case .need, .person:
             nil
         }
-        return JournalOnboardingSectionGuidance(title: title, message: message, messageSecondary: secondary)
+        return JournalOnboardingSectionGuidance(
+            title: title ?? "",
+            message: message,
+            messageSecondary: secondary
+        )
     }
 }
 
@@ -93,15 +104,19 @@ enum JournalOnboardingFlowEvaluator {
             return .inactive
         }
 
-        if context.gratitudesCount == 0 {
+        let gratitudes = max(0, context.gratitudesCount)
+        let needs = max(0, context.needsCount)
+        let people = max(0, context.peopleCount)
+
+        if gratitudes == 0 {
             return firstGratitudePresentation()
         }
 
-        if context.needsCount == 0 {
+        if needs == 0 {
             return firstNeedPresentation()
         }
 
-        if context.peopleCount == 0 {
+        if people == 0 {
             return firstPersonPresentation()
         }
 
@@ -112,7 +127,7 @@ enum JournalOnboardingFlowEvaluator {
 private extension JournalOnboardingFlowEvaluator {
     static func presentation(
         step: JournalOnboardingStep,
-        title: String,
+        title: String?,
         message: String,
         states: [JournalOnboardingSection: JournalOnboardingSectionState]
     ) -> JournalOnboardingPresentation {
@@ -135,7 +150,7 @@ private extension JournalOnboardingFlowEvaluator {
     static func firstGratitudePresentation() -> JournalOnboardingPresentation {
         presentation(
             step: .gratitude,
-            title: "",
+            title: nil,
             message: String(localized: "journal.onboarding.startWithGratitude"),
             states: [
                 .gratitude: .active,

--- a/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalOnboardingFlowEvaluator.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalOnboardingFlowEvaluator.swift
@@ -62,8 +62,10 @@ struct JournalOnboardingPresentation: Equatable {
         sectionStates: [:]
     )
 
+    /// True when guided copy is actually shown (`sectionGuidance` would be non-nil for the active step).
     var isGuidanceActive: Bool {
-        step != nil
+        guard step != nil, let message else { return false }
+        return !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     func state(for section: JournalOnboardingSection) -> JournalOnboardingSectionState {
@@ -73,14 +75,18 @@ struct JournalOnboardingPresentation: Equatable {
     /// Per-section placement: linear steps use the active row.
     func sectionGuidance(for section: JournalOnboardingSection) -> JournalOnboardingSectionGuidance? {
         guard let message, let step else { return nil }
-        guard !message.isEmpty else { return nil }
+        guard !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
         guard section == step.bannerSection else { return nil }
-        let secondary: String? = switch step {
-        case .gratitude:
-            String(localized: "journal.onboarding.keyboardFinishHint")
-        case .need, .person:
-            nil
-        }
+        let secondary: String? = {
+            switch step {
+            case .gratitude:
+                let hint = String(localized: "journal.onboarding.keyboardFinishHint")
+                let trimmed = hint.trimmingCharacters(in: .whitespacesAndNewlines)
+                return trimmed.isEmpty ? nil : trimmed
+            case .need, .person:
+                return nil
+            }
+        }()
         return JournalOnboardingSectionGuidance(
             title: title ?? "",
             message: message,

--- a/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalOnboardingFlowEvaluator.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalOnboardingFlowEvaluator.swift
@@ -63,7 +63,7 @@ struct JournalOnboardingPresentation: Equatable {
     )
 
     var isGuidanceActive: Bool {
-        step != nil
+        step != nil && !(message?.isEmpty ?? true)
     }
 
     func state(for section: JournalOnboardingSection) -> JournalOnboardingSectionState {
@@ -131,7 +131,16 @@ private extension JournalOnboardingFlowEvaluator {
         message: String,
         states: [JournalOnboardingSection: JournalOnboardingSectionState]
     ) -> JournalOnboardingPresentation {
-        JournalOnboardingPresentation(
+        if message.isEmpty {
+            #if DEBUG
+            assertionFailure(
+                "Journal onboarding requires non-empty message for step \(step); "
+                    + "treating as inactive to avoid locked sections without copy."
+            )
+            #endif
+            return .inactive
+        }
+        return JournalOnboardingPresentation(
             step: step,
             title: title,
             message: message,

--- a/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalOnboardingFlowEvaluator.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalOnboardingFlowEvaluator.swift
@@ -62,7 +62,8 @@ struct JournalOnboardingPresentation: Equatable {
         sectionStates: [:]
     )
 
-    /// True when guided copy is actually shown (`sectionGuidance` would be non-nil for the active step).
+    /// True when guided copy is actually shown for the active step's banner section
+    /// (that is, when `sectionGuidance(for: step.bannerSection)` would be non-nil).
     var isGuidanceActive: Bool {
         guard step != nil, let message else { return false }
         return !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -80,9 +81,9 @@ struct JournalOnboardingPresentation: Equatable {
         let secondary: String? = {
             switch step {
             case .gratitude:
-                let hint = String(localized: "journal.onboarding.keyboardFinishHint")
-                let trimmed = hint.trimmingCharacters(in: .whitespacesAndNewlines)
-                return trimmed.isEmpty ? nil : trimmed
+                return Self.trimmedKeyboardFinishHintLine(
+                    String(localized: "journal.onboarding.keyboardFinishHint")
+                )
             case .need, .person:
                 return nil
             }
@@ -92,6 +93,13 @@ struct JournalOnboardingPresentation: Equatable {
             message: message,
             messageSecondary: secondary
         )
+    }
+
+    /// Returns `nil` when `raw` is empty or only whitespace and newlines; otherwise returns trimmed text.
+    /// Used for the gratitude keyboard hint line; exposed for unit tests covering trim/empty rules.
+    static func trimmedKeyboardFinishHintLine(_ raw: String) -> String? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 }
 

--- a/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalOnboardingGuidanceView.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalOnboardingGuidanceView.swift
@@ -13,25 +13,16 @@ struct JournalOnboardingGuidanceView: View {
         self.messageSecondary = messageSecondary
     }
 
-    private var trimmedTitle: String {
-        title.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    private var trimmedMessage: String {
-        message.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    private var trimmedSecondaryLine: String? {
-        guard let messageSecondary else { return nil }
-        let trimmed = messageSecondary.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? nil : trimmed
-    }
-
-    private var hasMeaningfulContent: Bool {
-        !trimmedTitle.isEmpty || !trimmedMessage.isEmpty || trimmedSecondaryLine != nil
-    }
-
     var body: some View {
+        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedMessage = message.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedSecondaryLine: String? = {
+            guard let messageSecondary else { return nil }
+            let trimmed = messageSecondary.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }()
+        let hasMeaningfulContent = !trimmedTitle.isEmpty || !trimmedMessage.isEmpty || trimmedSecondaryLine != nil
+
         if !hasMeaningfulContent {
             EmptyView()
         } else {
@@ -50,8 +41,8 @@ struct JournalOnboardingGuidanceView: View {
                         .fixedSize(horizontal: false, vertical: true)
                 }
 
-                if let trimmedSecondaryLine {
-                    Text(trimmedSecondaryLine)
+                if let secondaryLine = trimmedSecondaryLine {
+                    Text(secondaryLine)
                         .font(AppTheme.warmPaperBody)
                         .foregroundStyle(palette.textPrimary)
                         .fixedSize(horizontal: false, vertical: true)

--- a/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalTutorialProgress.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalTutorialProgress.swift
@@ -11,6 +11,8 @@ enum JournalTutorialStorageKeys {
     /// First time all fifteen Entries were filled (Bloom).
     static let celebratedFirstBloom = "journalTutorial.celebratedFirstBloom"
 
+    // When adding a new key above, append it to `currentKeys` so `resetAll` clears it; add a migration line in
+    // `migrateLegacyKeysIfNeeded` when replacing a legacy spelling.
     private static let currentKeys: [String] = [
         dismissedSproutGuidance,
         dismissedBloomGuidance,

--- a/GraceNotes/GraceNotes/Features/Journal/ViewModels/JournalViewModel+EntryEditing.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/ViewModels/JournalViewModel+EntryEditing.swift
@@ -31,7 +31,8 @@ extension JournalViewModel {
         return true
     }
 
-    /// Returns true if the item was updated (valid index and trimmed text non-empty).
+    /// Returns false for an invalid index or empty trimmed text; returns true if the stored value
+    /// already matches or was updated.
     func updateGratitude(at index: Int, fullText: String) async -> Bool {
         guard gratitudes.indices.contains(index) else { return false }
         let trimmed = fullText.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -44,7 +45,8 @@ extension JournalViewModel {
         return true
     }
 
-    /// Returns true if the item was updated (valid index and trimmed text non-empty).
+    /// Returns false for an invalid index or empty trimmed text; returns true if the stored value
+    /// already matches or was updated.
     func updateNeed(at index: Int, fullText: String) async -> Bool {
         guard needs.indices.contains(index) else { return false }
         let trimmed = fullText.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -57,7 +59,8 @@ extension JournalViewModel {
         return true
     }
 
-    /// Returns true if the item was updated (valid index and trimmed text non-empty).
+    /// Returns false for an invalid index or empty trimmed text; returns true if the stored value
+    /// already matches or was updated.
     func updatePerson(at index: Int, fullText: String) async -> Bool {
         guard people.indices.contains(index) else { return false }
         let trimmed = fullText.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/GraceNotes/GraceNotes/Features/Journal/Views/CompletionInfoCard.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/CompletionInfoCard.swift
@@ -1,6 +1,27 @@
 import SwiftUI
 
 struct CompletionInfoCard: View {
+    let badgeInfo: CompletionBadgeInfo
+    let cardTintColor: Color
+    let reduceTransparency: Bool
+    let morphNamespace: Namespace.ID
+    let showMorph: Bool
+    let bloomProgress: CGFloat
+
+    var body: some View {
+        CompletionInfoCardContent(
+            badgeInfo: badgeInfo,
+            cardTintColor: cardTintColor,
+            reduceTransparency: reduceTransparency,
+            morphNamespace: morphNamespace,
+            showMorph: showMorph,
+            bloomProgress: bloomProgress
+        )
+        .id(badgeInfo)
+    }
+}
+
+private struct CompletionInfoCardContent: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.todayJournalPalette) private var palette
     @State private var contentVisible = false

--- a/GraceNotes/GraceNotes/Features/Journal/Views/JournalCompletionBarChip.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/JournalCompletionBarChip.swift
@@ -192,7 +192,7 @@ struct JournalCompletionBarChip: View {
 
     private var accessibilityLabelText: String {
         let statusName = completionTitle
-        let format = String(localized: "journal.share.sectionCountsSentence")
+        let format = String(localized: "journal.share.sectionCountsSentence", locale: locale)
         return String(format: format, locale: locale, statusName, gratitudesCount, needsCount, peopleCount)
     }
 

--- a/GraceNotes/GraceNotes/Features/Journal/Views/JournalCompletionInfoPresentation.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/JournalCompletionInfoPresentation.swift
@@ -72,7 +72,7 @@ final class JournalCompletionInfoPresentation {
     }
 
     private func scheduleInfoCardCloseThenReopenAfterDelay(reduceMotion: Bool) {
-        cancelInfoCardBloomAnimation(resetProgress: true)
+        cancelInfoCardBloomAnimation(resetProgress: !reduceMotion)
         withAnimation(infoCardExitAnimation(reduceMotion: reduceMotion)) {
             isInfoCardPresented = false
         }

--- a/GraceNotes/GraceNotes/Features/Journal/Views/JournalKeyboardScrollSupport.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/JournalKeyboardScrollSupport.swift
@@ -1,3 +1,4 @@
+import os
 import SwiftUI
 import UIKit
 
@@ -77,6 +78,11 @@ enum JournalKeyboardScrollMetrics {
 
 /// Keyboard overlap with the key window; sizes extra scroll affordance without guessing global safe-area behavior.
 enum JournalKeyboardOverlapReader {
+    private static let logger = Logger(
+        subsystem: "com.gracenotes.GraceNotes",
+        category: "JournalKeyboardScroll"
+    )
+
     static func overlapHeight(from notification: Notification) -> CGFloat {
         guard let frame = keyboardFrameEnd(from: notification) else {
             return 0
@@ -99,7 +105,16 @@ enum JournalKeyboardOverlapReader {
         if let value = raw as? NSValue {
             return value.cgRectValue
         }
+        logUnrecognizedKeyboardFrameUserInfoValue(raw)
         return nil
+    }
+
+    private static func logUnrecognizedKeyboardFrameUserInfoValue(_ raw: Any) {
+        let typeName = String(describing: type(of: raw))
+        #if DEBUG
+        assertionFailure("Keyboard frame end userInfo value had unexpected type: \(typeName)")
+        #endif
+        logger.warning("Keyboard frame end userInfo value had unexpected type: \(typeName, privacy: .public)")
     }
 }
 
@@ -167,11 +182,23 @@ enum JournalCaretVisibilityReader {
     }
 
     /// First responder is sometimes an internal subview; walk up to the `UITextView` that owns the caret APIs.
+    /// Skips an outer `UITextView` when a `UITextField` owns first responder (nested controls). Only accepts an
+    /// ancestor `UITextView` when the responder lies inside that view’s bounds in local coordinates.
     private static func nearestTextView(from view: UIView) -> UITextView? {
-        var current: UIView? = view
+        if let direct = view as? UITextView {
+            return direct
+        }
+        if view is UITextField {
+            return nil
+        }
+        let responder = view
+        var current: UIView? = view.superview
         while let node = current {
             if let textView = node as? UITextView {
-                return textView
+                let originInTextView = textView.convert(responder.bounds.origin, from: responder)
+                if responder.isDescendant(of: textView), textView.bounds.contains(originInTextView) {
+                    return textView
+                }
             }
             current = node.superview
         }
@@ -179,11 +206,23 @@ enum JournalCaretVisibilityReader {
     }
 
     /// Same as `nearestTextView` but for single-line fields (`UITextField` and common subclasses).
+    /// Skips an outer `UITextField` when a `UITextView` owns first responder. Only accepts an ancestor field when
+    /// the responder lies inside that field’s bounds in local coordinates.
     private static func nearestTextField(from view: UIView) -> UITextField? {
-        var current: UIView? = view
+        if let direct = view as? UITextField {
+            return direct
+        }
+        if view is UITextView {
+            return nil
+        }
+        let responder = view
+        var current: UIView? = view.superview
         while let node = current {
             if let textField = node as? UITextField {
-                return textField
+                let originInField = textField.convert(responder.bounds.origin, from: responder)
+                if responder.isDescendant(of: textField), textField.bounds.contains(originInField) {
+                    return textField
+                }
             }
             current = node.superview
         }

--- a/GraceNotes/GraceNotes/Features/Journal/Views/JournalScreenEntryHandling.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/JournalScreenEntryHandling.swift
@@ -172,7 +172,8 @@ enum JournalScreenEntryHandling {
                     canSwitch = false
                 }
             } else {
-                // At capacity with no row being edited: draft text cannot be saved before switching strips.
+                // At capacity with no row being edited: the draft cannot be saved, and switching strips would
+                // discard it.
                 canSwitch = false
             }
         }

--- a/GraceNotes/GraceNotes/Features/Journal/Views/JournalShareCardView.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/JournalShareCardView.swift
@@ -83,6 +83,8 @@ private extension JournalShareCardView {
                 .padding(.bottom, 32)
 
             VStack(alignment: .leading, spacing: 24) {
+                // Invariant: each `ShareSectionKind` appears at most once in `payload.sections`
+                // (enforced by `ShareRenderPayloadBuilder`); duplicate kinds would break `ForEach` identity.
                 ForEach(Array(payload.sections.enumerated()), id: \.element.kind) { index, section in
                     if payload.style.showsSectionDividers, index > 0 {
                         Rectangle()
@@ -263,6 +265,7 @@ private extension JournalShareCardView {
             .italic()
             .foregroundStyle(surface.stubInk)
             .fixedSize(horizontal: false, vertical: true)
+            .frame(maxWidth: .infinity, alignment: .leading)
             .accessibilityLabel(String(localized: "sharing.a11y.sectionStub"))
     }
 

--- a/GraceNotes/GraceNotes/Features/Journal/Views/JournalShareComposerView.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/JournalShareComposerView.swift
@@ -42,8 +42,9 @@ struct JournalShareComposerView: View {
                 }
                 .padding(.horizontal, 20)
                 .padding(.vertical, 16)
-                .disabled(isShareCommitInProgress)
             }
+            .scrollDisabled(isShareCommitInProgress)
+            .allowsHitTesting(!isShareCommitInProgress)
             .scrollContentBackground(.hidden)
             .background(AppTheme.settingsBackground.ignoresSafeArea())
             .navigationTitle(String(localized: "sharing.composer.title"))
@@ -218,5 +219,6 @@ struct JournalShareComposerView: View {
             return
         }
         onShare(image)
+        isShareCommitInProgress = false
     }
 }

--- a/GraceNotes/GraceNotes/Features/Journal/Views/JournalShareComposerView.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/JournalShareComposerView.swift
@@ -42,6 +42,7 @@ struct JournalShareComposerView: View {
                 }
                 .padding(.horizontal, 20)
                 .padding(.vertical, 16)
+                .disabled(isShareCommitInProgress)
             }
             .scrollContentBackground(.hidden)
             .background(AppTheme.settingsBackground.ignoresSafeArea())
@@ -201,10 +202,10 @@ struct JournalShareComposerView: View {
         .buttonStyle(.plain)
     }
 
+    @MainActor
     private func commitShare() {
         guard !isShareCommitInProgress else { return }
         isShareCommitInProgress = true
-        defer { isShareCommitInProgress = false }
 
         let built = ShareRenderPayloadBuilder.build(
             full: basePayload,
@@ -212,6 +213,7 @@ struct JournalShareComposerView: View {
             includePreviewStubs: false
         )
         guard let image = JournalShareRenderer.renderImage(from: built) else {
+            isShareCommitInProgress = false
             showRenderError = true
             return
         }

--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewHistoryDrilldownCalendarGrid.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewHistoryDrilldownCalendarGrid.swift
@@ -362,6 +362,7 @@ struct ReviewHistoryDrilldownCalendarGrid: View {
     }
 
     /// VoiceOver hint for tappable in-range days (empty days are not “open existing entry”).
+    /// Only used from the `Button` branch in `dayCell`; outside-window days take the non-button path.
     private func dayCellButtonAccessibilityHint(disposition: ReviewHistoryDrilldownDayDisposition) -> String {
         switch disposition {
         case .emptyHistoryDay:
@@ -369,7 +370,7 @@ struct ReviewHistoryDrilldownCalendarGrid: View {
         case .matched, .journalDayNotMatched:
             return String(localized: "past.accessibility.openEntryThatDay")
         case .outsideHistoryWindow:
-            return ""
+            fatalError("dayCellButtonAccessibilityHint: outside-window cells use the non-button path in dayCell.")
         }
     }
 }

--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewHistoryInsightsPanels.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewHistoryInsightsPanels.swift
@@ -197,6 +197,7 @@ private struct ReviewHistoryGrowthSkyline: View {
                     : String(localized: "accessibility.reviewHistory.growthColumn")
             )
             .accessibilityAddTraits(count == 0 ? [] : .isButton)
+            .accessibilityRemoveTraits(count == 0 ? .isButton : [])
         }
     }
 }
@@ -420,6 +421,7 @@ private struct ReviewHistorySectionStrip: View {
                         )
                         .accessibilityHint(segmentAccessibilityHint(forCount: item.count))
                         .accessibilityAddTraits(item.count == 0 ? [] : .isButton)
+                        .accessibilityRemoveTraits(item.count == 0 ? .isButton : [])
                     }
                 }
                 .frame(width: width, height: stripHeight)
@@ -466,6 +468,7 @@ private struct ReviewHistorySectionStrip: View {
                     )
                     .accessibilityHint(segmentAccessibilityHint(forCount: item.count))
                     .accessibilityAddTraits(item.count == 0 ? [] : .isButton)
+                    .accessibilityRemoveTraits(item.count == 0 ? .isButton : [])
                 }
             }
         }

--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewMostRecurringCard.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewMostRecurringCard.swift
@@ -82,7 +82,7 @@ struct ReviewMostRecurringCard: View {
         ) {
             VStack(alignment: .leading, spacing: 10) {
                 VStack(alignment: .leading, spacing: 8) {
-                    ForEach(Array(themes.prefix(3))) { theme in
+                    ForEach(Array(themes.prefix(3)), id: \.mostRecurringRowIdentity) { theme in
                         mostRecurringThemeRow(theme)
                     }
                 }
@@ -120,7 +120,9 @@ struct ReviewMostRecurringCard: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(PastTappablePressStyle())
-        .accessibilityIdentifier("MostRecurringThemeRow.\(reviewInsightSanitizedThemeId(theme.id))")
+        .accessibilityIdentifier(
+            "MostRecurringThemeRow.\(reviewInsightSanitizedThemeId(theme.mostRecurringRowIdentity))"
+        )
         .accessibilityLabel(
             String(
                 format: String(localized: "journal.share.lineCountsThree"),
@@ -169,5 +171,21 @@ struct ReviewMostRecurringCard: View {
             .accessibilityElement(children: .ignore)
             .accessibilityLabel(String(localized: "review.insights.loading"))
         }
+    }
+}
+
+private extension ReviewMostRecurringTheme {
+    /// Row identity for `ForEach` and accessibility: display `label` is not unique across canonical themes.
+    var mostRecurringRowIdentity: String {
+        let evidenceKey = evidence.map(\.id).sorted().joined(separator: "\u{001e}")
+        let sep = "\u{001f}"
+        return [
+            label,
+            String(totalCount),
+            String(dayCount),
+            String(currentWeekCount),
+            String(previousWeekCount),
+            evidenceKey
+        ].joined(separator: sep)
     }
 }

--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewRhythmScrollPinIdentity.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewRhythmScrollPinIdentity.swift
@@ -5,8 +5,15 @@ import Foundation
 /// Used to reset trailing-edge scroll pinning after a real dataset change, without clearing user scroll when
 /// `ReviewInsights` is regenerated for the same week with the same per-day rhythm payload (#131).
 ///
-/// Equality ignores ``ReviewDayActivity/strongestCompletionLevel``: it only affects which growth-stage row is
-/// highlighted, not column count or horizontal extent, so recomputing completion staging must not reset pin state.
+/// Equality matches **week anchor + ordered calendar day columns** only: `ReviewSummaryCard` renders one column per
+/// `days` element, so horizontal extent is driven by ``weekStart``, ``days.count``, and each paired day’s
+/// ``ReviewDayActivity/date``.
+/// Fields that affect only cell content (``ReviewDayActivity/hasReflectiveActivity``,
+/// ``ReviewDayActivity/hasPersistedEntry``, ``ReviewDayActivity/strongestCompletionLevel``) are ignored so pin state
+/// does not reset when those values refresh without layout changes.
+///
+/// If new fields are added to ``ReviewDayActivity`` that affect column count or width, extend this comparison
+/// accordingly.
 struct ReviewRhythmScrollPinIdentity: Equatable {
     let weekStart: Date
     let days: [ReviewDayActivity]
@@ -15,8 +22,6 @@ struct ReviewRhythmScrollPinIdentity: Equatable {
         guard lhs.weekStart == rhs.weekStart, lhs.days.count == rhs.days.count else { return false }
         return zip(lhs.days, rhs.days).allSatisfy { left, right in
             left.date == right.date
-                && left.hasReflectiveActivity == right.hasReflectiveActivity
-                && left.hasPersistedEntry == right.hasPersistedEntry
         }
     }
 }

--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewScreen.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewScreen.swift
@@ -107,6 +107,12 @@ extension ReviewScreen {
             .configuredCalendar()
     }
 
+    /// Week start for the current review period (`makeInsightsRefreshKey(referenceDate: Date()).weekStart`),
+    /// without iterating entries for `entrySnapshotsAffectingInsights` (cache hydration only needs the week key).
+    private var currentReviewWeekStart: Date {
+        ReviewInsightsPeriod.currentPeriod(containing: Date(), calendar: calendar).lowerBound
+    }
+
     /// Same instant used when the visible `reviewInsights` were built (Copilot PR #176 follow-up).
     private var insightsReferenceDate: Date {
         reviewInsights?.generatedAt ?? Date()
@@ -463,7 +469,7 @@ extension ReviewScreen {
         guard !entries.isEmpty else { return }
         guard reviewInsights == nil else { return }
         reviewInsights = await reviewInsightsCache.insights(
-            forWeekStart: currentInsightsRefreshKey.weekStart,
+            forWeekStart: currentReviewWeekStart,
             calendar: calendar,
             weekBoundaryPreferenceRawValue: reviewWeekBoundaryRawValue,
             pastStatisticsIntervalToken: pastStatisticsInterval.cacheKeyToken

--- a/GraceNotes/GraceNotes/Features/Journal/Views/SaveToPhotosActivity.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/SaveToPhotosActivity.swift
@@ -32,9 +32,8 @@ final class SaveToPhotosActivity: UIActivity {
     }
 
     override func perform() {
-        PHPhotoLibrary.requestAuthorization(for: .addOnly) { [weak self] status in
+        PHPhotoLibrary.requestAuthorization(for: .addOnly) { status in
             DispatchQueue.main.async {
-                guard let self else { return }
                 guard status == .authorized else {
                     self.activityDidFinish(false)
                     return

--- a/GraceNotes/GraceNotes/Features/Journal/Views/SequentialSectionInlineLayout.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/SequentialSectionInlineLayout.swift
@@ -1,6 +1,11 @@
 import UIKit
 
 /// Shared metrics for inline sentence editing (entry-row editor and add morph composer).
+///
+/// Layout spacing uses `UIFontMetrics(forTextStyle: .body)` because
+/// `InlineSentenceEditorField` applies body Dynamic Type scaling to its `UITextView`
+/// (`InlineSentenceEditorFieldLayout.bodyUIFont()`), so inset, offset, and bottom
+/// spacing follow the same curve as the editor typography.
 enum SequentialSectionInlineLayout {
     private static let bodyMetrics = UIFontMetrics(forTextStyle: .body)
 
@@ -19,8 +24,14 @@ enum SequentialSectionInlineLayout {
     /// Opacity for non-focused rows and guidance while inline editing is active elsewhere in the journal.
     static let ambientUnfocusedOpacity: CGFloat = 0.45
 
+    private static let inlineEditBottomTapCatcherBasePoints: CGFloat = 280
+    /// Upper bound as a fraction of screen height (avoids huge empty scroll at accessibility sizes).
+    private static let bottomTapCatcherScreenHeightCap: CGFloat = 0.42
+
     /// Minimum height for bottom tap catcher when journal content is short (dismiss inline edit from empty space).
     static var inlineEditBottomTapCatcherMinHeight: CGFloat {
-        bodyMetrics.scaledValue(for: 280)
+        let scaled = bodyMetrics.scaledValue(for: inlineEditBottomTapCatcherBasePoints)
+        let screenCap = UIScreen.main.bounds.height * bottomTapCatcherScreenHeightCap
+        return min(scaled, screenCap)
     }
 }

--- a/GraceNotes/GraceNotes/Features/Journal/Views/SequentialSectionPrimaryColumn.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/SequentialSectionPrimaryColumn.swift
@@ -1,6 +1,12 @@
 import SwiftUI
 import UniformTypeIdentifiers
 
+/// Editing index clamped to item count; `nil` when stale or out-of-range (shared by dots and rows).
+func sequentialSectionActiveEditingIndex(editingIndex: Int?, itemCount: Int) -> Int? {
+    guard let editingIndex, editingIndex >= 0, editingIndex < itemCount else { return nil }
+    return editingIndex
+}
+
 private enum SequentialSectionPrimaryColumnLayout {
     static let sectionProgressDotsTrailingInset: CGFloat = 8
 }
@@ -26,6 +32,8 @@ struct SequentialSectionPrimaryColumn<ProgressDots: View>: View {
     let onboardingState: JournalOnboardingSectionState
     let isTransitioning: Bool
     let editingIndex: Int?
+    /// In-bounds inline editor index; matches progress dots (ignores stale `editingIndex`).
+    let activeEditingIndex: Int?
     let inputFocus: FocusState<Bool>.Binding?
     let onInputFocusLost: (() -> Void)?
     let onSubmit: () -> Void
@@ -53,11 +61,6 @@ struct SequentialSectionPrimaryColumn<ProgressDots: View>: View {
 }
 
 extension SequentialSectionPrimaryColumn {
-    private var activeEditingIndex: Int? {
-        guard let editingIndex, items.indices.contains(editingIndex) else { return nil }
-        return editingIndex
-    }
-
     private var isInlineEditingActive: Bool {
         activeEditingIndex != nil
     }
@@ -413,7 +416,7 @@ private extension SequentialSectionPrimaryColumn {
             itemCount: items.count,
             sentence: item.fullText,
             accessibilityIdentifier: rowAccessibilityPrefix,
-            isSelected: editingIndex == index,
+            isSelected: activeEditingIndex == index,
             isExpanded: expandedItemIDs.contains(item.id),
             isExpandable: isExpandable,
             expansionAccessibilityIdentifier: rowAccessibilityPrefix.map { "\($0).more" },

--- a/GraceNotes/GraceNotes/Features/Journal/Views/SequentialSectionView.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/SequentialSectionView.swift
@@ -127,10 +127,8 @@ struct SequentialSectionView: View {
         inputFocus?.wrappedValue ?? false
     }
 
-    /// Matches `SequentialSectionPrimaryColumn.activeEditingIndex`: ignore stale or out-of-bounds indices.
     private var activeEditingIndex: Int? {
-        guard let editingIndex, items.indices.contains(editingIndex) else { return nil }
-        return editingIndex
+        sequentialSectionActiveEditingIndex(editingIndex: editingIndex, itemCount: items.count)
     }
 
     private var shouldAnimateEditingPulse: Bool {
@@ -185,6 +183,7 @@ struct SequentialSectionView: View {
             onboardingState: onboardingState,
             isTransitioning: isTransitioning,
             editingIndex: editingIndex,
+            activeEditingIndex: activeEditingIndex,
             inputFocus: inputFocus,
             onInputFocusLost: onInputFocusLost,
             onSubmit: onSubmit,

--- a/GraceNotes/GraceNotes/Features/Journal/Views/ShareSheet.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ShareSheet.swift
@@ -7,39 +7,59 @@ struct ShareableImage: Identifiable {
     let image: UIImage
 }
 
+// MARK: - Popover anchoring
+
+private enum ShareSheetPopover {
+    /// On iPad and other horizontally regular layouts, `UIActivityViewController` uses a popover and must have a
+    /// valid popover source or the system can fail to present it.
+    static func configureIfNeeded(for controller: UIActivityViewController) {
+        guard let popover = controller.popoverPresentationController else { return }
+        guard let view = controller.viewIfLoaded else { return }
+        guard view.bounds.width > 0, view.bounds.height > 0 else { return }
+
+        popover.sourceView = view
+        popover.sourceRect = CGRect(
+            x: view.bounds.midX,
+            y: view.bounds.midY,
+            width: 0,
+            height: 0
+        )
+        popover.permittedArrowDirections = []
+    }
+}
+
+/// Defers popover configuration until the activity view is in the hierarchy and laid out, avoiding reliance on a
+/// key window during the first `makeUIViewController` frame.
+private final class ShareActivityViewController: UIActivityViewController {
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        ShareSheetPopover.configureIfNeeded(for: self)
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        ShareSheetPopover.configureIfNeeded(for: self)
+    }
+}
+
 struct ShareSheet: UIViewControllerRepresentable {
     let activityItems: [Any]
     var applicationActivities: [UIActivity]?
 
     func makeUIViewController(context: Context) -> UIActivityViewController {
-        assert(!activityItems.isEmpty, "ShareSheet requires at least one activity item.")
-        let controller = UIActivityViewController(
+        precondition(!activityItems.isEmpty, "ShareSheet requires at least one activity item.")
+        let controller = ShareActivityViewController(
             activityItems: activityItems,
             applicationActivities: applicationActivities
         )
-        configurePopoverPresentationIfNeeded(for: controller)
+        ShareSheetPopover.configureIfNeeded(for: controller)
+        DispatchQueue.main.async {
+            ShareSheetPopover.configureIfNeeded(for: controller)
+        }
         return controller
     }
 
-    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
-
-    /// On iPad and other horizontally regular layouts, `UIActivityViewController` uses a popover and must have a
-    /// valid popover source or the system can fail to present it.
-    private func configurePopoverPresentationIfNeeded(for controller: UIActivityViewController) {
-        guard let popover = controller.popoverPresentationController else { return }
-        guard let window = UIApplication.shared.connectedScenes
-            .compactMap({ $0 as? UIWindowScene })
-            .flatMap(\.windows)
-            .first(where: \.isKeyWindow)
-        else { return }
-
-        popover.sourceView = window
-        popover.sourceRect = CGRect(
-            x: window.bounds.midX,
-            y: window.bounds.midY,
-            width: 0,
-            height: 0
-        )
-        popover.permittedArrowDirections = []
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {
+        ShareSheetPopover.configureIfNeeded(for: uiViewController)
     }
 }

--- a/GraceNotes/GraceNotes/Features/Settings/AdvancedSettingsScreen.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/AdvancedSettingsScreen.swift
@@ -21,8 +21,8 @@ struct AdvancedSettingsScreen: View {
     @State private var customUnit: PastStatisticsIntervalUnit
 
     init() {
-        let encoded = UserDefaults.standard.string(forKey: PastStatisticsIntervalPreference.appStorageKey) ?? ""
-        let selection = PastStatisticsIntervalPreference.selection(fromAppStorage: encoded).validated
+        let raw = PastStatisticsIntervalPreference.appStorageRawValue()
+        let selection = PastStatisticsIntervalPreference.selection(fromAppStorage: raw).validated
         _intervalMode = State(initialValue: selection.mode == .all ? .all : .custom)
         _customQuantity = State(initialValue: Self.clampedPickerQuantity(selection.quantity))
         _customUnit = State(initialValue: selection.unit)

--- a/GraceNotes/GraceNotes/Features/Settings/AdvancedSettingsScreen.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/AdvancedSettingsScreen.swift
@@ -71,7 +71,7 @@ struct AdvancedSettingsScreen: View {
                             String(localized: "settings.advanced.pastStatsInterval.quantity.a11y"),
                             selection: $customQuantity
                         ) {
-                            ForEach(1...999, id: \.self) { value in
+                            ForEach(Self.pickerQuantityRange, id: \.self) { value in
                                 Text("\(value)").tag(value)
                             }
                         }
@@ -147,8 +147,13 @@ struct AdvancedSettingsScreen: View {
         )
     }
 
+    private static let pickerQuantityRange = 1...999
+
     private static func clampedPickerQuantity(_ quantity: Int) -> Int {
-        min(max(quantity, 1), 999)
+        min(
+            max(quantity, Self.pickerQuantityRange.lowerBound),
+            Self.pickerQuantityRange.upperBound
+        )
     }
 
     private func localizedUnitLabel(_ unit: PastStatisticsIntervalUnit) -> String {

--- a/GraceNotes/GraceNotes/Features/Settings/ImportExportTechnicalDetailFormatting.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/ImportExportTechnicalDetailFormatting.swift
@@ -48,10 +48,16 @@ enum ImportExportTechnicalDetailFormatting {
     }
 
     /// Trims surrounding whitespace, treats whitespace-only as absent, and flattens line breaks so
-    /// history rows and accessibility labels stay single-line.
+    /// history rows and accessibility labels stay single-line. Each newline-delimited segment is
+    /// trimmed; empty segments are dropped so spacing collapses to single spaces between words.
     private static func normalizedExportHistoryDetail(_ raw: String) -> String? {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
-        return trimmed.split { $0.isNewline }.joined(separator: " ")
+        let segments = trimmed
+            .split(whereSeparator: \.isNewline)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        guard !segments.isEmpty else { return nil }
+        return segments.joined(separator: " ")
     }
 }

--- a/GraceNotes/GraceNotes/Features/Settings/ReminderSettingsFlowModel.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/ReminderSettingsFlowModel.swift
@@ -59,6 +59,9 @@ final class ReminderSettingsFlowModel: ObservableObject {
     }
 
     func enableReminders() async {
+        // User intent to turn reminders on cancels any deferred "disable after current work" and must not
+        // be overridden by a later drain from an earlier busy window.
+        pendingDisableAfterCurrentWork = false
         await runWithWorking {
             transientErrorMessage = nil
             let result = await reminderScheduler.enableDailyReminder(at: selectedTime, body: resolvedReminderBody())
@@ -93,6 +96,8 @@ final class ReminderSettingsFlowModel: ObservableObject {
         transientErrorMessage = nil
         _ = await reminderScheduler.disableDailyReminder()
         await refreshStatus()
+        // Coalesced disable requests that arrived during `await` are redundant once this attempt finishes.
+        pendingDisableAfterCurrentWork = false
     }
 
     func saveEnabledReminderTime() async {
@@ -188,6 +193,7 @@ final class ReminderSettingsFlowModel: ObservableObject {
         transientErrorMessage = nil
         _ = await reminderScheduler.disableDailyReminder()
         await refreshStatus()
+        pendingDisableAfterCurrentWork = false
     }
 
     /// Runs a deferred time save after `isWorking` drops (picker updates coalesced during enable or overlapping saves).

--- a/GraceNotes/GraceNotes/Features/Settings/ReminderSettingsFlowModel.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/ReminderSettingsFlowModel.swift
@@ -25,9 +25,8 @@ final class ReminderSettingsFlowModel: ObservableObject {
     ) {
         self.reminderScheduler = reminderScheduler
         self.userDefaults = userDefaults
-        let storedTimeInterval = userDefaults.object(forKey: ReminderSettings.timeIntervalKey) as? TimeInterval
-            ?? ReminderSettings.defaultTimeInterval
-        selectedTime = ReminderSettings.date(from: storedTimeInterval)
+        let interval = ReminderSettings.coercedTimeInterval(fromUserDefaults: userDefaults)
+        selectedTime = ReminderSettings.date(from: interval)
     }
 
     deinit {

--- a/GraceNotes/GraceNotes/Features/Settings/Services/BackupFolderPickerResolution.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/Services/BackupFolderPickerResolution.swift
@@ -53,8 +53,19 @@ enum BackupFolderPickerResolution {
         case .directory:
             return url
         case .missing:
-            try fileManager.createDirectory(at: url, withIntermediateDirectories: true)
-            return url
+            do {
+                try fileManager.createDirectory(at: url, withIntermediateDirectories: true)
+                return url
+            } catch {
+                switch pathKind(at: url, fileManager: fileManager) {
+                case .directory:
+                    return url
+                case .notDirectory:
+                    throw ResolutionError.pathComponentIsNotDirectory(url)
+                case .missing:
+                    throw error
+                }
+            }
         }
     }
 }

--- a/GraceNotes/GraceNotes/Features/Settings/Services/ICloudAccountStatusService.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/Services/ICloudAccountStatusService.swift
@@ -18,13 +18,20 @@ final class ICloudAccountStatusService: ICloudAccountStatusProviding {
     func fetchAccountBucket() async -> ICloudAccountBucket {
         let container = CKContainer(identifier: containerIdentifier)
         do {
-            let status = try await container.accountStatus()
+            let status = try await Task(priority: .utility) {
+                try await container.accountStatus()
+            }.value
             return ICloudAccountBucket(status)
         } catch {
             if !(error is CancellationError) {
-                let detail = error.localizedDescription
+                let nsError = error as NSError
                 iCloudAccountStatusLogger.error(
-                    "Failed to fetch iCloud account status. \(detail, privacy: .public)"
+                    """
+                    Failed to fetch iCloud account status. \
+                    type=\(String(describing: type(of: error)), privacy: .public) \
+                    domain=\(nsError.domain, privacy: .public) \
+                    code=\(nsError.code, privacy: .public)
+                    """
                 )
             }
             return .couldNotDetermine

--- a/GraceNotes/GraceNotes/Features/Settings/Services/ICloudAccountStatusService.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/Services/ICloudAccountStatusService.swift
@@ -1,7 +1,13 @@
 import CloudKit
 import Foundation
+import os
 
-/// Live `CKContainer.accountStatus()` bridge; work runs off the main actor.
+private let iCloudAccountStatusLogger = Logger(
+    subsystem: "com.gracenotes.GraceNotes",
+    category: "ICloudAccountStatus"
+)
+
+/// Live `CKContainer.accountStatus()` bridge; `accountStatus()` suspends without blocking the caller.
 final class ICloudAccountStatusService: ICloudAccountStatusProviding {
     private let containerIdentifier: String
 
@@ -10,15 +16,19 @@ final class ICloudAccountStatusService: ICloudAccountStatusProviding {
     }
 
     func fetchAccountBucket() async -> ICloudAccountBucket {
-        await Task.detached(priority: .utility) { [containerIdentifier] in
-            let container = CKContainer(identifier: containerIdentifier)
-            do {
-                let status = try await container.accountStatus()
-                return ICloudAccountBucket(status)
-            } catch {
-                return .couldNotDetermine
+        let container = CKContainer(identifier: containerIdentifier)
+        do {
+            let status = try await container.accountStatus()
+            return ICloudAccountBucket(status)
+        } catch {
+            if !(error is CancellationError) {
+                let detail = error.localizedDescription
+                iCloudAccountStatusLogger.error(
+                    "Failed to fetch iCloud account status. \(detail, privacy: .public)"
+                )
             }
-        }.value
+            return .couldNotDetermine
+        }
     }
 }
 

--- a/GraceNotes/GraceNotes/Features/Settings/Services/ICloudAccountStatusService.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/Services/ICloudAccountStatusService.swift
@@ -39,13 +39,49 @@ final class ICloudAccountStatusService: ICloudAccountStatusProviding {
     }
 }
 
-/// CloudKit may report cancellation as `CKError.operationCancelled`; URL loading as `URLError.cancelled`, not only
+/// CloudKit may report cancellation as `CKError.Code.operationCancelled`; URL loading as `URLError.cancelled`, not only
 /// `CancellationError`.
-private func isCancellationLike(_ error: Error) -> Bool {
+internal func isCancellationLike(_ error: Error) -> Bool {
+    isCancellationLikeRecursively(error, depth: 0)
+}
+
+private let underlyingErrorsUserInfoKey = "NSUnderlyingErrorsKey"
+
+private func isDirectCancellationMatch(_ error: Error) -> Bool {
     if error is CancellationError { return true }
     if let ckError = error as? CKError, ckError.code == .operationCancelled { return true }
+
     let nsError = error as NSError
+    if nsError.domain == CKError.errorDomain, nsError.code == CKError.Code.operationCancelled.rawValue {
+        return true
+    }
     return nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled
+}
+
+private func isCancellationInUnderlyingErrorsArray(_ nsError: NSError, depth: Int) -> Bool {
+    guard let raw = nsError.userInfo[underlyingErrorsUserInfoKey] else { return false }
+    if let errors = raw as? [Error] {
+        return errors.contains { isCancellationLikeRecursively($0, depth: depth + 1) }
+    }
+    guard let array = raw as? NSArray else { return false }
+    for idx in 0..<array.count {
+        if let underlying = array[idx] as? Error, isCancellationLikeRecursively(underlying, depth: depth + 1) {
+            return true
+        }
+    }
+    return false
+}
+
+private func isCancellationLikeRecursively(_ error: Error, depth: Int) -> Bool {
+    guard depth < 32 else { return false }
+    if isDirectCancellationMatch(error) { return true }
+
+    let nsError = error as NSError
+    if let underlying = nsError.userInfo[NSUnderlyingErrorKey] as? Error,
+       isCancellationLikeRecursively(underlying, depth: depth + 1) {
+        return true
+    }
+    return isCancellationInUnderlyingErrorsArray(nsError, depth: depth)
 }
 
 extension ICloudAccountBucket {

--- a/GraceNotes/GraceNotes/Features/Settings/Services/ICloudSyncActivityModel.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/Services/ICloudSyncActivityModel.swift
@@ -1,5 +1,6 @@
 import CoreData
 import Foundation
+import UIKit
 
 /// Best-effort “last time iCloud-related store activity was observed” using persistent-store
 /// remote-change notifications.
@@ -9,7 +10,8 @@ final class ICloudSyncActivityModel: ObservableObject {
 
     @Published private(set) var lastRemoteChangeAt: Date?
 
-    private var observerToken: NSObjectProtocol?
+    private var remoteChangeObserverToken: NSObjectProtocol?
+    private var appLifecycleObserverTokens: [NSObjectProtocol] = []
     /// Limits disk writes when many remote-change notifications arrive in a short burst (e.g. sync).
     private var pendingUserDefaultsPersist = false
 
@@ -21,19 +23,51 @@ final class ICloudSyncActivityModel: ObservableObject {
     }
 
     func startMonitoring() {
-        guard observerToken == nil else { return }
-        observerToken = NotificationCenter.default.addObserver(
+        guard remoteChangeObserverToken == nil else { return }
+
+        remoteChangeObserverToken = NotificationCenter.default.addObserver(
             forName: .NSPersistentStoreRemoteChange,
             object: nil,
             queue: .main
         ) { [weak self] _ in
             self?.recordRemoteChange()
         }
+
+        let center = NotificationCenter.default
+        appLifecycleObserverTokens = [
+            center.addObserver(
+                forName: UIApplication.didEnterBackgroundNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                self?.persistLastRemoteChangeIfNeeded()
+            },
+            center.addObserver(
+                forName: UIApplication.willTerminateNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                self?.persistLastRemoteChangeIfNeeded()
+            }
+        ]
     }
 
     deinit {
-        if let observerToken {
-            NotificationCenter.default.removeObserver(observerToken)
+        if let remoteChangeObserverToken {
+            NotificationCenter.default.removeObserver(remoteChangeObserverToken)
+        }
+        for token in appLifecycleObserverTokens {
+            NotificationCenter.default.removeObserver(token)
+        }
+    }
+
+    /// Synchronously mirrors `lastRemoteChangeAt` into `UserDefaults` when present.
+    /// Used on background/terminate so disk is less likely to lag in-memory state if the process exits
+    /// before a coalesced write runs.
+    func persistLastRemoteChangeIfNeeded() {
+        pendingUserDefaultsPersist = false
+        if let stamp = lastRemoteChangeAt {
+            UserDefaults.standard.set(stamp.timeIntervalSince1970, forKey: Self.persistedTimestampKey)
         }
     }
 
@@ -43,7 +77,7 @@ final class ICloudSyncActivityModel: ObservableObject {
             return
         }
         pendingUserDefaultsPersist = true
-        DispatchQueue.main.async { [weak self] in
+        Task { @MainActor [weak self] in
             guard let self else { return }
             self.pendingUserDefaultsPersist = false
             if let stamp = self.lastRemoteChangeAt {

--- a/GraceNotes/GraceNotes/Features/Settings/Services/JournalDataExportService.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/Services/JournalDataExportService.swift
@@ -17,7 +17,7 @@ struct JournalDataExportService {
         let entries = try context.fetch(descriptor)
         let data = try makeArchiveData(from: entries, exportedAt: now)
 
-        let filename = "grace-notes-export-\(timestampString(from: now))-\(UUID().uuidString).json"
+        let filename = "grace-notes-export-\(exportFilenameTimestamp(for: now))-\(UUID().uuidString).json"
         let fileURL = fileManager.temporaryDirectory.appendingPathComponent(filename, isDirectory: false)
         try data.write(to: fileURL, options: .atomic)
         return fileURL
@@ -39,6 +39,8 @@ struct JournalDataExportService {
             if lhs.createdAt != rhs.createdAt {
                 return lhs.createdAt < rhs.createdAt
             }
+            // Ties: `UUID` `<` uses RFC 4122 byte order, not `uuidString` lexicographic order—stable within a build,
+            // but can differ from older exports that compared strings.
             return lhs.id < rhs.id
         }
         return JournalDataExportArchive(
@@ -70,20 +72,19 @@ struct JournalDataExportService {
         )
     }
 
-    private func timestampString(from date: Date) -> String {
-        var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
-        let parts = calendar.dateComponents([.year, .month, .day, .hour, .minute, .second], from: date)
-        return String(
-            format: "%04d%02d%02d-%02d%02d%02d",
-            parts.year ?? 0,
-            parts.month ?? 0,
-            parts.day ?? 0,
-            parts.hour ?? 0,
-            parts.minute ?? 0,
-            parts.second ?? 0
-        )
+    /// UTC `yyyyMMdd-HHmmss` stamp for export filenames; deterministic and locale-insensitive (`en_US_POSIX`).
+    func exportFilenameTimestamp(for date: Date) -> String {
+        Self.exportFilenameTimestampFormatter.string(from: date)
     }
+
+    private static let exportFilenameTimestampFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.timeZone = TimeZone(secondsFromGMT: 0) ?? TimeZone(identifier: "GMT")!
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyyMMdd-HHmmss"
+        return formatter
+    }()
 }
 
 struct JournalDataExportArchive: Codable, Equatable {

--- a/GraceNotes/GraceNotes/Features/Settings/Services/ScheduledBackupRunner.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/Services/ScheduledBackupRunner.swift
@@ -23,8 +23,8 @@ private final class ScheduledBackupSingleFlight: @unchecked Sendable {
 
     func end() {
         lock.lock()
+        defer { lock.unlock() }
         inFlight = false
-        lock.unlock()
     }
 }
 
@@ -45,10 +45,10 @@ enum ScheduledBackupRunner {
         }
 
         guard scheduledBackupSingleFlight.tryBegin() else { return }
-        defer { scheduledBackupSingleFlight.end() }
 
         let result = await Task.detached(priority: .utility) {
-            Self.performScheduledExport(modelContainer: modelContainer)
+            defer { scheduledBackupSingleFlight.end() }
+            return Self.performScheduledExport(modelContainer: modelContainer)
         }.value
 
         switch result {

--- a/GraceNotes/GraceNotes/Services/Reminders/DailyReminderNotificationSync.swift
+++ b/GraceNotes/GraceNotes/Services/Reminders/DailyReminderNotificationSync.swift
@@ -14,7 +14,10 @@ enum DailyReminderNotificationSync {
         guard status == .enabled else { return }
 
         let stored = userDefaults.object(forKey: ReminderSettings.timeIntervalKey) as? TimeInterval
-        let interval = stored ?? ReminderSettings.defaultTimeInterval
+        var interval = stored ?? ReminderSettings.defaultTimeInterval
+        if !interval.isFinite {
+            interval = ReminderSettings.defaultTimeInterval
+        }
         let reminderTime = ReminderSettings.date(from: interval)
         let body: String
         do {

--- a/GraceNotes/GraceNotes/Services/Reminders/DailyReminderNotificationSync.swift
+++ b/GraceNotes/GraceNotes/Services/Reminders/DailyReminderNotificationSync.swift
@@ -13,11 +13,7 @@ enum DailyReminderNotificationSync {
         let status = await reminderScheduler.currentReminderStatus()
         guard status == .enabled else { return }
 
-        let stored = userDefaults.object(forKey: ReminderSettings.timeIntervalKey) as? TimeInterval
-        var interval = stored ?? ReminderSettings.defaultTimeInterval
-        if !interval.isFinite {
-            interval = ReminderSettings.defaultTimeInterval
-        }
+        let interval = ReminderSettings.coercedTimeInterval(fromUserDefaults: userDefaults)
         let reminderTime = ReminderSettings.date(from: interval)
         let body: String
         do {

--- a/GraceNotes/GraceNotes/Services/Reminders/ReminderScheduler.swift
+++ b/GraceNotes/GraceNotes/Services/Reminders/ReminderScheduler.swift
@@ -71,7 +71,11 @@ struct ReminderScheduler {
     }
 
     func enableDailyReminder(at time: Date, body: String) async -> ReminderSyncResult {
-        switch await notificationPermissionOutcome(allowPermissionPrompt: true) {
+        let authorizationStatus = await notificationCenter.authorizationStatus()
+        switch await notificationPermissionOutcome(
+            allowPermissionPrompt: true,
+            authorizationStatus: authorizationStatus
+        ) {
         case .granted:
             let wasScheduled = await scheduleReminder(at: time, body: body)
             return wasScheduled ? .scheduled : .failed
@@ -94,11 +98,15 @@ struct ReminderScheduler {
         // `notDetermined` is not a denial. This path does not prompt, so treat it as “cannot
         // reconcile now” and keep any existing pending request (maps to the same UI result as
         // before, without clearing a still-valid schedule).
-        if await notificationCenter.authorizationStatus() == .notDetermined {
+        let authorizationStatus = await notificationCenter.authorizationStatus()
+        if authorizationStatus == .notDetermined {
             return .permissionDenied
         }
 
-        switch await notificationPermissionOutcome(allowPermissionPrompt: false) {
+        switch await notificationPermissionOutcome(
+            allowPermissionPrompt: false,
+            authorizationStatus: authorizationStatus
+        ) {
         case .granted:
             let wasScheduled = await scheduleReminder(at: time, body: body)
             return wasScheduled ? .scheduled : .failed
@@ -120,9 +128,9 @@ struct ReminderScheduler {
     }
 
     private func notificationPermissionOutcome(
-        allowPermissionPrompt: Bool
+        allowPermissionPrompt: Bool,
+        authorizationStatus status: UNAuthorizationStatus
     ) async -> NotificationPermissionOutcome {
-        let status = await notificationCenter.authorizationStatus()
         switch status {
         case .authorized, .provisional, .ephemeral:
             return .granted

--- a/GraceNotes/GraceNotes/Services/Reminders/ReminderSettings.swift
+++ b/GraceNotes/GraceNotes/Services/Reminders/ReminderSettings.swift
@@ -13,6 +13,24 @@ struct ReminderSettings {
         return date.timeIntervalSinceReferenceDate
     }
 
+    /// Interprets an optional stored `TimeInterval`, falling back to ``defaultTimeInterval`` when the value is
+    /// missing or non-finite.
+    static func sanitizedTimeInterval(stored: TimeInterval?) -> TimeInterval {
+        let base = stored ?? defaultTimeInterval
+        return base.isFinite ? base : defaultTimeInterval
+    }
+
+    /// Loads ``timeIntervalKey`` from `userDefaults`, applies ``sanitizedTimeInterval(stored:)``, and persists when
+    /// the stored value was present but non-finite.
+    static func coercedTimeInterval(fromUserDefaults userDefaults: UserDefaults) -> TimeInterval {
+        let stored = userDefaults.object(forKey: timeIntervalKey) as? TimeInterval
+        let interval = sanitizedTimeInterval(stored: stored)
+        if let stored, !stored.isFinite {
+            userDefaults.set(interval, forKey: timeIntervalKey)
+        }
+        return interval
+    }
+
     static func date(from storedTimeInterval: TimeInterval) -> Date {
         Date(timeIntervalSinceReferenceDate: storedTimeInterval)
     }

--- a/GraceNotesTests/Application/AppInstructionLocaleTests.swift
+++ b/GraceNotesTests/Application/AppInstructionLocaleTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+@testable import GraceNotes
+
+final class AppInstructionLocaleTests: XCTestCase {
+    func test_resolved_matchesRepresentativeBundlePreferredLocalizationTags() {
+        let cases: [(String, AppInstructionLocale)] = [
+            ("zh-Hans", .simplifiedChinese),
+            ("zh_CN", .simplifiedChinese),
+            ("zh_Hans_CN", .simplifiedChinese),
+            ("zh", .simplifiedChinese),
+            ("zh-Hant", .english),
+            ("en", .english)
+        ]
+        for (tag, expected) in cases {
+            XCTAssertEqual(
+                AppInstructionLocale.resolved(forPreferredLocalizationIdentifier: tag),
+                expected,
+                "preferred localization tag: \(tag)"
+            )
+        }
+    }
+
+    func test_preferred_emptyPreferredLocalizations_fallsBackToEnglish() {
+        let bundle = EmptyPreferredLocalizationsBundle()
+        XCTAssertEqual(AppInstructionLocale.preferred(bundle: bundle), .english)
+    }
+}
+
+private final class EmptyPreferredLocalizationsBundle: Bundle {
+    init() {
+        super.init(path: Bundle(for: EmptyPreferredLocalizationsBundle.self).bundlePath)!
+    }
+
+    override var preferredLocalizations: [String] { [] }
+}

--- a/GraceNotesTests/Application/AppInstructionLocaleTests.swift
+++ b/GraceNotesTests/Application/AppInstructionLocaleTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import GraceNotes
+
+final class AppInstructionLocaleTests: XCTestCase {
+    func test_isSimplifiedChineseUIIdentifier_simplifiedChineseVariants_match() {
+        for id in ["zh-Hans", "zh-hans", "zh-Hans-CN", "ZH-HANS"] {
+            XCTAssertTrue(
+                AppInstructionLocale.isSimplifiedChineseUIIdentifier(id),
+                "expected Simplified Chinese for \(id)"
+            )
+        }
+    }
+
+    func test_isSimplifiedChineseUIIdentifier_nonSimplifiedChinese_fallsBackToEnglish() {
+        for id in ["zh-Hant", "zh-hant", "zh-Hant-TW", "zh", "en", ""] {
+            XCTAssertFalse(
+                AppInstructionLocale.isSimplifiedChineseUIIdentifier(id),
+                "expected English instruction locale for \(id)"
+            )
+        }
+    }
+}

--- a/GraceNotesTests/Data/JournalItemDecodingTests.swift
+++ b/GraceNotesTests/Data/JournalItemDecodingTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import GraceNotes
+
+final class JournalItemDecodingTests: XCTestCase {
+
+    func test_decode_legacyJSON_emptyFullText_usesEntryLabel() throws {
+        let json = #"{"fullText":"","entryLabel":"Recovered line"}"#
+        let data = Data(json.utf8)
+
+        let item = try JSONDecoder().decode(JournalItem.self, from: data)
+
+        XCTAssertEqual(item.fullText, "Recovered line")
+    }
+
+    func test_decode_legacyJSON_emptyFullText_usesChipLabelWhenEntryLabelAbsent() throws {
+        let json = #"{"fullText":"","chipLabel":"Chip fallback"}"#
+        let data = Data(json.utf8)
+
+        let item = try JSONDecoder().decode(JournalItem.self, from: data)
+
+        XCTAssertEqual(item.fullText, "Chip fallback")
+    }
+
+    func test_decode_legacyJSON_emptyFullText_prefersEntryLabelOverChipLabel() throws {
+        let json = #"{"fullText":"","entryLabel":"Primary","chipLabel":"Secondary"}"#
+        let data = Data(json.utf8)
+
+        let item = try JSONDecoder().decode(JournalItem.self, from: data)
+
+        XCTAssertEqual(item.fullText, "Primary")
+    }
+}

--- a/GraceNotesTests/Features/Journal/DeterministicReviewInsightsGeneratorTests+NarrativeSummary.swift
+++ b/GraceNotesTests/Features/Journal/DeterministicReviewInsightsGeneratorTests+NarrativeSummary.swift
@@ -23,6 +23,48 @@ extension DeterministicReviewInsightsTests {
         XCTAssertEqual(builder.narrativeSummary(from: [first, second]), "Beta observation line.")
     }
 
+    func test_weeklyInsightCandidateBuilder_narrativeSummary_distinctObservations_secondEmpty_usesFirst() {
+        let builder = WeeklyInsightCandidateBuilder(textNormalizer: WeeklyInsightTextNormalizer())
+        let first = ReviewWeeklyInsight(
+            pattern: .recurringTheme,
+            observation: "Alpha observation line.",
+            action: "Q1?",
+            primaryTheme: "Alpha",
+            mentionCount: 2,
+            dayCount: 2
+        )
+        let second = ReviewWeeklyInsight(
+            pattern: .continuityShift,
+            observation: "",
+            action: "Q2?",
+            primaryTheme: "Beta",
+            mentionCount: 2,
+            dayCount: 2
+        )
+        XCTAssertEqual(builder.narrativeSummary(from: [first, second]), "Alpha observation line.")
+    }
+
+    func test_weeklyInsightCandidateBuilder_narrativeSummary_distinctObservations_secondWhitespaceOnly_usesFirst() {
+        let builder = WeeklyInsightCandidateBuilder(textNormalizer: WeeklyInsightTextNormalizer())
+        let first = ReviewWeeklyInsight(
+            pattern: .recurringTheme,
+            observation: "Alpha observation line.",
+            action: "Q1?",
+            primaryTheme: "Alpha",
+            mentionCount: 2,
+            dayCount: 2
+        )
+        let second = ReviewWeeklyInsight(
+            pattern: .continuityShift,
+            observation: "   ",
+            action: "Q2?",
+            primaryTheme: "Beta",
+            mentionCount: 2,
+            dayCount: 2
+        )
+        XCTAssertEqual(builder.narrativeSummary(from: [first, second]), "Alpha observation line.")
+    }
+
     func test_weeklyInsightCandidateBuilder_narrativeSummary_whenObservationsDuplicate_usesBothThemesLine() {
         let builder = WeeklyInsightCandidateBuilder(textNormalizer: WeeklyInsightTextNormalizer())
         let shared = "Same observation text."

--- a/GraceNotesTests/Features/Journal/HistoryEntryGroupingTests.swift
+++ b/GraceNotesTests/Features/Journal/HistoryEntryGroupingTests.swift
@@ -39,6 +39,72 @@ final class HistoryEntryGroupingTests: XCTestCase {
         XCTAssertEqual(grouped[0].entries.count, 2)
     }
 
+    /// When both month-interval and Y/M normalization fail, production uses `startOfDay` instead of
+    /// the raw entry timestamp so same-day entries stay in one bucket. Dual-nil combinations are
+    /// rare in `Foundation`, so this injects the same key function as that fallback branch.
+    func test_groupedByMonth_collapsesSameDayEntriesWhenMonthKeyFallsBackToStartOfDay() {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(secondsFromGMT: 0)!
+        let morning = Journal(
+            entryDate: date(
+                components: DateComponents(year: 2026, month: 3, day: 9, hour: 8, minute: 0, second: 0),
+                calendar: cal
+            )
+        )
+        let evening = Journal(
+            entryDate: date(
+                components: DateComponents(year: 2026, month: 3, day: 9, hour: 22, minute: 30, second: 0),
+                calendar: cal
+            )
+        )
+
+        let grouped = HistoryEntryGrouping.groupedByMonth(
+            entries: [morning, evening],
+            calendar: cal,
+            monthKeyResolver: { date, calendar in calendar.startOfDay(for: date) }
+        )
+
+        XCTAssertEqual(grouped.count, 1)
+        XCTAssertEqual(grouped[0].entries.count, 2)
+        XCTAssertEqual(grouped[0].key, cal.startOfDay(for: morning.entryDate))
+    }
+
+    /// Locks first-of-month section keys for a real-world style calendar and non-UTC timezone
+    /// (DST-safe same calendar month for varied times on one day).
+    func test_groupedByMonth_usesStableMonthKeysWithLosAngelesTimeZone() {
+        let previousDefaultTimeZone = NSTimeZone.default
+        guard let laTimeZone = TimeZone(identifier: "America/Los_Angeles") else {
+            XCTFail("Missing America/Los_Angeles timezone")
+            return
+        }
+        NSTimeZone.default = laTimeZone
+        defer { NSTimeZone.default = previousDefaultTimeZone }
+
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = laTimeZone
+
+        let morning = date(
+            components: DateComponents(year: 2026, month: 3, day: 9, hour: 8, minute: 0, second: 0),
+            calendar: cal
+        )
+        let evening = date(
+            components: DateComponents(year: 2026, month: 3, day: 9, hour: 22, minute: 30, second: 0),
+            calendar: cal
+        )
+
+        let grouped = HistoryEntryGrouping.groupedByMonth(
+            entries: [Journal(entryDate: evening), Journal(entryDate: morning)],
+            calendar: cal
+        )
+
+        XCTAssertEqual(grouped.count, 1)
+        XCTAssertEqual(grouped[0].entries.count, 2)
+        XCTAssertEqual(
+            grouped[0].key,
+            date(components: DateComponents(year: 2026, month: 3, day: 1), calendar: cal)
+        )
+    }
+
     private func date(year: Int, month: Int, day: Int) -> Date {
         var components = DateComponents()
         components.year = year
@@ -46,5 +112,12 @@ final class HistoryEntryGroupingTests: XCTestCase {
         components.day = day
         components.timeZone = calendar.timeZone
         return calendar.date(from: components)!
+    }
+
+    private func date(components: DateComponents, calendar cal: Calendar) -> Date {
+        var merged = components
+        merged.calendar = cal
+        merged.timeZone = cal.timeZone
+        return cal.date(from: merged)!
     }
 }

--- a/GraceNotesTests/Features/Journal/HistoryEntryGroupingTests.swift
+++ b/GraceNotesTests/Features/Journal/HistoryEntryGroupingTests.swift
@@ -39,6 +39,21 @@ final class HistoryEntryGroupingTests: XCTestCase {
         XCTAssertEqual(grouped[0].entries.count, 2)
     }
 
+    /// Covers the January 1 + `date(byAdding: .month, …)` path in `gregorianUTCMonthStart(for:)`, used when
+    /// `dateInterval(of: .month, …)` and `date(from:)` for day=1 both fail but year/month are still known.
+    /// That full chain is hard to force in a deterministic test; `gregorianUTCMonthStartFromYearMonth` is the
+    /// extracted implementation and is what we assert here.
+    func test_gregorianUTCMonthStartFromYearMonth_anchorsFromJanuaryFirst() {
+        let fallback = date(year: 2026, month: 3, day: 15)
+        let result = HistoryEntryGrouping.gregorianUTCMonthStartFromYearMonth(
+            year: 2026,
+            month: 3,
+            calendar: calendar,
+            fallbackDate: fallback
+        )
+        XCTAssertEqual(result, date(year: 2026, month: 3, day: 1))
+    }
+
     private func date(year: Int, month: Int, day: Int) -> Date {
         var components = DateComponents()
         components.year = year

--- a/GraceNotesTests/Features/Journal/JournalEntryTapCapacityTests.swift
+++ b/GraceNotesTests/Features/Journal/JournalEntryTapCapacityTests.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+import XCTest
+@testable import GraceNotes
+
+@MainActor
+final class JournalEntryTapCapacityTests: XCTestCase {
+    func test_performEntryTap_whenAtCapacityWithDraftNotEditing_doesNotSwitchToTappedStrip() {
+        var input = "Unsaved inline draft"
+        var editingIndex: Int?
+        var isTransitioning = false
+        var didAdd = false
+        let operations = EntrySectionOperations(
+            updateImmediate: { _, _ in nil },
+            addImmediate: { _ in
+                didAdd = true
+                return nil
+            },
+            remove: { _ in false },
+            fullText: { index in
+                index == 1 ? "Other strip text" : "First strip"
+            },
+            count: JournalViewModel.slotCount
+        )
+
+        let handled = JournalScreenEntryHandling.performEntryTap(
+            tapIndex: 1,
+            input: Binding(get: { input }, set: { input = $0 }),
+            editingIndex: Binding(get: { editingIndex }, set: { editingIndex = $0 }),
+            operations: operations,
+            isTransitioning: Binding(get: { isTransitioning }, set: { isTransitioning = $0 })
+        )
+
+        XCTAssertTrue(handled)
+        XCTAssertEqual(input, "Unsaved inline draft")
+        XCTAssertNil(editingIndex)
+        XCTAssertFalse(didAdd)
+    }
+
+    func test_performEntryTap_whenBelowCapacityButAddFails_doesNotSwitchToTappedStrip() {
+        var input = "Draft"
+        var editingIndex: Int?
+        var isTransitioning = false
+        var addCallCount = 0
+        let operations = EntrySectionOperations(
+            updateImmediate: { _, _ in nil },
+            addImmediate: { _ in
+                addCallCount += 1
+                return nil
+            },
+            remove: { _ in false },
+            fullText: { _ in "Would load if switched" },
+            count: JournalViewModel.slotCount - 1
+        )
+
+        let handled = JournalScreenEntryHandling.performEntryTap(
+            tapIndex: 0,
+            input: Binding(get: { input }, set: { input = $0 }),
+            editingIndex: Binding(get: { editingIndex }, set: { editingIndex = $0 }),
+            operations: operations,
+            isTransitioning: Binding(get: { isTransitioning }, set: { isTransitioning = $0 })
+        )
+
+        XCTAssertTrue(handled)
+        XCTAssertEqual(input, "Draft")
+        XCTAssertNil(editingIndex)
+        XCTAssertEqual(addCallCount, 1)
+    }
+}

--- a/GraceNotesTests/Features/Journal/JournalOnboardingFlowEvaluatorTests.swift
+++ b/GraceNotesTests/Features/Journal/JournalOnboardingFlowEvaluatorTests.swift
@@ -22,9 +22,10 @@ final class JournalOnboardingFlowEvaluatorTests: XCTestCase {
         let gratitudeGuidance = presentation.sectionGuidance(for: .gratitude)
         XCTAssertEqual(gratitudeGuidance?.title, "")
         XCTAssertEqual(gratitudeGuidance?.message, String(localized: "journal.onboarding.startWithGratitude"))
+        let keyboardHint = String(localized: "journal.onboarding.keyboardFinishHint")
         XCTAssertEqual(
             gratitudeGuidance?.messageSecondary,
-            String(localized: "journal.onboarding.keyboardFinishHint")
+            JournalOnboardingPresentation.trimmedKeyboardFinishHintLine(keyboardHint)
         )
         XCTAssertEqual(presentation.state(for: .gratitude), .active)
         XCTAssertEqual(
@@ -78,6 +79,29 @@ final class JournalOnboardingFlowEvaluatorTests: XCTestCase {
         )
 
         XCTAssertFalse(presentation.isGuidanceActive)
+    }
+
+    func test_presentation_whitespaceOnlyMessage_isNotGuidanceActiveAndSectionGuidanceNil() {
+        let presentation = JournalOnboardingPresentation(
+            step: .gratitude,
+            title: nil,
+            message: "  \n\t ",
+            sectionStates: [.gratitude: .active]
+        )
+
+        XCTAssertFalse(presentation.isGuidanceActive)
+        XCTAssertNil(presentation.sectionGuidance(for: .gratitude))
+    }
+
+    func test_trimmedKeyboardFinishHintLine_whitespaceOnly_returnsNil() {
+        XCTAssertNil(JournalOnboardingPresentation.trimmedKeyboardFinishHintLine("  \n  "))
+    }
+
+    func test_trimmedKeyboardFinishHintLine_surroundingWhitespace_returnsTrimmed() {
+        XCTAssertEqual(
+            JournalOnboardingPresentation.trimmedKeyboardFinishHintLine("  \n hint \t "),
+            "hint"
+        )
     }
 }
 

--- a/GraceNotesTests/Features/Journal/JournalOnboardingFlowEvaluatorTests.swift
+++ b/GraceNotesTests/Features/Journal/JournalOnboardingFlowEvaluatorTests.swift
@@ -79,6 +79,29 @@ final class JournalOnboardingFlowEvaluatorTests: XCTestCase {
 
         XCTAssertFalse(presentation.isGuidanceActive)
     }
+
+    func test_presentation_negativeGratitudesCount_targetsGratitudeLikeZero() {
+        let presentation = makePresentation(gratitudes: -1, needs: 0, people: 0)
+
+        XCTAssertEqual(presentation.step, .gratitude)
+        XCTAssertTrue(presentation.isGuidanceActive)
+        XCTAssertNotNil(presentation.sectionGuidance(for: .gratitude))
+        XCTAssertEqual(presentation.state(for: .gratitude), .active)
+        XCTAssertEqual(
+            presentation.state(for: .need),
+            .locked(reason: String(localized: "journal.onboarding.needsLockedReason"))
+        )
+    }
+
+    func test_presentation_negativeNeedsCount_targetsNeedAfterFirstGratitude() {
+        let presentation = makePresentation(gratitudes: 1, needs: -1, people: 0)
+
+        XCTAssertEqual(presentation.step, .need)
+        XCTAssertTrue(presentation.isGuidanceActive)
+        XCTAssertNotNil(presentation.sectionGuidance(for: .need))
+        XCTAssertEqual(presentation.state(for: .gratitude), .available)
+        XCTAssertEqual(presentation.state(for: .need), .active)
+    }
 }
 
 private extension JournalOnboardingFlowEvaluatorTests {

--- a/GraceNotesTests/Features/Journal/JournalOnboardingProgressTests.swift
+++ b/GraceNotesTests/Features/Journal/JournalOnboardingProgressTests.swift
@@ -23,6 +23,67 @@ final class JournalOnboardingProgressTests: XCTestCase {
         XCTAssertTrue(resolvedValue)
     }
 
+    func test_resolvedHasCompletedGuidedJournal_whenCompletedGuidedJournalIsNSNumberOne_preservesStoredValue() {
+        let defaults = makeIsolatedDefaults()
+        let one = NSNumber(value: 1)
+        defaults.set(one, forKey: JournalOnboardingStorageKeys.completedGuidedJournal)
+
+        let resolvedValue = JournalOnboardingProgress.resolvedHasCompletedGuidedJournal(using: defaults)
+
+        XCTAssertTrue(resolvedValue)
+        let stored = defaults.object(forKey: JournalOnboardingStorageKeys.completedGuidedJournal)
+        XCTAssertTrue(stored is NSNumber)
+        XCTAssertEqual((stored as? NSNumber)?.boolValue, true)
+    }
+
+    func test_resolvedHasCompletedGuidedJournal_whenCompletedGuidedJournalIsNSNumberZero_preservesStoredValue() {
+        let defaults = makeIsolatedDefaults()
+        let zero = NSNumber(value: 0)
+        defaults.set(zero, forKey: JournalOnboardingStorageKeys.completedGuidedJournal)
+
+        let resolvedValue = JournalOnboardingProgress.resolvedHasCompletedGuidedJournal(using: defaults)
+
+        XCTAssertFalse(resolvedValue)
+        let stored = defaults.object(forKey: JournalOnboardingStorageKeys.completedGuidedJournal)
+        XCTAssertTrue(stored is NSNumber)
+        XCTAssertEqual((stored as? NSNumber)?.boolValue, false)
+    }
+
+    func test_resolvedHasCompletedGuidedJournal_whenCompletedGuidedJournalIsNSNumberNonFinite_interpretsViaBoolValue() {
+        let defaults = makeIsolatedDefaults()
+        let infinityNumber = NSNumber(value: 1.0 / 0.0)
+        defaults.set(infinityNumber, forKey: JournalOnboardingStorageKeys.completedGuidedJournal)
+
+        let resolvedValue = JournalOnboardingProgress.resolvedHasCompletedGuidedJournal(using: defaults)
+
+        XCTAssertTrue(resolvedValue)
+        let stored = defaults.object(forKey: JournalOnboardingStorageKeys.completedGuidedJournal)
+        XCTAssertTrue(stored is NSNumber)
+    }
+
+    func test_resolvedHasCompletedGuidedJournal_whenLegacyFirstRunCompletedIsNSNumberOne_migratesWithoutLosingIntent() {
+        let defaults = makeIsolatedDefaults()
+        defaults.set(NSNumber(value: 1), forKey: FirstRunOnboardingStorageKeys.completed)
+
+        let resolvedValue = JournalOnboardingProgress.resolvedHasCompletedGuidedJournal(using: defaults)
+
+        XCTAssertTrue(resolvedValue)
+        XCTAssertTrue(defaults.bool(forKey: JournalOnboardingStorageKeys.completedGuidedJournal))
+    }
+
+    func test_migrateLegacyPostSeedOrientationFlags_whenBranchResolutionSetAndCompletedGuidedJournalIsNSNumber_doesNotOverwriteWithFalse() {
+        let defaults = makeIsolatedDefaults()
+        defaults.set(NSNumber(value: 1), forKey: JournalOnboardingStorageKeys.completedGuidedJournal)
+        defaults.set(true, forKey: JournalOnboardingStorageKeys.legacy051GuidedBranchResolution)
+
+        JournalOnboardingProgress.migrateLegacyPostSeedOrientationFlagsIfNeeded(using: defaults)
+
+        XCTAssertTrue(JournalOnboardingProgress.resolvedHasCompletedGuidedJournal(using: defaults))
+        let stored = defaults.object(forKey: JournalOnboardingStorageKeys.completedGuidedJournal)
+        XCTAssertTrue(stored is NSNumber)
+        XCTAssertEqual((stored as? NSNumber)?.boolValue, true)
+    }
+
     func test_resetAll_clearsGuidedJournalAndSuggestionFlags() {
         let defaults = makeIsolatedDefaults()
         let progress = JournalOnboardingProgress(defaults: defaults)

--- a/GraceNotesTests/Features/Journal/JournalShareRendererTests.swift
+++ b/GraceNotesTests/Features/Journal/JournalShareRendererTests.swift
@@ -58,4 +58,15 @@ final class JournalShareRendererTests: XCTestCase {
             XCTAssertGreaterThan(image.size.width, 0, style.rawValue)
         }
     }
+
+    func test_shareTypographyScript_forLocale_mapsCJKPrimaryLanguages() {
+        XCTAssertEqual(ShareTypographyScript.forLocale(Locale(identifier: "zh-Hans")), .cjk)
+        XCTAssertEqual(ShareTypographyScript.forLocale(Locale(identifier: "ja_JP")), .cjk)
+        XCTAssertEqual(ShareTypographyScript.forLocale(Locale(identifier: "ko")), .cjk)
+    }
+
+    func test_shareTypographyScript_forLocale_mapsLatinLocales() {
+        XCTAssertEqual(ShareTypographyScript.forLocale(Locale(identifier: "en_US")), .latin)
+        XCTAssertEqual(ShareTypographyScript.forLocale(Locale(identifier: "de_DE")), .latin)
+    }
 }

--- a/GraceNotesTests/Features/Journal/PastDrilldownCalendarLayoutTests.swift
+++ b/GraceNotesTests/Features/Journal/PastDrilldownCalendarLayoutTests.swift
@@ -273,3 +273,22 @@ final class PastDrilldownCalendarLayoutTests: XCTestCase {
         XCTAssertEqual(clamped, target, accuracy: 0.001)
     }
 }
+
+/// Isolated so `PastDrilldownCalendarLayoutTests` stays within SwiftLint `type_body_length`.
+final class PeekMetricsClampedViewportTests: XCTestCase {
+
+    func test_peekMetrics_clampedViewport_nonFiniteRemaining_nanReturnsZero() {
+        let clamped = ReviewHistoryDrilldownPeekMetrics.clampedViewportHeight(remainingHeight: .nan)
+        XCTAssertEqual(clamped, 0, accuracy: 0.001)
+    }
+
+    func test_peekMetrics_clampedViewport_nonFiniteRemaining_positiveInfinityReturnsZero() {
+        let clamped = ReviewHistoryDrilldownPeekMetrics.clampedViewportHeight(remainingHeight: .infinity)
+        XCTAssertEqual(clamped, 0, accuracy: 0.001)
+    }
+
+    func test_peekMetrics_clampedViewport_nonFiniteRemaining_negativeInfinityReturnsZero() {
+        let clamped = ReviewHistoryDrilldownPeekMetrics.clampedViewportHeight(remainingHeight: -.infinity)
+        XCTAssertEqual(clamped, 0, accuracy: 0.001)
+    }
+}

--- a/GraceNotesTests/Features/Journal/PastDrilldownCalendarLayoutTests.swift
+++ b/GraceNotesTests/Features/Journal/PastDrilldownCalendarLayoutTests.swift
@@ -265,6 +265,14 @@ final class PastDrilldownCalendarLayoutTests: XCTestCase {
         XCTAssertEqual(clamped, 0, accuracy: 0.001)
     }
 
+    /// `max(0, -0)` can yield IEEE −0; `abs` canonicalizes to +0 so layout heights are a clean non-negative signal.
+    func test_peekMetrics_clampedViewport_canonicalizesNegativeZeroRemainingToPositiveZero() {
+        let negativeZero = CGFloat(signOf: -1, magnitudeOf: 0)
+        let clamped = ReviewHistoryDrilldownPeekMetrics.clampedViewportHeight(remainingHeight: negativeZero)
+        XCTAssertEqual(clamped.bitPattern, CGFloat(0).bitPattern)
+        XCTAssertEqual(1 / clamped, .infinity)
+    }
+
     func test_peekMetrics_clampedViewport_usesRemainingWhenBetweenMinAndPreferred() {
         let minimum = ReviewHistoryDrilldownPeekMetrics.minimumViewportHeight
         let preferred = ReviewHistoryDrilldownCalendarGrid.Metrics.scrollViewportHeight

--- a/GraceNotesTests/Features/Journal/PastStatisticsIntervalPreferenceTests.swift
+++ b/GraceNotesTests/Features/Journal/PastStatisticsIntervalPreferenceTests.swift
@@ -52,4 +52,29 @@ final class PastStatisticsIntervalPreferenceTests: XCTestCase {
         XCTAssertEqual(range.lowerBound, refStart)
         XCTAssertEqual(range.upperBound, calendar.date(byAdding: .day, value: 1, to: refStart))
     }
+
+    func test_resolvedHistoryRange_customMode_outOfBoundsQuantity_clampsAndProducesWellFormedRange() {
+        var calendar = Calendar(identifier: .gregorian)
+        guard let utc = TimeZone(identifier: "UTC") else {
+            XCTFail("Missing UTC timezone")
+            return
+        }
+        calendar.timeZone = utc
+        let refStart = calendar.startOfDay(for: Date(timeIntervalSince1970: 1_700_000_000))
+        let entries: [Journal] = []
+
+        let rangeAtZero = PastStatisticsIntervalSelection(mode: .custom, quantity: 0, unit: .week)
+            .resolvedHistoryRange(referenceDate: refStart, calendar: calendar, allEntries: entries)
+        let rangeAtOne = PastStatisticsIntervalSelection(mode: .custom, quantity: 1, unit: .week)
+            .resolvedHistoryRange(referenceDate: refStart, calendar: calendar, allEntries: entries)
+        XCTAssertEqual(rangeAtZero, rangeAtOne)
+        XCTAssertLessThan(rangeAtZero.lowerBound, rangeAtZero.upperBound)
+
+        let rangeAt1000 = PastStatisticsIntervalSelection(mode: .custom, quantity: 1000, unit: .week)
+            .resolvedHistoryRange(referenceDate: refStart, calendar: calendar, allEntries: entries)
+        let rangeAt999 = PastStatisticsIntervalSelection(mode: .custom, quantity: 999, unit: .week)
+            .resolvedHistoryRange(referenceDate: refStart, calendar: calendar, allEntries: entries)
+        XCTAssertEqual(rangeAt1000, rangeAt999)
+        XCTAssertLessThan(rangeAt1000.lowerBound, rangeAt1000.upperBound)
+    }
 }

--- a/GraceNotesTests/Features/Journal/ReviewInsightsPeriodTests.swift
+++ b/GraceNotesTests/Features/Journal/ReviewInsightsPeriodTests.swift
@@ -62,11 +62,33 @@ final class ReviewInsightsPeriodTests: XCTestCase {
         XCTAssertEqual(period.lowerBound, weekStart)
     }
 
-    private func date(year: Int, month: Int, day: Int) -> Date {
+    /// US Eastern spring forward March 8, 2026 (2:00 → 3:00 local). Exercises `previousPeriod` with
+    /// non-GMT offsets and a reference instant after the transition so week math stays day-anchored.
+    func test_previousPeriod_dstAmericaNewYork_sevenLocalDaysAfterSpringForward() {
+        var nyCalendar = Calendar(identifier: .gregorian)
+        nyCalendar.timeZone = TimeZone(identifier: "America/New_York")!
+        nyCalendar.firstWeekday = 1
+        calendar = nyCalendar
+
+        let reference = date(year: 2026, month: 3, day: 8, hour: 4, minute: 0)
+        let current = ReviewInsightsPeriod.currentPeriod(containing: reference, calendar: calendar)
+        let previous = ReviewInsightsPeriod.previousPeriod(before: current, calendar: calendar)
+
+        XCTAssertEqual(previous.upperBound, current.lowerBound)
+        XCTAssertEqual(previous.lowerBound, calendar.startOfDay(for: previous.lowerBound))
+        XCTAssertEqual(current.lowerBound, calendar.startOfDay(for: current.lowerBound))
+
+        let daySpan = calendar.dateComponents([.day], from: previous.lowerBound, to: previous.upperBound).day
+        XCTAssertEqual(daySpan, 7)
+    }
+
+    private func date(year: Int, month: Int, day: Int, hour: Int = 0, minute: Int = 0) -> Date {
         var components = DateComponents()
         components.year = year
         components.month = month
         components.day = day
+        components.hour = hour
+        components.minute = minute
         components.timeZone = calendar.timeZone
         return calendar.date(from: components)!
     }

--- a/GraceNotesTests/Features/Journal/ReviewInsightsPeriodTests.swift
+++ b/GraceNotesTests/Features/Journal/ReviewInsightsPeriodTests.swift
@@ -62,6 +62,54 @@ final class ReviewInsightsPeriodTests: XCTestCase {
         XCTAssertEqual(period.lowerBound, weekStart)
     }
 
+    /// Forces the `weekStart..<interval.end` branch when the seven-day exclusive end is unavailable.
+    func test_currentPeriod_fallsBackToIntervalEndWhenExclusiveEndUnavailable() {
+        calendar.firstWeekday = 1
+        let reference = date(year: 2026, month: 3, day: 18)
+        let interval = calendar.dateInterval(of: .weekOfYear, for: reference)!
+        let weekStart = calendar.startOfDay(for: interval.start)
+        let period = ReviewInsightsPeriod.currentPeriod(
+            containing: reference,
+            calendar: calendar,
+            weekExclusiveEnd: { _ in nil }
+        )
+        XCTAssertEqual(period.lowerBound, weekStart)
+        XCTAssertEqual(period.upperBound, interval.end)
+    }
+
+    /// Forces ``rollingSevenDayFallback`` when the week interval cannot be resolved.
+    func test_currentPeriod_rollingFallbackWhenWeekIntervalUnavailable() {
+        calendar.firstWeekday = 1
+        let reference = date(year: 2026, month: 3, day: 18)
+        let period = ReviewInsightsPeriod.currentPeriod(
+            containing: reference,
+            calendar: calendar,
+            weekIntervalForReference: { _ in nil }
+        )
+        let endDay = calendar.startOfDay(for: reference)
+        let expectedEnd = calendar.date(byAdding: .day, value: 1, to: endDay) ?? endDay
+        let expectedStart = calendar.date(byAdding: .day, value: -6, to: endDay) ?? endDay
+        XCTAssertEqual(period.lowerBound, expectedStart)
+        XCTAssertEqual(period.upperBound, expectedEnd)
+    }
+
+    /// Forces the span-based fallback when subtracting seven local days returns nil.
+    func test_previousPeriod_fallsBackToSpanWhenSubtractSevenDaysUnavailable() {
+        calendar.firstWeekday = 1
+        let lower = date(year: 2026, month: 3, day: 15)
+        let upper = date(year: 2026, month: 3, day: 24)
+        let current = lower..<upper
+        let span = upper.timeIntervalSince(lower)
+        let previous = ReviewInsightsPeriod.previousPeriod(
+            before: current,
+            calendar: calendar,
+            subtractSevenDaysFromLowerBound: { _ in nil }
+        )
+        XCTAssertEqual(previous.upperBound, lower)
+        XCTAssertEqual(previous.lowerBound, lower.addingTimeInterval(-span))
+        XCTAssertEqual(previous.upperBound.timeIntervalSince(previous.lowerBound), span, accuracy: 0.001)
+    }
+
     private func date(year: Int, month: Int, day: Int) -> Date {
         var components = DateComponents()
         components.year = year

--- a/GraceNotesTests/Features/Journal/ReviewJournalThemeLanguageResolverTests.swift
+++ b/GraceNotesTests/Features/Journal/ReviewJournalThemeLanguageResolverTests.swift
@@ -30,4 +30,17 @@ final class ReviewJournalThemeLanguageResolverTests: XCTestCase {
         let locale = resolver.resolvedDisplayLocale(forJournalCorpus: corpus)
         XCTAssertEqual(locale.identifier, "en")
     }
+
+    /// Prefix-only analysis (50k grapheme clusters): Latin head vs Han tail would differ under full-corpus scanning.
+    func test_resolvedDisplayLocale_usesBoundedAnalysisPrefixForVeryLargeCorpora() {
+        let resolver = ReviewJournalThemeLanguageResolver(
+            minimumMeaningfulGraphemes: 8,
+            confidenceThreshold: 1.0
+        )
+        let prefixLatin = String(repeating: "a", count: 50_000)
+        let suffixHan = String(repeating: "休", count: 100_000)
+        let corpus = prefixLatin + suffixHan
+        let locale = resolver.resolvedDisplayLocale(forJournalCorpus: corpus)
+        XCTAssertEqual(locale.identifier, "en")
+    }
 }

--- a/GraceNotesTests/Features/Journal/ReviewJournalThemeLanguageResolverTests.swift
+++ b/GraceNotesTests/Features/Journal/ReviewJournalThemeLanguageResolverTests.swift
@@ -30,4 +30,14 @@ final class ReviewJournalThemeLanguageResolverTests: XCTestCase {
         let locale = resolver.resolvedDisplayLocale(forJournalCorpus: corpus)
         XCTAssertEqual(locale.identifier, "en")
     }
+
+    func test_resolvedDisplayLocale_sparseAnalysisPrefixDenseTail_fallsBackToEnglish() {
+        let resolver = ReviewJournalThemeLanguageResolver()
+        // One meaningful grapheme in the first 50k clusters, then spaces to fill the prefix, then dense
+        // Chinese: the meaningful-grapheme gate only sees the analysis prefix, so we fall back to English.
+        let sparseHead = "A" + String(repeating: " ", count: 49_999)
+        let denseTail = String(repeating: "休", count: 10_000)
+        let locale = resolver.resolvedDisplayLocale(forJournalCorpus: sparseHead + denseTail)
+        XCTAssertEqual(locale.identifier, "en")
+    }
 }

--- a/GraceNotesTests/Features/Journal/ReviewRhythmScrollPinIdentityTests.swift
+++ b/GraceNotesTests/Features/Journal/ReviewRhythmScrollPinIdentityTests.swift
@@ -10,14 +10,34 @@ final class ReviewRhythmScrollPinIdentityTests: XCTestCase {
         XCTAssertEqual(lhs, rhs)
     }
 
-    func test_pinIdentity_notEqualWhenDayPayloadChanges() {
+    func test_pinIdentity_equalWhenOnlyPerDayPayloadFlagsChange() {
         let weekStart = Date(timeIntervalSince1970: 1_700_000_000)
         let dayDate = Date(timeIntervalSince1970: 1_700_086_400)
         let rich = ReviewDayActivity(date: dayDate, hasReflectiveActivity: true, hasPersistedEntry: true)
         let sparse = ReviewDayActivity(date: dayDate, hasReflectiveActivity: false, hasPersistedEntry: true)
         let lhs = ReviewRhythmScrollPinIdentity(weekStart: weekStart, days: [rich])
         let rhs = ReviewRhythmScrollPinIdentity(weekStart: weekStart, days: [sparse])
-        XCTAssertNotEqual(lhs, rhs)
+        XCTAssertEqual(lhs, rhs)
+    }
+
+    func test_pinIdentity_equalWhenOnlyStrongestCompletionLevelChanges() {
+        let weekStart = Date(timeIntervalSince1970: 1_700_000_000)
+        let dayDate = Date(timeIntervalSince1970: 1_700_086_400)
+        let lhsDay = ReviewDayActivity(
+            date: dayDate,
+            hasReflectiveActivity: true,
+            strongestCompletionLevel: .soil,
+            hasPersistedEntry: true
+        )
+        let rhsDay = ReviewDayActivity(
+            date: dayDate,
+            hasReflectiveActivity: true,
+            strongestCompletionLevel: .leaf,
+            hasPersistedEntry: true
+        )
+        let lhs = ReviewRhythmScrollPinIdentity(weekStart: weekStart, days: [lhsDay])
+        let rhs = ReviewRhythmScrollPinIdentity(weekStart: weekStart, days: [rhsDay])
+        XCTAssertEqual(lhs, rhs)
     }
 
     func test_pinIdentity_notEqualWhenReviewWeekChanges() {
@@ -26,6 +46,21 @@ final class ReviewRhythmScrollPinIdentityTests: XCTestCase {
         let day = ReviewDayActivity(date: ws1, hasReflectiveActivity: true, hasPersistedEntry: true)
         let lhs = ReviewRhythmScrollPinIdentity(weekStart: ws1, days: [day])
         let rhs = ReviewRhythmScrollPinIdentity(weekStart: ws2, days: [day])
+        XCTAssertNotEqual(lhs, rhs)
+    }
+
+    func test_pinIdentity_notEqualWhenDayColumnDatesDiffer() {
+        let weekStart = Date(timeIntervalSince1970: 1_700_000_000)
+        let earlierDay = Date(timeIntervalSince1970: 1_700_086_400)
+        let laterDay = Date(timeIntervalSince1970: 1_700_172_800)
+        let lhs = ReviewRhythmScrollPinIdentity(
+            weekStart: weekStart,
+            days: [ReviewDayActivity(date: earlierDay, hasReflectiveActivity: true, hasPersistedEntry: true)]
+        )
+        let rhs = ReviewRhythmScrollPinIdentity(
+            weekStart: weekStart,
+            days: [ReviewDayActivity(date: laterDay, hasReflectiveActivity: true, hasPersistedEntry: true)]
+        )
         XCTAssertNotEqual(lhs, rhs)
     }
 }

--- a/GraceNotesTests/Features/Journal/ReviewWeekBoundaryPreferenceTests.swift
+++ b/GraceNotesTests/Features/Journal/ReviewWeekBoundaryPreferenceTests.swift
@@ -16,4 +16,18 @@ final class ReviewWeekBoundaryPreferenceTests: XCTestCase {
         XCTAssertEqual(sunday.firstWeekday, 1)
         XCTAssertEqual(monday.firstWeekday, 2)
     }
+
+    func test_configuredCalendar_nonGregorianBase_returnsGregorianPreservingTimeZoneAndLocale() {
+        var base = Calendar(identifier: .islamicUmmAlQura)
+        base.timeZone = TimeZone(identifier: "America/Los_Angeles")!
+        base.locale = Locale(identifier: "en_US")
+
+        let result = ReviewWeekBoundaryPreference.mondayStart.configuredCalendar(base: base)
+
+        XCTAssertEqual(base.identifier, .islamicUmmAlQura)
+        XCTAssertEqual(result.identifier, .gregorian)
+        XCTAssertEqual(result.timeZone, base.timeZone)
+        XCTAssertEqual(result.locale, base.locale)
+        XCTAssertEqual(result.firstWeekday, 2)
+    }
 }

--- a/GraceNotesTests/Features/Journal/ReviewWeekTrendPolicyTests.swift
+++ b/GraceNotesTests/Features/Journal/ReviewWeekTrendPolicyTests.swift
@@ -80,6 +80,28 @@ final class ReviewWeekTrendPolicyTests: XCTestCase {
         XCTAssertEqual(ReviewWeekTrendPolicy.rawTrend(current: 2, previous: 2), .stable)
     }
 
+    /// Invalid negative counts are treated as `.stable` so bad upstream data does not imply rising/down labels.
+    func test_rawTrend_negativeCountsAreStable() {
+        XCTAssertEqual(ReviewWeekTrendPolicy.rawTrend(current: -1, previous: 0), .stable)
+        XCTAssertEqual(ReviewWeekTrendPolicy.rawTrend(current: 0, previous: -1), .stable)
+        XCTAssertEqual(ReviewWeekTrendPolicy.rawTrend(current: -1, previous: -2), .stable)
+    }
+
+    func test_trendingSurfacingTrend_negativeCountsAreStable() {
+        XCTAssertEqual(
+            ReviewWeekTrendPolicy.trendingSurfacingTrend(current: -1, previous: 0, isWarmUpPhase: false),
+            .stable
+        )
+        XCTAssertEqual(
+            ReviewWeekTrendPolicy.trendingSurfacingTrend(current: 0, previous: -1, isWarmUpPhase: false),
+            .stable
+        )
+        XCTAssertEqual(
+            ReviewWeekTrendPolicy.trendingSurfacingTrend(current: -1, previous: -2, isWarmUpPhase: true),
+            .stable
+        )
+    }
+
     func test_trendingSurfacing_new_requiresCurrentAtLeastTwo() {
         XCTAssertEqual(
             ReviewWeekTrendPolicy.trendingSurfacingTrend(current: 1, previous: 0, isWarmUpPhase: false),

--- a/GraceNotesTests/Features/Journal/ReviewWeekTrendPolicyTests.swift
+++ b/GraceNotesTests/Features/Journal/ReviewWeekTrendPolicyTests.swift
@@ -70,23 +70,6 @@ final class ReviewWeekTrendPolicyTests: XCTestCase {
         )
     }
 
-    /// Inverted `currentPeriod` (lowerBound > upperBound) must fail closed to non–warm-up.
-    func test_isWarmUpPhase_invalidInvertedRange_returnsFalse() {
-        calendar.firstWeekday = 1
-        let dayStart = date(year: 2026, month: 3, day: 15)
-        let nextDayStart = calendar.date(byAdding: .day, value: 1, to: dayStart)!
-        let invertedPeriod = Range<Date>(uncheckedBounds: (nextDayStart, dayStart))
-        let reference = calendar.date(byAdding: .hour, value: 14, to: dayStart)!
-
-        XCTAssertFalse(
-            ReviewWeekTrendPolicy.isWarmUpPhase(
-                currentPeriod: invertedPeriod,
-                referenceDate: reference,
-                calendar: calendar
-            )
-        )
-    }
-
     /// Empty half-open range (`lowerBound == upperBound`) must not be treated as warm-up.
     func test_isWarmUpPhase_emptyRange_returnsFalse() {
         calendar.firstWeekday = 1

--- a/GraceNotesTests/Features/Journal/ReviewWeekTrendPolicyTests.swift
+++ b/GraceNotesTests/Features/Journal/ReviewWeekTrendPolicyTests.swift
@@ -70,6 +70,39 @@ final class ReviewWeekTrendPolicyTests: XCTestCase {
         )
     }
 
+    /// Inverted `currentPeriod` (lowerBound > upperBound) must fail closed to non–warm-up.
+    func test_isWarmUpPhase_invalidInvertedRange_returnsFalse() {
+        calendar.firstWeekday = 1
+        let dayStart = date(year: 2026, month: 3, day: 15)
+        let nextDayStart = calendar.date(byAdding: .day, value: 1, to: dayStart)!
+        let invertedPeriod = Range<Date>(uncheckedBounds: (nextDayStart, dayStart))
+        let reference = calendar.date(byAdding: .hour, value: 14, to: dayStart)!
+
+        XCTAssertFalse(
+            ReviewWeekTrendPolicy.isWarmUpPhase(
+                currentPeriod: invertedPeriod,
+                referenceDate: reference,
+                calendar: calendar
+            )
+        )
+    }
+
+    /// Empty half-open range (`lowerBound == upperBound`) must not be treated as warm-up.
+    func test_isWarmUpPhase_emptyRange_returnsFalse() {
+        calendar.firstWeekday = 1
+        let dayStart = date(year: 2026, month: 3, day: 15)
+        let emptyPeriod = dayStart..<dayStart
+        let reference = calendar.date(byAdding: .hour, value: 14, to: dayStart)!
+
+        XCTAssertFalse(
+            ReviewWeekTrendPolicy.isWarmUpPhase(
+                currentPeriod: emptyPeriod,
+                referenceDate: reference,
+                calendar: calendar
+            )
+        )
+    }
+
     // MARK: - Surfacing trend (floors + warm-up exceptions)
 
     func test_rawTrend_matchesWeekOverWeekDirection() {

--- a/GraceNotesTests/Features/Journal/ShareTypographyScriptTests.swift
+++ b/GraceNotesTests/Features/Journal/ShareTypographyScriptTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+@testable import GraceNotes
+
+final class ShareTypographyScriptTests: XCTestCase {
+    private let english = Locale.Language(identifier: "en")
+
+    func test_current_englishUIBeforeJapaneseSystem_checksOnlyFirstBundleLocalization() {
+        // Active UI is English (`preferredLocalizations.first`), system is Japanese: CJK should come
+        // from the system locale, not from secondary entries in `preferredLocalizations`.
+        let script = ShareTypographyScript.current(
+            preferredUILocalizationIdentifier: "en",
+            systemLanguage: Locale.Language(identifier: "ja")
+        )
+        XCTAssertEqual(script, .chinese)
+    }
+
+    func test_current_englishUIAndEnglishSystem_staysLatin_notCJKFromSecondaryPreferences() {
+        // Regression: the full `preferredLocalizations` array can list additional user languages.
+        // We must not treat a non-first entry (e.g. Japanese later in the list) as the app UI language.
+        let script = ShareTypographyScript.current(
+            preferredUILocalizationIdentifier: "en",
+            systemLanguage: Locale.Language(identifier: "en")
+        )
+        XCTAssertEqual(script, .latin)
+    }
+
+    func test_current_usesPreferredUILocalizationIdentifier_zhHans_beforeSystemEnglish() {
+        let script = ShareTypographyScript.current(
+            preferredUILocalizationIdentifier: "zh-Hans",
+            systemLanguage: english
+        )
+        XCTAssertEqual(script, .chinese)
+    }
+
+    func test_current_usesPreferredUILocalizationIdentifier_zhHant_beforeSystemEnglish() {
+        let script = ShareTypographyScript.current(
+            preferredUILocalizationIdentifier: "zh-Hant",
+            systemLanguage: english
+        )
+        XCTAssertEqual(script, .chinese)
+    }
+
+    func test_current_usesPreferredUILocalizationIdentifier_ja_beforeSystemEnglish() {
+        let script = ShareTypographyScript.current(
+            preferredUILocalizationIdentifier: "ja",
+            systemLanguage: english
+        )
+        XCTAssertEqual(script, .chinese)
+    }
+
+    func test_current_usesPreferredUILocalizationIdentifier_ko_beforeSystemEnglish() {
+        let script = ShareTypographyScript.current(
+            preferredUILocalizationIdentifier: "ko",
+            systemLanguage: english
+        )
+        XCTAssertEqual(script, .chinese)
+    }
+
+    func test_current_fallsBackToSystemLanguage_whenUIIsEnglish() {
+        let script = ShareTypographyScript.current(
+            preferredUILocalizationIdentifier: "en",
+            systemLanguage: Locale.Language(identifier: "zh-Hans")
+        )
+        XCTAssertEqual(script, .chinese)
+    }
+
+    func test_current_latinWhenUIAndSystemAreNonCJK() {
+        let script = ShareTypographyScript.current(
+            preferredUILocalizationIdentifier: "en",
+            systemLanguage: english
+        )
+        XCTAssertEqual(script, .latin)
+    }
+}

--- a/GraceNotesTests/Features/Journal/ShareTypographyScriptTests.swift
+++ b/GraceNotesTests/Features/Journal/ShareTypographyScriptTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import GraceNotes
+
+final class ShareTypographyScriptTests: XCTestCase {
+    func test_forLanguageCode_zhJaKo_mapsToCJKTypography() {
+        XCTAssertEqual(ShareTypographyScript.forLanguageCode(.chinese), .chinese)
+        XCTAssertEqual(ShareTypographyScript.forLanguageCode(.japanese), .chinese)
+        XCTAssertEqual(ShareTypographyScript.forLanguageCode(.korean), .chinese)
+    }
+
+    func test_forLanguageCode_nonCJK_mapsToLatin() {
+        XCTAssertEqual(ShareTypographyScript.forLanguageCode(.english), .latin)
+    }
+
+    func test_forLanguageCode_nil_mapsToLatin() {
+        XCTAssertEqual(ShareTypographyScript.forLanguageCode(nil), .latin)
+    }
+}

--- a/GraceNotesTests/Features/Journal/ShareTypographyScriptTests.swift
+++ b/GraceNotesTests/Features/Journal/ShareTypographyScriptTests.swift
@@ -11,7 +11,7 @@ final class ShareTypographyScriptTests: XCTestCase {
             preferredUILocalizationIdentifier: "en",
             systemLanguage: Locale.Language(identifier: "ja")
         )
-        XCTAssertEqual(script, .chinese)
+        XCTAssertEqual(script, .cjk)
     }
 
     func test_current_englishUIAndEnglishSystem_staysLatin_notCJKFromSecondaryPreferences() {
@@ -29,7 +29,7 @@ final class ShareTypographyScriptTests: XCTestCase {
             preferredUILocalizationIdentifier: "zh-Hans",
             systemLanguage: english
         )
-        XCTAssertEqual(script, .chinese)
+        XCTAssertEqual(script, .cjk)
     }
 
     func test_current_usesPreferredUILocalizationIdentifier_zhHant_beforeSystemEnglish() {
@@ -37,7 +37,7 @@ final class ShareTypographyScriptTests: XCTestCase {
             preferredUILocalizationIdentifier: "zh-Hant",
             systemLanguage: english
         )
-        XCTAssertEqual(script, .chinese)
+        XCTAssertEqual(script, .cjk)
     }
 
     func test_current_usesPreferredUILocalizationIdentifier_ja_beforeSystemEnglish() {
@@ -45,7 +45,7 @@ final class ShareTypographyScriptTests: XCTestCase {
             preferredUILocalizationIdentifier: "ja",
             systemLanguage: english
         )
-        XCTAssertEqual(script, .chinese)
+        XCTAssertEqual(script, .cjk)
     }
 
     func test_current_usesPreferredUILocalizationIdentifier_ko_beforeSystemEnglish() {
@@ -53,7 +53,7 @@ final class ShareTypographyScriptTests: XCTestCase {
             preferredUILocalizationIdentifier: "ko",
             systemLanguage: english
         )
-        XCTAssertEqual(script, .chinese)
+        XCTAssertEqual(script, .cjk)
     }
 
     func test_current_fallsBackToSystemLanguage_whenUIIsEnglish() {
@@ -61,7 +61,7 @@ final class ShareTypographyScriptTests: XCTestCase {
             preferredUILocalizationIdentifier: "en",
             systemLanguage: Locale.Language(identifier: "zh-Hans")
         )
-        XCTAssertEqual(script, .chinese)
+        XCTAssertEqual(script, .cjk)
     }
 
     func test_current_latinWhenUIAndSystemAreNonCJK() {

--- a/GraceNotesTests/Features/Journal/WeeklyInsightRuleEngineHeadlineTests.swift
+++ b/GraceNotesTests/Features/Journal/WeeklyInsightRuleEngineHeadlineTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import GraceNotes
+
+final class WeeklyInsightRuleEngineHeadlineTests: XCTestCase {
+    func test_firstNonEmptyTrimmedHeadline_prefersFirstObservationAcrossAllInsightsBeforeAnyTheme() {
+        let insights = [
+            ReviewWeeklyInsight(
+                pattern: .sparseFallback,
+                observation: "   ",
+                action: nil,
+                primaryTheme: "Earlier theme",
+                mentionCount: nil,
+                dayCount: nil
+            ),
+            ReviewWeeklyInsight(
+                pattern: .recurringTheme,
+                observation: "Later observation wins",
+                action: nil,
+                primaryTheme: "Other theme",
+                mentionCount: nil,
+                dayCount: nil
+            )
+        ]
+        XCTAssertEqual(
+            WeeklyInsightRuleEngine.firstNonEmptyTrimmedHeadline(in: insights),
+            "Later observation wins"
+        )
+    }
+
+    func test_firstNonEmptyTrimmedHeadline_usesPrimaryThemeWhenObservationsAreBlank() {
+        let insights = [
+            ReviewWeeklyInsight(
+                pattern: .sparseFallback,
+                observation: "\n\t ",
+                action: nil,
+                primaryTheme: "  Theme headline  ",
+                mentionCount: nil,
+                dayCount: nil
+            )
+        ]
+        XCTAssertEqual(
+            WeeklyInsightRuleEngine.firstNonEmptyTrimmedHeadline(in: insights),
+            "Theme headline"
+        )
+    }
+}

--- a/GraceNotesTests/Features/Journal/WeeklyInsightRuleEngineTests.swift
+++ b/GraceNotesTests/Features/Journal/WeeklyInsightRuleEngineTests.swift
@@ -251,3 +251,123 @@ final class WeeklyInsightRuleEngineTests: XCTestCase {
         return calendar.date(from: components)!
     }
 }
+
+// MARK: - Continuity prompt + resurfacing headline alignment
+
+final class WeeklyInsightRuleEngineContinuityTests: XCTestCase {
+    func test_continuityPrompt_prefersTrimmedActionFromPrimaryInsightWhenTwoInsightsDisagree() {
+        let other = ReviewWeeklyInsight(
+            pattern: .recurringTheme,
+            observation: "Second card",
+            action: "Other action",
+            primaryTheme: nil,
+            mentionCount: nil,
+            dayCount: nil
+        )
+        let primary = ReviewWeeklyInsight(
+            pattern: .continuityShift,
+            observation: "Headline insight",
+            action: "  Primary action  ",
+            primaryTheme: nil,
+            mentionCount: nil,
+            dayCount: nil
+        )
+        let selected = [primary, other]
+        let (headline, primaryInsight) = WeeklyInsightRuleEngine.headlineAndPrimaryInsight(from: selected)
+        XCTAssertEqual(headline, "Headline insight")
+        XCTAssertEqual(primaryInsight?.action, primary.action)
+
+        let prompt = WeeklyInsightRuleEngine.continuityPrompt(
+            matching: primaryInsight,
+            in: selected,
+            defaultPrompt: "DEFAULT"
+        )
+        XCTAssertEqual(prompt, "Primary action")
+    }
+
+    func test_continuityPrompt_alignsWithHeadlineRowWhenEarlierInsightHasOnlyAction() {
+        let skippedRow = ReviewWeeklyInsight(
+            pattern: .recurringTheme,
+            observation: "",
+            action: "Only non-empty action on first row",
+            primaryTheme: nil,
+            mentionCount: nil,
+            dayCount: nil
+        )
+        let headlineRow = ReviewWeeklyInsight(
+            pattern: .continuityShift,
+            observation: "Resurfacing headline",
+            action: "  Action from headline row  ",
+            primaryTheme: nil,
+            mentionCount: nil,
+            dayCount: nil
+        )
+        let selected = [skippedRow, headlineRow]
+        let (headline, primaryInsight) = WeeklyInsightRuleEngine.headlineAndPrimaryInsight(from: selected)
+        XCTAssertEqual(headline, "Resurfacing headline")
+        XCTAssertEqual(primaryInsight, headlineRow)
+        let prompt = WeeklyInsightRuleEngine.continuityPrompt(
+            matching: primaryInsight,
+            in: selected,
+            defaultPrompt: "DEFAULT"
+        )
+        XCTAssertEqual(prompt, "Action from headline row")
+    }
+
+    func test_continuityPrompt_fallsBackToFirstNonEmptyActionInOrderWhenPrimaryIsBlank() {
+        let primary = ReviewWeeklyInsight(
+            pattern: .continuityShift,
+            observation: "Headline",
+            action: " \n ",
+            primaryTheme: nil,
+            mentionCount: nil,
+            dayCount: nil
+        )
+        let fallback = ReviewWeeklyInsight(
+            pattern: .recurringTheme,
+            observation: "",
+            primaryTheme: "Theme",
+            action: "  Fallback action ",
+            mentionCount: nil,
+            dayCount: nil
+        )
+        let selected = [primary, fallback]
+        let (_, primaryInsight) = WeeklyInsightRuleEngine.headlineAndPrimaryInsight(from: selected)
+        XCTAssertEqual(primaryInsight, primary)
+
+        let prompt = WeeklyInsightRuleEngine.continuityPrompt(
+            matching: primaryInsight,
+            in: selected,
+            defaultPrompt: "DEFAULT"
+        )
+        XCTAssertEqual(prompt, "Fallback action")
+    }
+
+    func test_continuityPrompt_usesDefaultWhenAllActionsEmpty() {
+        let insights = [
+            ReviewWeeklyInsight(
+                pattern: .recurringTheme,
+                observation: "Only observation",
+                action: nil,
+                primaryTheme: nil,
+                mentionCount: nil,
+                dayCount: nil
+            ),
+            ReviewWeeklyInsight(
+                pattern: .fullCompletion,
+                observation: "Another",
+                action: "   ",
+                primaryTheme: nil,
+                mentionCount: nil,
+                dayCount: nil
+            )
+        ]
+        let (_, primaryInsight) = WeeklyInsightRuleEngine.headlineAndPrimaryInsight(from: insights)
+        let prompt = WeeklyInsightRuleEngine.continuityPrompt(
+            matching: primaryInsight,
+            in: insights,
+            defaultPrompt: "DEFAULT"
+        )
+        XCTAssertEqual(prompt, "DEFAULT")
+    }
+}

--- a/GraceNotesTests/Features/Journal/WeeklyInsightRuleEngineTests.swift
+++ b/GraceNotesTests/Features/Journal/WeeklyInsightRuleEngineTests.swift
@@ -2,6 +2,7 @@ import SwiftData
 import XCTest
 @testable import GraceNotes
 
+// swiftlint:disable:next type_body_length
 final class WeeklyInsightRuleEngineTests: XCTestCase {
     private var calendar: Calendar!
     private var ruleEngine: WeeklyInsightRuleEngine!
@@ -151,6 +152,72 @@ final class WeeklyInsightRuleEngineTests: XCTestCase {
     }
 
     /// Surface text counts as a reflection day for `.empty` chip status (no chips filled).
+    func test_resurfacingMessage_whitespaceOnlyObservation_fallsBackToStarterReflection() {
+        let starter = String(localized: "review.insights.starterReflection")
+        let insights = [
+            ReviewWeeklyInsight(
+                pattern: .sparseFallback,
+                observation: "   \n",
+                action: "Valid action",
+                primaryTheme: nil,
+                mentionCount: nil,
+                dayCount: 1
+            )
+        ]
+        let normalized = WeeklyInsightRuleEngine.normalizedWeeklyInsights(insights)
+        XCTAssertEqual(normalized.first?.observation, "")
+        XCTAssertEqual(
+            WeeklyInsightRuleEngine.resurfacingMessage(for: normalized, emptyObservationFallback: starter),
+            starter
+        )
+    }
+
+    func test_continuityPrompt_firstActionWhitespace_usesSecondNonEmptyAction() {
+        let defaultPrompt = String(localized: "review.prompts.carryIntoNextWeek")
+        let insights = [
+            ReviewWeeklyInsight(
+                pattern: .sparseFallback,
+                observation: "Headline",
+                action: "  \n",
+                primaryTheme: nil,
+                mentionCount: nil,
+                dayCount: 1
+            ),
+            ReviewWeeklyInsight(
+                pattern: .sparseFallback,
+                observation: "Other",
+                action: "  Carry this forward  ",
+                primaryTheme: nil,
+                mentionCount: nil,
+                dayCount: 1
+            )
+        ]
+        let normalized = WeeklyInsightRuleEngine.normalizedWeeklyInsights(insights)
+        XCTAssertEqual(
+            WeeklyInsightRuleEngine.continuityPrompt(for: normalized, defaultPrompt: defaultPrompt),
+            "Carry this forward"
+        )
+    }
+
+    func test_continuityPrompt_allActionsWhitespace_usesDefaultContinuityPrompt() {
+        let defaultPrompt = String(localized: "review.prompts.carryIntoNextWeek")
+        let insights = [
+            ReviewWeeklyInsight(
+                pattern: .sparseFallback,
+                observation: "x",
+                action: "  ",
+                primaryTheme: nil,
+                mentionCount: nil,
+                dayCount: 1
+            )
+        ]
+        let normalized = WeeklyInsightRuleEngine.normalizedWeeklyInsights(insights)
+        XCTAssertEqual(
+            WeeklyInsightRuleEngine.continuityPrompt(for: normalized, defaultPrompt: defaultPrompt),
+            defaultPrompt
+        )
+    }
+
     func test_analyze_soilEntryWithSurfaceText_usesNonEmptySparseFallbackWhenWeekIsSparse() throws {
         try withInsertedEntries { context in
             let entries = [

--- a/GraceNotesTests/Features/Journal/WeeklyInsightRuleEngineTests.swift
+++ b/GraceNotesTests/Features/Journal/WeeklyInsightRuleEngineTests.swift
@@ -393,8 +393,8 @@ final class WeeklyInsightRuleEngineContinuityTests: XCTestCase {
         let fallback = ReviewWeeklyInsight(
             pattern: .recurringTheme,
             observation: "",
-            primaryTheme: "Theme",
             action: "  Fallback action ",
+            primaryTheme: "Theme",
             mentionCount: nil,
             dayCount: nil
         )

--- a/GraceNotesTests/Features/Journal/WeeklyReviewAggregatesMostRecurringTests.swift
+++ b/GraceNotesTests/Features/Journal/WeeklyReviewAggregatesMostRecurringTests.swift
@@ -500,6 +500,31 @@ extension WeeklyReviewAggregatesMostRecurringTests {
         XCTAssertFalse(recurring.contains(where: { $0.label == "Exercise" || $0.label == "Movement" }))
     }
 
+    func test_moderateSurfaceSemanticMatch_latinRestDoesNotMatchForestSubstring() {
+        XCTAssertFalse(
+            builder.moderateSurfaceSemanticMatch(themeConcept: "rest", supportText: "I walked in the forest")
+        )
+    }
+
+    func test_moderateSurfaceSemanticMatch_latinMatchesWholeWordAndPhrase() {
+        XCTAssertTrue(builder.moderateSurfaceSemanticMatch(themeConcept: "rest", supportText: "I need rest today"))
+        XCTAssertTrue(
+            builder.moderateSurfaceSemanticMatch(
+                themeConcept: "quiet morning",
+                supportText: "A quiet morning walk helped"
+            )
+        )
+    }
+
+    func test_moderateSurfaceSemanticMatch_hanContentionAfterNormalization() {
+        XCTAssertTrue(builder.moderateSurfaceSemanticMatch(themeConcept: "休息", supportText: "今天 休息 很重要"))
+        XCTAssertTrue(builder.moderateSurfaceSemanticMatch(themeConcept: "今天休息", supportText: "休息"))
+    }
+
+    func test_moderateSurfaceSemanticMatch_punctuationOnlySupportDoesNotMatch() {
+        XCTAssertFalse(builder.moderateSurfaceSemanticMatch(themeConcept: "rest", supportText: "   ..., "))
+    }
+
     /// Mirrors `PersistenceController.seedUITestDataIfNeeded` default seed + Monday reference (issue #140 UI test).
     func test_uitestSeed_onePriorDayEntry_hasNoTrendingMovementThemes() throws {
         let referenceDate = date(year: 2026, month: 3, day: 30)

--- a/GraceNotesTests/Features/Journal/WeeklyReviewAggregatesMostRecurringTests.swift
+++ b/GraceNotesTests/Features/Journal/WeeklyReviewAggregatesMostRecurringTests.swift
@@ -500,6 +500,47 @@ extension WeeklyReviewAggregatesMostRecurringTests {
         XCTAssertFalse(recurring.contains(where: { $0.label == "Exercise" || $0.label == "Movement" }))
     }
 
+    /// Latin-only themes must not pick up supporting evidence when the only Latin overlap is a substring inside
+    /// another word (e.g. "rest" ⊂ "forest") in mixed-script reading notes or reflections.
+    func test_buildThemeSections_mixedScriptSupportDoesNotMatchLatinSubstringInsideAnotherWord() throws {
+        let referenceDate = date(year: 2026, month: 3, day: 18)
+        let period = ReviewInsightsPeriod.currentPeriod(containing: referenceDate, calendar: calendar)
+        let previous = ReviewInsightsPeriod.previousPeriod(before: period, calendar: calendar)
+
+        let entries = [
+            makeEntry(on: date(year: 2026, month: 3, day: 16), needs: ["rest"]),
+            makeEntry(on: date(year: 2026, month: 3, day: 17), needs: ["rest"]),
+            makeEntry(
+                on: date(year: 2026, month: 3, day: 18),
+                readingNotes: "forest 森林",
+                reflections: "Walking through the forest 森林."
+            ),
+            makeEntry(
+                on: date(year: 2026, month: 3, day: 18),
+                readingNotes: "I need rest 休息."
+            )
+        ]
+
+        let recurring = builder.build(
+            currentPeriod: period,
+            currentWeekEntries: entries.filter { period.contains($0.entryDate) },
+            previousWeekEntries: entries.filter { previous.contains($0.entryDate) },
+            allEntries: entries,
+            calendar: calendar,
+            referenceDate: referenceDate
+        ).stats.mostRecurringThemes
+
+        let rest = try XCTUnwrap(recurring.first(where: { $0.label == "Rest" }))
+        XCTAssertFalse(
+            rest.evidence.contains { $0.content.contains("forest") },
+            "Mixed-script support text must not match a Latin theme via in-word substring overlap."
+        )
+        XCTAssertTrue(
+            rest.evidence.contains { $0.content.contains("I need rest 休息") },
+            "Whole-word Latin matches should still attach supporting evidence when Han is also present."
+        )
+    }
+
     /// Mirrors `PersistenceController.seedUITestDataIfNeeded` default seed + Monday reference (issue #140 UI test).
     func test_uitestSeed_onePriorDayEntry_hasNoTrendingMovementThemes() throws {
         let referenceDate = date(year: 2026, month: 3, day: 30)

--- a/GraceNotesTests/Features/Journal/WeeklyReviewAggregatesMostRecurringTests.swift
+++ b/GraceNotesTests/Features/Journal/WeeklyReviewAggregatesMostRecurringTests.swift
@@ -286,6 +286,61 @@ extension WeeklyReviewAggregatesMostRecurringTests {
         )
     }
 
+    /// When two themes first appear on the same structured surface in one pass and later tie on recurring
+    /// counts and day counts, ordering must follow per-theme debut order (`firstSeenOrder`), not arbitrary
+    /// `Dictionary` key order.
+    func test_buildThemeSections_mostRecurringTieBreakUsesSameSurfaceDebutOrder() throws {
+        let surfacePhrase = "walking and rest"
+        let normalizer = WeeklyInsightTextNormalizer()
+        let distilled = normalizer.distillConcepts(
+            from: surfacePhrase,
+            source: .gratitudes,
+            maximumCount: 3,
+            highConfidenceOnly: false,
+            journalThemeDisplayLocale: Locale(identifier: "en")
+        )
+        let restIndex = distilled.firstIndex { $0.canonicalConcept == "rest" }
+        let walkingIndex = distilled.firstIndex { $0.canonicalConcept == "walking" }
+        guard let restIndex, let walkingIndex else {
+            XCTFail(
+                "Test setup requires distillConcepts to surface both rest and walking from \"\(surfacePhrase)\"."
+            )
+            return
+        }
+        let walkingShouldRankAboveRest = walkingIndex < restIndex
+
+        let referenceDate = date(year: 2026, month: 3, day: 18)
+        let period = ReviewInsightsPeriod.currentPeriod(containing: referenceDate, calendar: calendar)
+        let previous = ReviewInsightsPeriod.previousPeriod(before: period, calendar: calendar)
+
+        let entries = [
+            makeEntry(on: date(year: 2026, month: 3, day: 16), gratitudes: [surfacePhrase]),
+            makeEntry(on: date(year: 2026, month: 3, day: 17), gratitudes: [surfacePhrase])
+        ]
+        let aggregates = builder.build(
+            currentPeriod: period,
+            currentWeekEntries: entries.filter { period.contains($0.entryDate) },
+            previousWeekEntries: entries.filter { previous.contains($0.entryDate) },
+            allEntries: entries,
+            calendar: calendar,
+            referenceDate: referenceDate
+        )
+
+        let recurring = aggregates.stats.mostRecurringThemes
+        let walking = try XCTUnwrap(recurring.first(where: { $0.label == "Walking" }))
+        let rest = try XCTUnwrap(recurring.first(where: { $0.label == "Rest" }))
+        XCTAssertEqual(walking.totalCount, rest.totalCount)
+        XCTAssertEqual(walking.dayCount, rest.dayCount)
+
+        let walkingRank = try XCTUnwrap(recurring.firstIndex(where: { $0.label == "Walking" }))
+        let restRank = try XCTUnwrap(recurring.firstIndex(where: { $0.label == "Rest" }))
+        if walkingShouldRankAboveRest {
+            XCTAssertLessThan(walkingRank, restRank)
+        } else {
+            XCTAssertLessThan(restRank, walkingRank)
+        }
+    }
+
     func test_buildThemeSections_hardBannedConceptsNeverSurface() {
         let referenceDate = date(year: 2026, month: 3, day: 18)
         let period = ReviewInsightsPeriod.currentPeriod(containing: referenceDate, calendar: calendar)

--- a/GraceNotesTests/Features/Journal/WeeklyReviewAggregatesMostRecurringTests.swift
+++ b/GraceNotesTests/Features/Journal/WeeklyReviewAggregatesMostRecurringTests.swift
@@ -169,6 +169,49 @@ extension WeeklyReviewAggregatesMostRecurringTests {
         XCTAssertEqual(literal.totalCount, 3)
     }
 
+    /// When the same canonical theme appears under gratitudes, needs, and people, `buildThemeSections` picks a
+    /// single winning `ReviewThemeSourceCategory` for `displayLabel` (people > needs > gratitudes). This
+    /// integration test locks that merge plus the curated label for `rest`.
+    func test_buildThemeSections_sameCanonicalAcrossPeopleNeedsGratitudesPicksRankedDisplaySource() throws {
+        let referenceDate = date(year: 2026, month: 3, day: 18)
+        let period = ReviewInsightsPeriod.currentPeriod(containing: referenceDate, calendar: calendar)
+        let previous = ReviewInsightsPeriod.previousPeriod(before: period, calendar: calendar)
+
+        // Day 16: gratitudes + needs both map to canonical `rest`; needs outranks gratitudes (no people yet).
+        // Day 17: people-only surface for `rest`, merged with prior days so people outranks needs for the label source.
+        let entries = [
+            makeEntry(
+                on: date(year: 2026, month: 3, day: 16),
+                gratitudes: ["recover"],
+                needs: ["downtime"],
+                people: []
+            ),
+            makeEntry(
+                on: date(year: 2026, month: 3, day: 17),
+                gratitudes: [],
+                needs: [],
+                people: ["Rest"]
+            )
+        ]
+        let aggregates = builder.build(
+            currentPeriod: period,
+            currentWeekEntries: entries.filter { period.contains($0.entryDate) },
+            previousWeekEntries: entries.filter { previous.contains($0.entryDate) },
+            allEntries: entries,
+            calendar: calendar,
+            referenceDate: referenceDate
+        )
+
+        let restTheme = try XCTUnwrap(
+            aggregates.stats.mostRecurringThemes.first(where: { $0.label == "Rest" })
+        )
+        XCTAssertGreaterThanOrEqual(restTheme.totalCount, 2)
+        let sources = Set(restTheme.evidence.map(\.source))
+        XCTAssertTrue(sources.contains(.gratitudes))
+        XCTAssertTrue(sources.contains(.needs))
+        XCTAssertTrue(sources.contains(.people))
+    }
+
     func test_buildThemeSections_trendingIncludesNewUpAndDownWithPriorVsCurrentCounts() throws {
         let referenceDate = date(year: 2026, month: 3, day: 18)
         let period = ReviewInsightsPeriod.currentPeriod(containing: referenceDate, calendar: calendar)

--- a/GraceNotesTests/Features/Journal/WeeklyReviewAggregatesSemanticMatchTests.swift
+++ b/GraceNotesTests/Features/Journal/WeeklyReviewAggregatesSemanticMatchTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import GraceNotes
+
+final class WeeklyReviewAggregatesSemanticMatchTests: XCTestCase {
+    private var builder: WeeklyReviewAggregatesBuilder!
+
+    override func setUp() {
+        super.setUp()
+        builder = WeeklyReviewAggregatesBuilder()
+    }
+
+    func test_moderateSurfaceSemanticMatch_hanAdjacencyMatchesWhenLatinTokenPathWouldMiss() {
+        // Han/kanji substring adjacency: token overlap often fails (short tokens / no spaces).
+        XCTAssertTrue(builder.moderateSurfaceSemanticMatch(themeConcept: "休息", supportText: "公园休息"))
+    }
+
+    func test_moderateSurfaceSemanticMatch_latinThemeDoesNotMatchInsideLatinWordWhenMixedWithHan() {
+        // Regression: a Han character must not force substring matching that revives "rest" ⊂ "forest".
+        XCTAssertFalse(builder.moderateSurfaceSemanticMatch(themeConcept: "rest", supportText: "forest 公园"))
+    }
+
+    func test_moderateSurfaceSemanticMatch_mixedLatinAndHanStillUsesWordBoundaryWhenBothSidesHaveLatin() {
+        XCTAssertTrue(builder.moderateSurfaceSemanticMatch(themeConcept: "rest", supportText: "deep rest 公园"))
+    }
+}

--- a/GraceNotesTests/Features/Journal/WeeklyReviewChipOrderTests.swift
+++ b/GraceNotesTests/Features/Journal/WeeklyReviewChipOrderTests.swift
@@ -1,0 +1,117 @@
+import XCTest
+@testable import GraceNotes
+
+/// Locks in recurring chip tie order (`firstSeenOrder` before label) vs ``sortedThemeSummaries``.
+final class WeeklyReviewChipOrderTests: XCTestCase {
+    private var calendar: Calendar!
+    private var builder: WeeklyReviewAggregatesBuilder!
+
+    override func setUp() {
+        super.setUp()
+        calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        calendar.firstWeekday = 1 // Sunday
+        builder = WeeklyReviewAggregatesBuilder()
+    }
+
+    /// When mention/day counts tie across many chip themes, recurring chips follow `firstSeenOrder` (scan order)
+    /// before localized label—same tie stack as ``sortedThemeSummaries`` for chip-only aggregates.
+    func test_recurringChips_breakTiesOnFirstSeenOrderBeforeLabel() throws {
+        let referenceDate = date(year: 2026, month: 3, day: 18)
+        let period = ReviewInsightsPeriod.currentPeriod(containing: referenceDate, calendar: calendar)
+        let previous = ReviewInsightsPeriod.previousPeriod(before: period, calendar: calendar)
+
+        let sameDay = date(year: 2026, month: 3, day: 17)
+        // Not alphabetical: if ties fell through to label only, "Apple" would beat "Zebra".
+        let entries = [
+            makeEntry(on: sameDay, gratitudes: ["Zebra", "Apple", "Mango", "Banana"])
+        ]
+        let aggregates = builder.build(
+            currentPeriod: period,
+            currentWeekEntries: entries.filter { period.contains($0.entryDate) },
+            previousWeekEntries: entries.filter { previous.contains($0.entryDate) },
+            allEntries: entries,
+            calendar: calendar,
+            referenceDate: referenceDate
+        )
+
+        let gratitudeSummaries = aggregates.candidateInputs.gratitudes
+        let expectedTopThree = Array(gratitudeSummaries.prefix(3)).map(\.displayLabel)
+
+        XCTAssertEqual(
+            aggregates.recurringGratitudes.map(\.label),
+            ["Zebra", "Apple", "Mango"],
+            "Top recurring chips should follow journal/chip scan order when mention and day counts are fully tied."
+        )
+        XCTAssertEqual(
+            aggregates.recurringGratitudes.map(\.label),
+            expectedTopThree,
+            """
+            Recurring gratitude chips should mirror the first three `ThemeSummary` rows from chip aggregation \
+            for the same tie scenario.
+            """
+        )
+    }
+
+    func test_recurringNeedsAndPeople_breakTiesOnFirstSeenOrderBeforeLabel() throws {
+        let referenceDate = date(year: 2026, month: 3, day: 18)
+        let period = ReviewInsightsPeriod.currentPeriod(containing: referenceDate, calendar: calendar)
+        let previous = ReviewInsightsPeriod.previousPeriod(before: period, calendar: calendar)
+
+        let sameDay = date(year: 2026, month: 3, day: 17)
+        let entries = [
+            makeEntry(
+                on: sameDay,
+                needs: ["Zebra", "Apple", "Mango", "Banana"],
+                people: ["Yvonne", "Alex", "Quinn", "Pat"]
+            )
+        ]
+        let aggregates = builder.build(
+            currentPeriod: period,
+            currentWeekEntries: entries.filter { period.contains($0.entryDate) },
+            previousWeekEntries: entries.filter { previous.contains($0.entryDate) },
+            allEntries: entries,
+            calendar: calendar,
+            referenceDate: referenceDate
+        )
+
+        XCTAssertEqual(aggregates.recurringNeeds.map(\.label), ["Zebra", "Apple", "Mango"])
+        XCTAssertEqual(aggregates.recurringPeople.map(\.label), ["Yvonne", "Alex", "Quinn"])
+
+        XCTAssertEqual(
+            aggregates.recurringNeeds.map(\.label),
+            Array(aggregates.candidateInputs.needs.prefix(3)).map(\.displayLabel)
+        )
+        XCTAssertEqual(
+            aggregates.recurringPeople.map(\.label),
+            Array(aggregates.candidateInputs.people.prefix(3)).map(\.displayLabel)
+        )
+    }
+}
+
+private extension WeeklyReviewChipOrderTests {
+    func makeEntry(
+        on date: Date,
+        gratitudes: [String] = [],
+        needs: [String] = [],
+        people: [String] = []
+    ) -> Journal {
+        Journal(
+            entryDate: date,
+            gratitudes: gratitudes.map { Entry(fullText: $0) },
+            needs: needs.map { Entry(fullText: $0) },
+            people: people.map { Entry(fullText: $0) },
+            readingNotes: "",
+            reflections: ""
+        )
+    }
+
+    func date(year: Int, month: Int, day: Int) -> Date {
+        var components = DateComponents()
+        components.year = year
+        components.month = month
+        components.day = day
+        components.timeZone = calendar.timeZone
+        return calendar.date(from: components)!
+    }
+}

--- a/GraceNotesTests/Features/Journal/WeeklyReviewHistoryRollupsTests.swift
+++ b/GraceNotesTests/Features/Journal/WeeklyReviewHistoryRollupsTests.swift
@@ -254,7 +254,70 @@ final class WeeklyReviewHistoryRollupsTests: XCTestCase {
 
         let rhythm = try XCTUnwrap(aggregates.stats.rhythmHistory)
         XCTAssertEqual(calendar.startOfDay(for: rhythm.first!.date), calendar.startOfDay(for: ancient))
-        XCTAssertGreaterThan(rhythm.count, 180, "Uncapped history should span ancient entry through week end.")
+        XCTAssertGreaterThan(
+            rhythm.count,
+            180,
+            "History should span ancient entry through week end when under the hard horizon cap."
+        )
+    }
+
+    func test_rhythmHistory_skipsDaysBeforeHardHorizonWhenJournalSpansManyYears() throws {
+        let referenceDate = date(year: 2026, month: 3, day: 18)
+        let period = ReviewInsightsPeriod.currentPeriod(containing: referenceDate, calendar: calendar)
+        let previous = ReviewInsightsPeriod.previousPeriod(before: period, calendar: calendar)
+        let veryOld = date(year: 1995, month: 1, day: 1)
+        let recent = date(year: 2026, month: 3, day: 17)
+        let oldEntry = makeEntry(on: veryOld, gratitudes: ["dust"])
+        let recentEntry = makeEntry(on: recent, gratitudes: ["new"])
+        let allEntries = [oldEntry, recentEntry]
+
+        let aggregates = builder.build(
+            currentPeriod: period,
+            currentWeekEntries: allEntries.filter { period.contains($0.entryDate) },
+            previousWeekEntries: allEntries.filter { previous.contains($0.entryDate) },
+            allEntries: allEntries,
+            calendar: calendar,
+            referenceDate: referenceDate
+        )
+        let rhythm = try XCTUnwrap(aggregates.stats.rhythmHistory)
+        XCTAssertLessThanOrEqual(rhythm.count, 731)
+        let firstStart = calendar.startOfDay(for: rhythm.first!.date)
+        XCTAssertGreaterThan(firstStart, calendar.startOfDay(for: veryOld))
+    }
+
+    func test_build_weekActivity_matchesAlignedPeriod_whenCurrentPeriodLowerBoundIsNotMidnight() throws {
+        let referenceDate = date(year: 2026, month: 3, day: 18)
+        let alignedPeriod = ReviewInsightsPeriod.currentPeriod(containing: referenceDate, calendar: calendar)
+        let noonLower = try XCTUnwrap(calendar.date(byAdding: .hour, value: 12, to: alignedPeriod.lowerBound))
+        XCTAssertLessThan(noonLower, alignedPeriod.upperBound)
+        let skewedPeriod = noonLower..<alignedPeriod.upperBound
+        let previous = ReviewInsightsPeriod.previousPeriod(before: alignedPeriod, calendar: calendar)
+
+        let entryDay = date(year: 2026, month: 3, day: 17)
+        let weekEntry = makeEntry(on: entryDay, gratitudes: ["solo"])
+        let allEntries = [weekEntry]
+
+        let skewed = builder.build(
+            currentPeriod: skewedPeriod,
+            currentWeekEntries: allEntries,
+            previousWeekEntries: allEntries.filter { previous.contains($0.entryDate) },
+            allEntries: allEntries,
+            calendar: calendar,
+            referenceDate: referenceDate
+        )
+        let aligned = builder.build(
+            currentPeriod: alignedPeriod,
+            currentWeekEntries: allEntries,
+            previousWeekEntries: allEntries.filter { previous.contains($0.entryDate) },
+            allEntries: allEntries,
+            calendar: calendar,
+            referenceDate: referenceDate
+        )
+
+        XCTAssertEqual(skewed.stats.activity, aligned.stats.activity)
+        for row in skewed.stats.activity {
+            XCTAssertEqual(row.date, calendar.startOfDay(for: row.date))
+        }
     }
 
     func test_reviewHistoryWindowing_entriesContributingToSection_sortsNewestFirst() {

--- a/GraceNotesTests/Features/Settings/ICloudSyncActivityModelTests.swift
+++ b/GraceNotesTests/Features/Settings/ICloudSyncActivityModelTests.swift
@@ -43,4 +43,47 @@ final class ICloudSyncActivityModelTests: XCTestCase {
 
         await waitForLastRemoteChange(on: model)
     }
+
+    func test_multiplePersistentStoreRemoteChangeNotifications_persistLatestTimestamp() async {
+        let model = ICloudSyncActivityModel()
+        model.startMonitoring()
+
+        for _ in 0..<8 {
+            NotificationCenter.default.post(name: .NSPersistentStoreRemoteChange, object: nil)
+        }
+
+        await waitForLastRemoteChange(on: model)
+
+        let expected = model.lastRemoteChangeAt!.timeIntervalSince1970
+        await waitUntilPersistedTimestampEquals(expected)
+
+        XCTAssertEqual(
+            UserDefaults.standard.double(forKey: ICloudSyncActivityModel.persistedTimestampKey),
+            expected,
+            accuracy: 1e-9
+        )
+    }
+
+    private func waitUntilPersistedTimestampEquals(
+        _ expected: TimeInterval,
+        timeout: TimeInterval = 1,
+        pollIntervalNanoseconds: UInt64 = 1_000_000,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            let stored = UserDefaults.standard.double(forKey: ICloudSyncActivityModel.persistedTimestampKey)
+            if abs(stored - expected) < 1e-9 {
+                return
+            }
+            try? await Task.sleep(nanoseconds: pollIntervalNanoseconds)
+        }
+
+        XCTFail(
+            "Timed out waiting for UserDefaults to match coalesced lastRemoteChangeAt",
+            file: file,
+            line: line
+        )
+    }
 }

--- a/GraceNotesTests/Features/Settings/ImportExportDetailFormattingTests.swift
+++ b/GraceNotesTests/Features/Settings/ImportExportDetailFormattingTests.swift
@@ -67,4 +67,73 @@ final class ImportExportDetailFormattingTests: XCTestCase {
         )
         XCTAssertTrue(plain.contains("grace-notes-export-test.json"))
     }
+
+    func test_exportHistoryLineParts_multilineDetailBecomesSingleLineWithSpaces() {
+        let entry = BackupExportHistoryEntry(
+            id: UUID(),
+            finishedAt: Date(),
+            success: true,
+            kind: .manualShare,
+            detail: "first line\nsecond line"
+        )
+        let parts = ImportExportTechnicalDetailFormatting.exportHistoryLineParts(for: entry)
+        XCTAssertEqual(parts.detail, "first line second line")
+        let plain = ImportExportTechnicalDetailFormatting.exportHistoryPlainLabel(for: entry)
+        XCTAssertTrue(plain.contains("first line second line"))
+        XCTAssertFalse(plain.contains("\n"))
+    }
+
+    func test_exportHistoryLineParts_whitespaceOnlyDetailIsNil() {
+        let entry = BackupExportHistoryEntry(
+            id: UUID(),
+            finishedAt: Date(),
+            success: false,
+            kind: .manualFolder,
+            detail: "   \n  \t  "
+        )
+        let parts = ImportExportTechnicalDetailFormatting.exportHistoryLineParts(for: entry)
+        XCTAssertNil(parts.detail)
+        let plain = ImportExportTechnicalDetailFormatting.exportHistoryPlainLabel(for: entry)
+        XCTAssertEqual(plain, "\(parts.kindLabel) · \(parts.statusLabel)")
+        XCTAssertEqual(plain.components(separatedBy: " · ").count, 2)
+    }
+
+    func test_exportHistoryLineParts_trimsSegmentsAroundNewlinesNoDoubleSpaces() {
+        let entry = BackupExportHistoryEntry(
+            id: UUID(),
+            finishedAt: Date(),
+            success: true,
+            kind: .scheduledFolder,
+            detail: "foo \n bar"
+        )
+        let parts = ImportExportTechnicalDetailFormatting.exportHistoryLineParts(for: entry)
+        XCTAssertEqual(parts.detail, "foo bar")
+        let plain = ImportExportTechnicalDetailFormatting.exportHistoryPlainLabel(for: entry)
+        XCTAssertTrue(plain.contains("foo bar"))
+        XCTAssertFalse(plain.contains("foo  bar"))
+    }
+
+    func test_exportHistoryLineParts_blankLinesBetweenContentCollapseToSingleSpaces() {
+        let entry = BackupExportHistoryEntry(
+            id: UUID(),
+            finishedAt: Date(),
+            success: true,
+            kind: .manualShare,
+            detail: "foo\n \nbar"
+        )
+        let parts = ImportExportTechnicalDetailFormatting.exportHistoryLineParts(for: entry)
+        XCTAssertEqual(parts.detail, "foo bar")
+    }
+
+    func test_exportHistoryLineParts_leadingAndTrailingNewlinesTrimmed() {
+        let entry = BackupExportHistoryEntry(
+            id: UUID(),
+            finishedAt: Date(),
+            success: true,
+            kind: .manualShare,
+            detail: "\n\ninner\n"
+        )
+        let parts = ImportExportTechnicalDetailFormatting.exportHistoryLineParts(for: entry)
+        XCTAssertEqual(parts.detail, "inner")
+    }
 }

--- a/GraceNotesTests/Features/Settings/JournalDataExportServiceTests.swift
+++ b/GraceNotesTests/Features/Settings/JournalDataExportServiceTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import GraceNotes
+
+final class JournalDataExportServiceTests: XCTestCase {
+    func test_makeArchive_sortsTiedEntryDateAndCreatedAt_byUUIDComparableOrder() {
+        let anchor = Date(timeIntervalSince1970: 1_742_147_200)
+        let idA = UUID(uuidString: "00000000-0000-0000-0000-000000000002")!
+        let idB = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
+        let journalA = Journal(id: idA, entryDate: anchor, createdAt: anchor, updatedAt: anchor)
+        let journalB = Journal(id: idB, entryDate: anchor, createdAt: anchor, updatedAt: anchor)
+
+        let service = JournalDataExportService()
+        let archive = service.makeArchive(from: [journalA, journalB], exportedAt: anchor)
+
+        let expectedIds = [idA, idB].sorted(by: <)
+        XCTAssertEqual(archive.entries.map(\.id), expectedIds)
+    }
+
+    func test_exportFilenameTimestamp_matchesUTCGregorianPattern() {
+        let service = JournalDataExportService()
+        XCTAssertEqual(service.exportFilenameTimestamp(for: Date(timeIntervalSince1970: 0)), "19700101-000000")
+        XCTAssertEqual(service.exportFilenameTimestamp(for: Date(timeIntervalSince1970: 432_000)), "19700106-000000")
+        // 1970-01-02 03:04:05 UTC
+        XCTAssertEqual(service.exportFilenameTimestamp(for: Date(timeIntervalSince1970: 97_445)), "19700102-030405")
+    }
+}

--- a/GraceNotesTests/Features/Settings/ReminderSettingsFlowModelTests.swift
+++ b/GraceNotesTests/Features/Settings/ReminderSettingsFlowModelTests.swift
@@ -33,6 +33,21 @@ final class ReminderSettingsFlowModelTests: XCTestCase {
         XCTAssertEqual(storedTime, selectedTime.timeIntervalSinceReferenceDate)
     }
 
+    func test_init_nonFiniteStoredTime_coercesToDefaultAndRepairsStorage() {
+        let scheduler = MockReminderScheduling()
+        let userDefaults = makeUserDefaults()
+        userDefaults.set(Double.nan, forKey: ReminderSettings.timeIntervalKey)
+
+        let model = ReminderSettingsFlowModel(reminderScheduler: scheduler, userDefaults: userDefaults)
+
+        let expectedInterval = ReminderSettings.defaultTimeInterval
+        XCTAssertEqual(model.selectedTime.timeIntervalSinceReferenceDate, expectedInterval, accuracy: 0.001)
+        XCTAssertEqual(
+            userDefaults.object(forKey: ReminderSettings.timeIntervalKey) as? TimeInterval,
+            expectedInterval
+        )
+    }
+
     func test_refreshStatus_reflectsSystemChangeFromDeniedToEnabled() async {
         let scheduler = MockReminderScheduling()
         scheduler.currentStatus = .denied

--- a/GraceNotesTests/Features/Settings/ReminderSettingsFlowModelTests.swift
+++ b/GraceNotesTests/Features/Settings/ReminderSettingsFlowModelTests.swift
@@ -164,6 +164,123 @@ final class ReminderSettingsFlowModelTests: XCTestCase {
         XCTAssertEqual(scheduler.rescheduleCallCount, 2)
     }
 
+    /// Disable while reschedule awaits the system defers until the busy window ends, then turns reminders off.
+    func test_disableDuringInFlightReschedule_defersDisableUntilRescheduleCompletes() async {
+        let scheduler = MockReminderScheduling()
+        scheduler.currentStatus = .enabled
+        scheduler.rescheduleResult = .scheduled
+        scheduler.disableResult = .disabled
+        let gate = RescheduleTestGate()
+        scheduler.rescheduleAwaitHook = { await gate.waitUntilOpened() }
+
+        let model = ReminderSettingsFlowModel(reminderScheduler: scheduler, userDefaults: makeUserDefaults())
+        model.reminderNotificationBody = { _ in "body" }
+        await model.refreshStatus()
+
+        async let saveTask: Void = model.saveEnabledReminderTime()
+
+        let deadline = Date().addingTimeInterval(2)
+        while scheduler.rescheduleCallCount < 1 {
+            if Date() > deadline {
+                XCTFail("Timed out waiting for the first reschedule call")
+                await gate.open()
+                await saveTask
+                return
+            }
+            await Task.yield()
+        }
+
+        XCTAssertEqual(scheduler.disableCallCount, 0)
+        await model.disableReminders()
+        XCTAssertEqual(scheduler.disableCallCount, 0)
+
+        await gate.open()
+        await saveTask
+
+        XCTAssertEqual(scheduler.disableCallCount, 1)
+        XCTAssertEqual(model.liveStatus, .off)
+        XCTAssertFalse(model.isWorking)
+    }
+
+    /// Toggle off during reschedule, then on before work finishes: no stale deferred disable after re-enable.
+    func test_disableThenEnableDuringInFlightReschedule_doesNotApplyDeferredDisableAfterReEnable() async {
+        let scheduler = MockReminderScheduling()
+        scheduler.currentStatus = .enabled
+        scheduler.rescheduleResult = .scheduled
+        scheduler.disableResult = .disabled
+        scheduler.enableResult = .scheduled
+        let gate = RescheduleTestGate()
+        scheduler.rescheduleAwaitHook = { await gate.waitUntilOpened() }
+
+        let model = ReminderSettingsFlowModel(reminderScheduler: scheduler, userDefaults: makeUserDefaults())
+        model.reminderNotificationBody = { _ in "body" }
+        await model.refreshStatus()
+
+        async let saveTask: Void = model.saveEnabledReminderTime()
+
+        let deadline = Date().addingTimeInterval(2)
+        while scheduler.rescheduleCallCount < 1 {
+            if Date() > deadline {
+                XCTFail("Timed out waiting for the first reschedule call")
+                await gate.open()
+                await saveTask
+                return
+            }
+            await Task.yield()
+        }
+
+        await model.disableReminders()
+        await model.enableReminders()
+
+        XCTAssertEqual(scheduler.disableCallCount, 0)
+
+        await gate.open()
+        await saveTask
+
+        XCTAssertEqual(scheduler.disableCallCount, 0)
+        XCTAssertEqual(scheduler.enableCallCount, 0)
+        XCTAssertEqual(model.liveStatus, .enabled)
+        XCTAssertFalse(model.isWorking)
+    }
+
+    /// A second disable while the first awaits must not leave coalesced pending disable stuck for a later drain.
+    func test_redundantDisableDuringInFlightDisable_clearsCoalescedPending() async {
+        let scheduler = MockReminderScheduling()
+        scheduler.currentStatus = .enabled
+        scheduler.disableResult = .disabled
+        scheduler.enableResult = .scheduled
+        let gate = RescheduleTestGate()
+        scheduler.disableAwaitHook = { await gate.waitUntilOpened() }
+
+        let model = ReminderSettingsFlowModel(reminderScheduler: scheduler, userDefaults: makeUserDefaults())
+        model.reminderNotificationBody = { _ in "body" }
+        await model.refreshStatus()
+
+        async let firstDisable: Void = model.disableReminders()
+
+        let deadline = Date().addingTimeInterval(2)
+        while scheduler.disableCallCount < 1 {
+            if Date() > deadline {
+                XCTFail("Timed out waiting for the first disable call")
+                await gate.open()
+                await firstDisable
+                return
+            }
+            await Task.yield()
+        }
+
+        await model.disableReminders()
+        await gate.open()
+        await firstDisable
+
+        XCTAssertEqual(scheduler.disableCallCount, 1)
+
+        await model.enableReminders()
+
+        XCTAssertEqual(scheduler.disableCallCount, 1)
+        XCTAssertEqual(scheduler.enableCallCount, 1)
+    }
+
     private func makeUserDefaults() -> UserDefaults {
         let suiteName = "ReminderSettingsFlowModelTests-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
@@ -180,9 +297,12 @@ private final class MockReminderScheduling: ReminderScheduling {
     var rescheduleResult: ReminderSyncResult = .scheduled
     /// Optional hook after `rescheduleCallCount` increments, before the result is returned.
     var rescheduleAwaitHook: (() async -> Void)?
+    /// Optional hook after `disableCallCount` increments, before the result is returned.
+    var disableAwaitHook: (() async -> Void)?
 
     private(set) var enableCallCount = 0
     private(set) var rescheduleCallCount = 0
+    private(set) var disableCallCount = 0
 
     func currentReminderStatus() async -> ReminderLiveStatus {
         currentStatus
@@ -195,7 +315,12 @@ private final class MockReminderScheduling: ReminderScheduling {
     }
 
     func disableDailyReminder() async -> ReminderSyncResult {
-        disableResult
+        disableCallCount += 1
+        if let disableAwaitHook {
+            await disableAwaitHook()
+        }
+        currentStatus = .off
+        return disableResult
     }
 
     func rescheduleEnabledReminder(at time: Date, body: String) async -> ReminderSyncResult {

--- a/GraceNotesTests/Features/Settings/ScheduledBackupIntervalTests.swift
+++ b/GraceNotesTests/Features/Settings/ScheduledBackupIntervalTests.swift
@@ -64,10 +64,10 @@ final class ScheduledBackupIntervalTests: XCTestCase {
         XCTAssertFalse(ScheduledBackupInterval.monthly.isDue(lastRun: start, now: plus29, calendar: calendar))
     }
 
-    func test_monthly_thirtyFirstDayFromStart_isDue() {
+    func test_monthly_firstDayOfNextCalendarMonth_isDue() {
         let start = makeDate(year: 2026, month: 1, day: 1)
-        let plus30 = makeDate(year: 2026, month: 1, day: 31)
-        XCTAssertTrue(ScheduledBackupInterval.monthly.isDue(lastRun: start, now: plus30, calendar: calendar))
+        let firstOfFebruary = makeDate(year: 2026, month: 2, day: 1)
+        XCTAssertTrue(ScheduledBackupInterval.monthly.isDue(lastRun: start, now: firstOfFebruary, calendar: calendar))
     }
 
     private func makeDate(year: Int, month: Int, day: Int, hour: Int = 12) -> Date {

--- a/GraceNotesTests/JournalAppearancePersistenceTests.swift
+++ b/GraceNotesTests/JournalAppearancePersistenceTests.swift
@@ -25,6 +25,20 @@ final class JournalAppearancePersistenceTests: XCTestCase {
         XCTAssertEqual(JournalAppearanceMode.resolveStored(rawValue: "summer"), .bloom)
     }
 
+    func test_resolveStored_normalizesWhitespaceAndCaseForBloom() {
+        XCTAssertEqual(JournalAppearanceMode.resolveStored(rawValue: " Bloom "), .bloom)
+        XCTAssertEqual(JournalAppearanceMode.resolveStored(rawValue: "BLOOM"), .bloom)
+    }
+
+    func test_resolveStored_normalizesWhitespaceAndCaseForLegacySummer() {
+        XCTAssertEqual(JournalAppearanceMode.resolveStored(rawValue: "  summer  "), .bloom)
+    }
+
+    func test_resolveStored_normalizesWhitespaceAndCaseForStandard() {
+        XCTAssertEqual(JournalAppearanceMode.resolveStored(rawValue: " Standard "), .standard)
+        XCTAssertEqual(JournalAppearanceMode.resolveStored(rawValue: "Standard"), .standard)
+    }
+
     func test_migrateLegacyJournalAppearance_rewritesSummerRawToBloom() {
         let key = JournalAppearanceStorageKeys.todayMode
         UserDefaults.standard.set("summer", forKey: key)
@@ -34,5 +48,35 @@ final class JournalAppearancePersistenceTests: XCTestCase {
             JournalAppearanceMode.resolveStored(rawValue: UserDefaults.standard.string(forKey: key) ?? ""),
             .bloom
         )
+    }
+
+    func test_migrateLegacyJournalAppearance_migratesWhitespacePaddedSummerInTestSuite() {
+        let suiteName = "test.JournalAppearance.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Could not create test suite")
+            return
+        }
+        defer { UserDefaults().removePersistentDomain(forName: suiteName) }
+
+        let key = JournalAppearanceStorageKeys.todayMode
+        defaults.set(" Summer ", forKey: key)
+        JournalAppearanceMode.migrateLegacyJournalAppearanceRawValueIfNeeded(defaults: defaults)
+        XCTAssertEqual(defaults.string(forKey: key), JournalAppearanceMode.bloom.rawValue)
+        XCTAssertEqual(JournalAppearanceMode.resolveStored(rawValue: defaults.string(forKey: key) ?? ""), .bloom)
+    }
+
+    func test_migrateLegacyJournalAppearance_migratesUppercasedSummerInTestSuite() {
+        let suiteName = "test.JournalAppearance.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Could not create test suite")
+            return
+        }
+        defer { UserDefaults().removePersistentDomain(forName: suiteName) }
+
+        let key = JournalAppearanceStorageKeys.todayMode
+        defaults.set("SUMMER", forKey: key)
+        JournalAppearanceMode.migrateLegacyJournalAppearanceRawValueIfNeeded(defaults: defaults)
+        XCTAssertEqual(defaults.string(forKey: key), JournalAppearanceMode.bloom.rawValue)
+        XCTAssertEqual(JournalAppearanceMode.resolveStored(rawValue: defaults.string(forKey: key) ?? ""), .bloom)
     }
 }

--- a/GraceNotesTests/Services/ICloudAccountStatusCancellationTests.swift
+++ b/GraceNotesTests/Services/ICloudAccountStatusCancellationTests.swift
@@ -1,0 +1,68 @@
+import CloudKit
+import XCTest
+@testable import GraceNotes
+
+final class ICloudAccountStatusCancellationTests: XCTestCase {
+    func test_isCancellationLike_recognizesSwiftCancellation() {
+        XCTAssertTrue(isCancellationLike(CancellationError()))
+    }
+
+    func test_isCancellationLike_recognizesCKOperationCancelled() {
+        let error = CKError(.operationCancelled)
+        XCTAssertTrue(isCancellationLike(error))
+    }
+
+    func test_isCancellationLike_recognizesNSURLCancelled() {
+        let error = URLError(.cancelled) as NSError
+        XCTAssertTrue(isCancellationLike(error))
+    }
+
+    func test_isCancellationLike_recognizesCloudKitNSErrorByDomainAndCode() {
+        let nsError = NSError(
+            domain: CKError.errorDomain,
+            code: CKError.Code.operationCancelled.rawValue,
+            userInfo: nil
+        )
+        XCTAssertTrue(isCancellationLike(nsError))
+    }
+
+    func test_isCancellationLike_walksNSUnderlyingErrorKey() {
+        let inner = CKError(.operationCancelled)
+        let wrapped = NSError(
+            domain: "TestDomain",
+            code: 1,
+            userInfo: [NSUnderlyingErrorKey: inner]
+        )
+        XCTAssertTrue(isCancellationLike(wrapped))
+    }
+
+    func test_isCancellationLike_walksNSUnderlyingErrorsKey() {
+        let inner = URLError(.cancelled) as NSError
+        let wrapped = NSError(
+            domain: "TestDomain",
+            code: 1,
+            userInfo: ["NSUnderlyingErrorsKey": [inner]]
+        )
+        XCTAssertTrue(isCancellationLike(wrapped))
+    }
+
+    func test_isCancellationLike_walksNestedUnderlyingChain() {
+        let innermost = CKError(.operationCancelled)
+        let middle = NSError(
+            domain: "Middle",
+            code: 2,
+            userInfo: [NSUnderlyingErrorKey: innermost]
+        )
+        let outer = NSError(
+            domain: "Outer",
+            code: 3,
+            userInfo: [NSUnderlyingErrorKey: middle]
+        )
+        XCTAssertTrue(isCancellationLike(outer))
+    }
+
+    func test_isCancellationLike_returnsFalseForUnrelatedErrors() {
+        let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet, userInfo: nil)
+        XCTAssertFalse(isCancellationLike(error))
+    }
+}

--- a/GraceNotesTests/Services/Reminders/DailyReminderNotificationSyncTests.swift
+++ b/GraceNotesTests/Services/Reminders/DailyReminderNotificationSyncTests.swift
@@ -67,7 +67,7 @@ private final class DailyReminderSyncSchedulerMock: ReminderScheduling {
     func enableDailyReminder(at time: Date, body: String) async -> ReminderSyncResult {
         _ = time
         _ = body
-        .scheduled
+        return .scheduled
     }
 
     func disableDailyReminder() async -> ReminderSyncResult {

--- a/GraceNotesTests/Services/Reminders/DailyReminderNotificationSyncTests.swift
+++ b/GraceNotesTests/Services/Reminders/DailyReminderNotificationSyncTests.swift
@@ -1,0 +1,83 @@
+import SwiftData
+import XCTest
+@testable import GraceNotes
+
+@MainActor
+final class DailyReminderNotificationSyncTests: XCTestCase {
+    func test_rescheduleEnabledReminderIfNeeded_nonFiniteStoredTime_schedulesDefaultReminderTime() async throws {
+        let scheduler = DailyReminderSyncSchedulerMock()
+        scheduler.currentStatus = .enabled
+
+        let suiteName = "DailyReminderNotificationSyncTests-\(UUID().uuidString)"
+        let userDefaults = UserDefaults(suiteName: suiteName)!
+        userDefaults.removePersistentDomain(forName: suiteName)
+        userDefaults.set(Double.nan, forKey: ReminderSettings.timeIntervalKey)
+
+        let context = try SwiftDataTestIsolation.makeModelContext()
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+        await DailyReminderNotificationSync.rescheduleEnabledReminderIfNeeded(
+            modelContext: context,
+            reminderScheduler: scheduler,
+            userDefaults: userDefaults,
+            now: now
+        )
+
+        let expectedInterval = ReminderSettings.defaultTimeInterval
+        XCTAssertEqual(
+            userDefaults.object(forKey: ReminderSettings.timeIntervalKey) as? TimeInterval,
+            expectedInterval
+        )
+        XCTAssertEqual(scheduler.rescheduleCallCount, 1)
+        let captured = try XCTUnwrap(scheduler.lastRescheduleTime)
+        XCTAssertEqual(captured.timeIntervalSinceReferenceDate, expectedInterval, accuracy: 0.001)
+    }
+
+    func test_rescheduleEnabledReminderIfNeeded_remindersOff_doesNotReschedule() async throws {
+        let scheduler = DailyReminderSyncSchedulerMock()
+        scheduler.currentStatus = .off
+
+        let suiteName = "DailyReminderNotificationSyncTests-\(UUID().uuidString)"
+        let userDefaults = UserDefaults(suiteName: suiteName)!
+        userDefaults.removePersistentDomain(forName: suiteName)
+        userDefaults.set(Double.nan, forKey: ReminderSettings.timeIntervalKey)
+
+        let context = try SwiftDataTestIsolation.makeModelContext()
+
+        await DailyReminderNotificationSync.rescheduleEnabledReminderIfNeeded(
+            modelContext: context,
+            reminderScheduler: scheduler,
+            userDefaults: userDefaults
+        )
+
+        XCTAssertEqual(scheduler.rescheduleCallCount, 0)
+    }
+}
+
+@MainActor
+private final class DailyReminderSyncSchedulerMock: ReminderScheduling {
+    var currentStatus: ReminderLiveStatus = .off
+    private(set) var rescheduleCallCount = 0
+    private(set) var lastRescheduleTime: Date?
+
+    func currentReminderStatus() async -> ReminderLiveStatus {
+        currentStatus
+    }
+
+    func enableDailyReminder(at time: Date, body: String) async -> ReminderSyncResult {
+        _ = time
+        _ = body
+        .scheduled
+    }
+
+    func disableDailyReminder() async -> ReminderSyncResult {
+        .disabled
+    }
+
+    func rescheduleEnabledReminder(at time: Date, body: String) async -> ReminderSyncResult {
+        rescheduleCallCount += 1
+        lastRescheduleTime = time
+        _ = body
+        return .scheduled
+    }
+}

--- a/GraceNotesTests/Services/Reminders/ReminderSchedulerTests.swift
+++ b/GraceNotesTests/Services/Reminders/ReminderSchedulerTests.swift
@@ -112,6 +112,7 @@ final class ReminderSchedulerTests: XCTestCase {
         XCTAssertEqual(result, .permissionDenied)
         XCTAssertFalse(center.didRequestAuthorization)
         XCTAssertNil(center.lastAddedRequest)
+        XCTAssertNil(center.removedIdentifiers)
     }
 
     func test_disableDailyReminder_removesPendingRequest() async {

--- a/GraceNotesTests/Services/Reminders/ReminderSettingsTests.swift
+++ b/GraceNotesTests/Services/Reminders/ReminderSettingsTests.swift
@@ -27,4 +27,33 @@ final class ReminderSettingsTests: XCTestCase {
         XCTAssertEqual(extracted.hour, 19)
         XCTAssertEqual(extracted.minute, 45)
     }
+
+    func test_sanitizedTimeInterval_nonFinite_fallsBackToDefault() {
+        XCTAssertEqual(
+            ReminderSettings.sanitizedTimeInterval(stored: .nan),
+            ReminderSettings.defaultTimeInterval
+        )
+        XCTAssertEqual(
+            ReminderSettings.sanitizedTimeInterval(stored: .infinity),
+            ReminderSettings.defaultTimeInterval
+        )
+        XCTAssertEqual(
+            ReminderSettings.sanitizedTimeInterval(stored: -.infinity),
+            ReminderSettings.defaultTimeInterval
+        )
+    }
+
+    func test_coercedTimeIntervalFromUserDefaults_repairsNonFiniteStorage() {
+        let suiteName = "ReminderSettingsTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+
+        defaults.set(Double.nan, forKey: ReminderSettings.timeIntervalKey)
+        let coerced = ReminderSettings.coercedTimeInterval(fromUserDefaults: defaults)
+        XCTAssertEqual(coerced, ReminderSettings.defaultTimeInterval)
+        XCTAssertEqual(
+            defaults.object(forKey: ReminderSettings.timeIntervalKey) as? TimeInterval,
+            ReminderSettings.defaultTimeInterval
+        )
+    }
 }

--- a/Scripts/integrate_sentry_review_fixes.py
+++ b/Scripts/integrate_sentry_review_fixes.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""
+Integrate origin/sentry-review-fix-<PR> branches onto the current branch.
+
+Assumes you are on an integration branch based on origin/main. For each remote
+branch (ascending PR #), tries to cherry-pick the "address PR review" commit;
+on failure, attempts a merge. Logs actions to stdout.
+
+Usage (from repo root):
+  git checkout -b integrate/sentry-review-fixes origin/main
+  python3 Scripts/integrate_sentry_review_fixes.py
+  python3 Scripts/integrate_sentry_review_fixes.py --min-pr 290   # resume after a conflict stop
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+
+REMOTE = "origin"
+OWNER_REPO = "grace-notes"  # unused; kept for clarity
+
+
+def run(cmd: list[str], check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, capture_output=True, text=True, check=check)
+
+
+def sh_out(cmd: list[str]) -> str:
+    p = run(cmd, check=False)
+    if p.returncode != 0:
+        return ""
+    return (p.stdout or "").strip()
+
+
+def list_fix_branches() -> list[tuple[int, str]]:
+    p = run(
+        ["git", "ls-remote", REMOTE, "refs/heads/sentry-review-fix-*"],
+        check=False,
+    )
+    if p.returncode != 0:
+        print(p.stderr, file=sys.stderr)
+        sys.exit(1)
+    out: list[tuple[int, str]] = []
+    for line in p.stdout.splitlines():
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+        ref = parts[1]
+        m = re.search(r"sentry-review-fix-(\d+)$", ref)
+        if m:
+            out.append((int(m.group(1)), ref.split("/")[-1]))
+    out.sort(key=lambda x: x[0])
+    return out
+
+
+def commits_ahead(main_ref: str, branch_name: str) -> list[tuple[str, str]]:
+    """Commits reachable from branch tip but not main, oldest first."""
+    p = run(
+        [
+            "git",
+            "log",
+            "--reverse",
+            "--format=%H %s",
+            f"{main_ref}..{branch_name}",
+        ],
+        check=False,
+    )
+    if p.returncode != 0:
+        return []
+    rows: list[tuple[str, str]] = []
+    for line in (p.stdout or "").strip().splitlines():
+        if not line:
+            continue
+        sha, _, subj = line.partition(" ")
+        rows.append((sha, subj))
+    return rows
+
+
+def pick_address_commit_sha(rows: list[tuple[str, str]]) -> str | None:
+    for sha, subj in rows:
+        s = subj.lower()
+        if "address" in s and "review" in s:
+            return sha
+    if not rows:
+        return None
+    # Newest commit (last in --reverse list)
+    return rows[-1][0]
+
+
+def fetch_branch(branch_name: str) -> bool:
+    p = run(
+        ["git", "fetch", REMOTE, f"{branch_name}:refs/heads/{branch_name}"],
+        check=False,
+    )
+    return p.returncode == 0
+
+
+def cherry_pick(sha: str) -> int:
+    p = run(["git", "cherry-pick", sha], check=False)
+    if p.returncode == 0:
+        return 0
+    err = (p.stderr or "") + (p.stdout or "")
+    if "nothing to commit" in err or "empty" in err.lower():
+        run(["git", "cherry-pick", "--abort"], check=False)
+        return 2
+    return 1
+
+
+def merge_branch(branch_name: str) -> bool:
+    # Prefer the fix branch for overlapping hunks (main already has the Sentry refine; we want the review patch).
+    p = run(
+        [
+            "git",
+            "merge",
+            "--no-ff",
+            "-X",
+            "theirs",
+            "-m",
+            f"Merge {branch_name}",
+            branch_name,
+        ],
+        check=False,
+    )
+    return p.returncode == 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Integrate sentry-review-fix-* branches.")
+    parser.add_argument(
+        "--min-pr",
+        type=int,
+        default=0,
+        metavar="N",
+        help="Only process branches sentry-review-fix-M where M >= N (for resume).",
+    )
+    args = parser.parse_args()
+    min_pr = args.min_pr
+
+    main_ref = f"{REMOTE}/main"
+    branches = [(n, b) for n, b in list_fix_branches() if n >= min_pr]
+    stats = {
+        "total_remote": len(branches),
+        "skipped_no_ahead": 0,
+        "cherry_pick_ok": 0,
+        "cherry_pick_empty": 0,
+        "cherry_pick_conflict": 0,
+        "merge_ok": 0,
+        "merge_fail": 0,
+        "fetch_fail": 0,
+    }
+
+    print(f"Found {len(branches)} remote sentry-review-fix-* branches.", flush=True)
+    print(f"Base: {main_ref} (current HEAD should be based on this)\n", flush=True)
+
+    for pr, branch_name in branches:
+        if not fetch_branch(branch_name):
+            print(f"PR {pr}: FETCH failed for {branch_name}", flush=True)
+            stats["fetch_fail"] += 1
+            continue
+
+        ahead = commits_ahead(main_ref, branch_name)
+        if not ahead:
+            print(f"PR {pr}: skip (0 commits ahead of {main_ref})", flush=True)
+            stats["skipped_no_ahead"] += 1
+            continue
+
+        pick_sha = pick_address_commit_sha(ahead)
+        if not pick_sha:
+            print(f"PR {pr}: skip (could not resolve commit)", flush=True)
+            stats["skipped_no_ahead"] += 1
+            continue
+
+        subj = next((s for h, s in ahead if h == pick_sha), "")
+        print(
+            f"PR {pr}: cherry-pick {pick_sha[:7]} {subj!r} ({len(ahead)} ahead)",
+            flush=True,
+        )
+        rc = cherry_pick(pick_sha)
+        if rc == 0:
+            stats["cherry_pick_ok"] += 1
+            continue
+        if rc == 2:
+            print(f"PR {pr}: cherry-pick empty (already applied?), skip", flush=True)
+            stats["cherry_pick_empty"] += 1
+            continue
+
+        run(["git", "cherry-pick", "--abort"], check=False)
+        stats["cherry_pick_conflict"] += 1
+        print(f"PR {pr}: cherry-pick conflict; trying merge {branch_name}...", flush=True)
+        if merge_branch(branch_name):
+            stats["merge_ok"] += 1
+        else:
+            print(
+                f"PR {pr}: MERGE FAILED — resolve manually with "
+                f"git merge {branch_name} or inspect and continue script after fix.",
+                flush=True,
+            )
+            stats["merge_fail"] += 1
+            sys.exit(1)
+
+    print("\nDone.\n" + "\n".join(f"{k}: {v}" for k, v in sorted(stats.items())))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Integrates the follow-up `sentry: address PR review feedback` work from remote branches `sentry-review-fix-<PR#>` into `main`. Those branches were pushed after the original Sentry PRs merged; this PR lands that review feedback in one pass.

## Approach

1. Branch `integrate/sentry-review-fixes` from `origin/main`.
2. For each `origin/sentry-review-fix-*` (ascending PR #): cherry-pick the `address PR review` commit when possible.
3. On cherry-pick conflict, merge the fix branch with `-X theirs` so the review patch wins over overlapping hunks (main already contains the initial Sentry refine).
4. Early PRs (281–322) needed manual conflict resolution where `-X theirs` would have dropped newer `main` improvements; those were merged by hand.

## Helper

`Scripts/integrate_sentry_review_fixes.py` documents/automates the cherry-pick + merge fallback for future use (`--min-pr` to resume).

## Verification

- `swiftlint lint` (Linux): 0 error-level issues.
- **macOS:** please run `grace ci` before merging.

## After merge (optional)

Delete stale `sentry-review-fix-*` remote branches if you no longer need them for audit.

Made with [Cursor](https://cursor.com)