### PR TITLE
Fix review inset panel title meta wrapping and empty VoiceOver hints

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewInsightInsetPanel.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewInsightInsetPanel.swift
@@ -129,8 +129,13 @@ struct ReviewInsightInsetPanel<Content: View>: View {
 private extension View {
     @ViewBuilder
     func optionalAccessibilityHint(_ hint: String?) -> some View {
-        if let hint, !hint.isEmpty {
-            accessibilityHint(hint)
+        if let hint {
+            let trimmed = hint.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                accessibilityHint(trimmed)
+            } else {
+                self
+            }
         } else {
             self
         }

--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewInsightInsetPanel.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewInsightInsetPanel.swift
@@ -97,6 +97,7 @@ struct ReviewInsightInsetPanel<Content: View>: View {
                         Text(trailing)
                             .font(AppTheme.warmPaperMeta)
                             .foregroundStyle(AppTheme.reviewTextMuted)
+                            .fixedSize(horizontal: false, vertical: true)
                     }
                 }
             }
@@ -128,7 +129,7 @@ struct ReviewInsightInsetPanel<Content: View>: View {
 private extension View {
     @ViewBuilder
     func optionalAccessibilityHint(_ hint: String?) -> some View {
-        if let hint {
+        if let hint, !hint.isEmpty {
             accessibilityHint(hint)
         } else {
             self


### PR DESCRIPTION
## Headline

Past review inset panels show full trailing meta text and avoid pointless VoiceOver hints.

## User impact

Long secondary text next to panel titles is less likely to get clipped when the layout stacks vertically. VoiceOver users no longer hear an empty hint when a tappable title is passed an empty hint string.

## What changed

The stacked fallback layout for the title row now allows the trailing meta line to grow vertically so multi-line secondary copy reads fully instead of being squeezed. The optional title accessibility hint helper only applies VoiceOver hint text when the string is non-empty, so we do not attach meaningless hints.

## Verification

On a Mac with Xcode and the project grace CLI installed, run `grace ci` from the repo root (or `grace test` with the project’s default simulator destination) to lint and build; in the simulator, open Past review flows that use ReviewInsightInsetPanel and confirm long trailing meta wraps; with VoiceOver on, verify tappable titles do not announce a blank hint when the hint is omitted or empty.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
