### PR TITLE
Skip empty secondary guidance and editing side effects when locked

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/EditableTextSection.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/EditableTextSection.swift
@@ -54,7 +54,8 @@ struct EditableTextSection: View {
                         .font(AppTheme.warmPaperBody)
                         .foregroundStyle(palette.textPrimary)
                         .fixedSize(horizontal: false, vertical: true)
-                    if let guidanceMessageSecondary, !guidanceMessageSecondary.isEmpty {
+                    if let guidanceMessageSecondary,
+                       !guidanceMessageSecondary.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                         Text(guidanceMessageSecondary)
                             .font(AppTheme.warmPaperBody)
                             .foregroundStyle(palette.textPrimary)

--- a/GraceNotes/GraceNotes/Features/Journal/Views/EditableTextSection.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/EditableTextSection.swift
@@ -54,7 +54,7 @@ struct EditableTextSection: View {
                         .font(AppTheme.warmPaperBody)
                         .foregroundStyle(palette.textPrimary)
                         .fixedSize(horizontal: false, vertical: true)
-                    if let guidanceMessageSecondary {
+                    if let guidanceMessageSecondary, !guidanceMessageSecondary.isEmpty {
                         Text(guidanceMessageSecondary)
                             .font(AppTheme.warmPaperBody)
                             .foregroundStyle(palette.textPrimary)
@@ -75,24 +75,27 @@ struct EditableTextSection: View {
                 .foregroundStyle(onboardingState.titleColor(palette: palette))
             textEditor
                 .onChange(of: text) { _, newValue in
-                    let newCount = newValue.filter { $0 == "\n" }.count
+                    let newCount = Self.countNewlines(in: newValue)
                     // `nudgeFirstResponderUITextViewCaretIntoVisibleContent` affects whichever UITextView is first
                     // responder; only react when this section owns focus (or no focus binding is provided).
                     let isThisFieldFocused = inputFocus?.wrappedValue ?? true
-                    if let onMultilineLineAdded, isThisFieldFocused, newCount > storedNewlineCount {
-                        onMultilineLineAdded()
-                    }
-                    storedNewlineCount = newCount
-                    if isThisFieldFocused {
-                        Task { @MainActor in
-                            await Task.yield()
-                            JournalCaretVisibilityReader.nudgeFirstResponderUITextViewCaretIntoVisibleContent()
+                    let shouldHandleEditingSideEffects = !onboardingState.isLocked
+                    if shouldHandleEditingSideEffects {
+                        if let onMultilineLineAdded, isThisFieldFocused, newCount > storedNewlineCount {
+                            onMultilineLineAdded()
+                        }
+                        if isThisFieldFocused {
+                            Task { @MainActor in
+                                await Task.yield()
+                                JournalCaretVisibilityReader.nudgeFirstResponderUITextViewCaretIntoVisibleContent()
+                            }
                         }
                     }
+                    storedNewlineCount = newCount
                 }
         }
         .onAppear {
-            storedNewlineCount = text.filter { $0 == "\n" }.count
+            storedNewlineCount = Self.countNewlines(in: text)
         }
         .journalOnboardingSectionStyle(onboardingState)
     }
@@ -134,6 +137,12 @@ struct EditableTextSection: View {
             keyboardScrollAnchoredEditor(editor).focused(inputFocus)
         } else {
             keyboardScrollAnchoredEditor(editor)
+        }
+    }
+
+    private static func countNewlines(in string: String) -> Int {
+        string.reduce(0) { count, character in
+            character == "\n" ? count + 1 : count
         }
     }
 }


### PR DESCRIPTION
## Headline

Journal text sections no longer show blank secondary guidance or run keyboard caret work while onboarding locks editing.

## User impact

Readers see cleaner guidance blocks without an extra empty line when secondary copy is blank. While a section is locked during onboarding, typing-related side effects stay quiet, which reduces unnecessary scrolling and caret adjustments that could feel jumpy or unreliable.

## What changed

Secondary guidance now follows the same rule as the primary message: it only appears when the string is non-empty, so the layout does not reserve space for an invisible line.

Text change handling now treats a locked onboarding section as read-only for editing side effects: multiline scroll callbacks and the caret visibility nudge run only when the section is not locked, while newline counting still updates so state stays consistent.

Newline counting is centralized in a small helper so the view uses one clear implementation instead of repeating filtering logic.

## Verification

On a Mac with Xcode and the iOS Simulator, run `grace ci` (or `grace test` with the project’s usual destination). In the app, open a journal section that can show secondary guidance and confirm an empty secondary string does not add a blank line. With onboarding in a locked state for a text section, edit if applicable and confirm no unexpected scroll or caret nudges fire from that path.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
