### PR TITLE
Sort Past statistics history after filtering, not the full journal list

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/ReviewHistoryWindowing.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ReviewHistoryWindowing.swift
@@ -17,16 +17,16 @@ enum ReviewHistoryWindowing {
         calendar: Calendar,
         pastStatisticsInterval: PastStatisticsIntervalSelection
     ) -> [Journal] {
-        let sortedAll = sortedEntries(allEntries)
         let historyRange = pastStatisticsInterval.validated.resolvedHistoryRange(
             referenceDate: referenceDate,
             calendar: calendar,
             allEntries: allEntries
         )
-        return sortedAll.filter { entry in
+        let inWindow = allEntries.filter { entry in
             let day = calendar.startOfDay(for: entry.entryDate)
             return day >= historyRange.lowerBound && day < historyRange.upperBound
         }
+        return sortedEntries(inWindow)
     }
 
     /// Strongest completion level per calendar day (same rules as ``WeeklyReviewAggregatesBuilder`` / skyline mix).


### PR DESCRIPTION
## Headline

Past statistics no longer sorts every journal before applying the selected history window, which keeps large libraries responsive.

## User impact

Users with many entries outside the chosen Past range should see the same charts and lists as before, with less wasted work when opening Past statistics. Reliability improves indirectly by reducing unnecessary sorting on the main thread during those updates.

## What changed

The history window helper used to sort the entire journal list, then drop entries outside the range. That meant the cost of sorting grew with total library size even when only a small slice was needed. It now filters to the validated date range first and sorts only that subset, using the same ordering rules as before.

## Verification

On a Mac with Xcode and the iOS Simulator, run `grace ci` (or `grace test` with the project’s usual destination) to confirm the app still builds and tests pass.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
