### PR TITLE
fix(sentry): push review/CI fixes to the PR branch

### DIFF
--- a/Scripts/gracenotes-dev/src/gracenotes_dev/sentry/ci_fix.py
+++ b/Scripts/gracenotes-dev/src/gracenotes_dev/sentry/ci_fix.py
@@ -147,6 +147,22 @@ def _git_has_uncommitted_changes(git_root: Path) -> bool:
     return bool((st.stdout or "").strip())
 
 
+def _git_push_origin_head_to_branch(git_root: Path, remote_branch: str) -> subprocess.CompletedProcess[str]:
+    """
+    Push ``HEAD`` to ``origin``'s branch ``remote_branch`` (GitHub PR ``headRefName``).
+
+    Sentry worktrees use local names like ``sentry-review-fix-N``; a plain ``git push origin HEAD``
+    would update the wrong remote branch without this refspec.
+    """
+    refspec = f"HEAD:refs/heads/{remote_branch}"
+    return subprocess.run(
+        ["git", "push", "origin", refspec],
+        cwd=git_root,
+        capture_output=True,
+        text=True,
+    )
+
+
 def try_fix_ci_with_agent(
     repo_root: Path,
     settings: SentrySettings,
@@ -280,6 +296,7 @@ def try_fix_ci_with_agent(
             settings=settings,
             pr_number=pr_number,
             git_root=git_root,
+            push_remote_branch=str(head_ref),
             sink=sink,
         )
     finally:
@@ -291,16 +308,12 @@ def _push_git_head(
     repo_root: Path,
     git_root: Path,
     pr_number: int,
+    push_remote_branch: str,
     *,
     sink: SentryLogSink | None,
 ) -> bool:
-    """Push ``HEAD`` to ``origin`` (e.g. after local ``grace ci`` passed with a clean tree)."""
-    push = subprocess.run(
-        ["git", "push", "origin", "HEAD"],
-        cwd=git_root,
-        capture_output=True,
-        text=True,
-    )
+    """Push ``HEAD`` to ``origin``'s PR head branch (e.g. after local ``grace ci`` passed)."""
+    push = _git_push_origin_head_to_branch(git_root, push_remote_branch)
     if push.returncode != 0:
         append_event(
             repo_root,
@@ -329,6 +342,7 @@ def run_ci_recovery_loop_in_worktree(
     settings: SentrySettings,
     pr_number: int,
     git_root: Path,
+    head_ref: str,
     *,
     sink: SentryLogSink | None,
 ) -> bool:
@@ -337,12 +351,15 @@ def run_ci_recovery_loop_in_worktree(
 
     Use after a **local commit** exists in ``git_root`` (e.g. review feedback applied) so a
     green run with a clean tree still pushes that commit.
+
+    ``head_ref`` is the PR's ``headRefName``; pushes target ``origin``'s branch of that name.
     """
     return _try_fix_ci_in_git_root(
         repo_root,
         settings,
         pr_number,
         git_root,
+        push_remote_branch=head_ref,
         sink=sink,
         push_when_ci_green_clean=True,
     )
@@ -353,6 +370,7 @@ def _try_fix_ci_in_git_root(
     settings: SentrySettings,
     pr_number: int,
     git_root: Path,
+    push_remote_branch: str,
     *,
     sink: SentryLogSink | None,
     push_when_ci_green_clean: bool = False,
@@ -394,12 +412,7 @@ def _try_fix_ci_in_git_root(
             )
             return False
 
-        push = subprocess.run(
-            ["git", "push", "origin", "HEAD"],
-            cwd=git_root,
-            capture_output=True,
-            text=True,
-        )
+        push = _git_push_origin_head_to_branch(git_root, push_remote_branch)
         if push.returncode != 0:
             append_event(
                 repo_root,
@@ -486,7 +499,13 @@ def _try_fix_ci_in_git_root(
             if _git_has_uncommitted_changes(git_root):
                 return _commit_and_push()
             if push_when_ci_green_clean:
-                return _push_git_head(repo_root, git_root, pr_number, sink=sink)
+                return _push_git_head(
+                    repo_root,
+                    git_root,
+                    pr_number,
+                    push_remote_branch,
+                    sink=sink,
+                )
             append_event(
                 repo_root,
                 {

--- a/Scripts/gracenotes-dev/src/gracenotes_dev/sentry/cursor_review_fix.py
+++ b/Scripts/gracenotes-dev/src/gracenotes_dev/sentry/cursor_review_fix.py
@@ -304,6 +304,7 @@ def try_address_cursor_review_with_agent(
             settings=settings,
             pr_number=pr_number,
             git_root=git_root,
+            head_ref=str(head_ref),
             feedback_text=ft,
             sink=sink,
         )
@@ -318,6 +319,7 @@ def _try_address_review_in_git_root(
     pr_number: int,
     git_root: Path,
     *,
+    head_ref: str,
     feedback_text: str,
     sink: SentryLogSink | None,
 ) -> bool:
@@ -456,6 +458,7 @@ def _try_address_review_in_git_root(
             settings,
             pr_number,
             git_root,
+            head_ref,
             sink=sink,
         )
         if not ci_ok:

--- a/Scripts/gracenotes-dev/tests/test_sentry.py
+++ b/Scripts/gracenotes-dev/tests/test_sentry.py
@@ -1287,3 +1287,17 @@ class MergePollCommentModeTest(unittest.TestCase):
                 sink=None,
             )
         self.assertEqual(out, MergePollOutcome.WAIT_FOR_GATES)
+
+
+class CiFixPushRefspecTest(unittest.TestCase):
+    """Sentry worktrees use local branch names; push must target PR headRefName."""
+
+    def test_git_push_origin_head_to_branch_uses_refspec(self) -> None:
+        from gracenotes_dev.sentry.ci_fix import _git_push_origin_head_to_branch
+
+        fake = mock.Mock(return_value=mock.Mock(returncode=0))
+        with mock.patch("gracenotes_dev.sentry.ci_fix.subprocess.run", fake):
+            _git_push_origin_head_to_branch(Path("/wt"), "feat/sentry-pr-branch")
+        fake.assert_called_once()
+        argv = fake.call_args[0][0]
+        self.assertEqual(argv, ["git", "push", "origin", "HEAD:refs/heads/feat/sentry-pr-branch"])


### PR DESCRIPTION
## Headline

`grace sentry` automated review and CI fixes now update the **same GitHub branch the PR uses**, instead of pushing to a stray `sentry-review-fix-*` / `sentry-ci-fix-*` remote branch.

## User impact

- **Before:** Fixes could land on `origin/sentry-review-fix-<PR>` while the open PR still pointed at the original head branch, so the PR did not show the new commits.
- **After:** Pushes use `git push origin HEAD:refs/heads/<headRefName>` so `origin` updates the PR head.

## What changed

Sentry worktrees keep using local branch names to avoid collisions. All CI-fix and review-recovery pushes now target the PR’s `headRefName` explicitly.

## Verification

- `cd Scripts/gracenotes-dev && uv run python -m unittest tests.test_sentry -v` (82 tests)


Made with [Cursor](https://cursor.com)