### PR TITLE
Pin guided journal completion false after onboarding reset

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalOnboardingProgress.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalOnboardingProgress.swift
@@ -128,8 +128,10 @@ final class JournalOnboardingProgress {
         defaults.removeObject(forKey: JournalOnboardingStorageKeys.legacy051GuidedBranchResolution)
     }
 
-    /// Clears journal onboarding keys and tutorial milestone keys so ``resolvedHasCompletedGuidedJournal`` does not
-    /// immediately re-derive completion from leftover tutorial presence (see ``shouldTreatInstallAsPreviouslyOnboarded``).
+    /// Clears journal onboarding keys and tutorial milestone keys, then pins ``completedGuidedJournal`` to `false`
+    /// so ``resolvedHasCompletedGuidedJournal`` does not immediately re-derive `true` from first-run, reminders, or
+    /// other heuristics in ``shouldTreatInstallAsPreviouslyOnboarded``.
+    /// (Removing the key alone would let migration run again on the next read.)
     static func resetAll(in defaults: UserDefaults = .standard) {
         JournalTutorialStorageKeys.removeAllStoredKeys(in: defaults)
 
@@ -147,6 +149,7 @@ final class JournalOnboardingProgress {
         for key in keys {
             defaults.removeObject(forKey: key)
         }
+        defaults.set(false, forKey: JournalOnboardingStorageKeys.completedGuidedJournal)
         AppLaunchVersionTracker.resetLaunchTracking(in: defaults)
     }
 


### PR DESCRIPTION
## Headline

Resetting journal onboarding now leaves users in a true fresh state instead of silently re-marking the guided journal as complete.

## User impact

When support or developers reset onboarding, people should see the full guided journal flow again. Before this fix, clearing stored keys could let the app infer “already completed” from reminders, first-run, or other signals, so the journal could still behave like a finished onboarding even right after a reset.

## What changed

The journal onboarding reset path clears the usual UserDefaults keys and tutorial milestones, then explicitly stores guided journal completion as false. That stops the resolver from treating a missing key as a signal to run the migration heuristics again and immediately write completion back to true. Documentation on the reset helper was updated to explain why removing the key alone was not enough.

## Verification

On a Mac with Xcode, run `grace test` or `grace ci` from the repo root (or the project’s usual CI profile) to lint, build, and exercise tests against the configured simulator destinations.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
