### PR TITLE
Clear tutorial storage when resetting journal onboarding

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalOnboardingProgress.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalOnboardingProgress.swift
@@ -128,7 +128,11 @@ final class JournalOnboardingProgress {
         defaults.removeObject(forKey: JournalOnboardingStorageKeys.legacy051GuidedBranchResolution)
     }
 
+    /// Clears journal onboarding keys and tutorial milestone keys so ``resolvedHasCompletedGuidedJournal`` does not
+    /// immediately re-derive completion from leftover tutorial presence (see ``shouldTreatInstallAsPreviouslyOnboarded``).
     static func resetAll(in defaults: UserDefaults = .standard) {
+        JournalTutorialStorageKeys.removeAllStoredKeys(in: defaults)
+
         let keys = [
             JournalOnboardingStorageKeys.completedGuidedJournal,
             LegacyJournalOnboardingStorageKeys.pending051UpgradeOrientation,


### PR DESCRIPTION
## Headline

Onboarding reset now truly starts the guided journal path from a clean slate.

## User impact

If someone reset journal onboarding (for example from Settings or support flows), leftover tutorial milestone flags could still make the app treat the install as already onboarded. That could skip or confuse the guided journal experience right after a reset. Clearing those keys prevents the completion flag from being immediately inferred again from old tutorial state.

## What changed

The journal onboarding reset path now removes all stored journal tutorial keys up front, using the existing helper on `JournalTutorialStorageKeys`, before clearing the onboarding-specific `UserDefaults` entries and launch tracking. A short doc comment was added on `resetAll` to explain that this avoids re-deriving “guided journal complete” from leftover tutorial presence when the explicit completion key is gone.

## Verification

On a Mac with Xcode and the project’s `grace` CLI installed, run `grace ci` (or `grace test` with the usual simulator destination from `gracenotes-dev.toml`) to confirm the app still builds and tests pass.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
