### PR TITLE
Fix share composer draft updates and share commit busy state

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/JournalShareComposerView.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/JournalShareComposerView.swift
@@ -188,7 +188,9 @@ struct JournalShareComposerView: View {
     private func styleChip(_ style: ShareCardStyle) -> some View {
         let selected = draft.style == style
         return Button {
-            draft.style = style
+            var next = draft
+            next.style = style
+            draft = next
         } label: {
             Text(style.localizedTitle)
                 .font(AppTheme.warmPaperBody)
@@ -208,6 +210,7 @@ struct JournalShareComposerView: View {
     private func commitShare() {
         guard !isShareCommitInProgress else { return }
         isShareCommitInProgress = true
+        defer { isShareCommitInProgress = false }
 
         let built = ShareRenderPayloadBuilder.build(
             full: basePayload,
@@ -215,11 +218,9 @@ struct JournalShareComposerView: View {
             includePreviewStubs: false
         )
         guard let image = JournalShareRenderer.renderImage(from: built) else {
-            isShareCommitInProgress = false
             showRenderError = true
             return
         }
         onShare(image)
-        isShareCommitInProgress = false
     }
 }


### PR DESCRIPTION
## Headline

Share card style picks and the busy overlay behave more predictably when you customize and export a journal image.

## User impact

Style chip taps should refresh the live preview the same way other share options do. After you tap Share, the screen should not stay frozen if image creation fails or if future code paths are added, because the in-progress lock is cleared in one place.

## What changed

The style preset buttons no longer mutate the share draft in place. They copy the draft, change the selected style, and assign it back, matching how redaction, section visibility, and toggles already update state so SwiftUI reliably notices changes to the struct-backed draft.

Share now uses a single defer to clear the in-progress flag when rendering finishes, instead of repeating that reset on the success and error paths. That keeps the UI from staying disabled if a new early exit slips in later and makes the intent obvious in one spot.

## Verification

On a Mac with Xcode and the project’s grace CLI, run `grace ci` (or `grace test` with the repo’s default simulator destination). In the app, open the journal share composer, tap different style chips and confirm the preview updates, tap Share, and confirm controls re-enable after the sheet flow; trigger a render failure path if you can and confirm the composer is not stuck disabled.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
