### PR TITLE
Guard journal row taps against stale or out-of-range indices

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/JournalEntryInteractionCoordinator.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/JournalEntryInteractionCoordinator.swift
@@ -27,6 +27,9 @@ enum JournalEntryInteractionCoordinator {
         tapIndex: Int,
         restoreInputFocus: (FocusState<Bool>.Binding) -> Void
     ) {
+        // Row taps come from list indices; ignore out-of-range values so we do not run transitions
+        // or keyboard focus restoration for a non-existent row (e.g. stale index after a data race).
+        guard tapIndex >= 0, tapIndex < context.operations.count else { return }
         let handled = JournalScreenEntryHandling.performEntryTap(
             tapIndex: tapIndex,
             input: context.input,

--- a/GraceNotes/GraceNotes/Features/Journal/Views/JournalEntryInteractionCoordinator.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/JournalEntryInteractionCoordinator.swift
@@ -27,8 +27,9 @@ enum JournalEntryInteractionCoordinator {
         tapIndex: Int,
         restoreInputFocus: (FocusState<Bool>.Binding) -> Void
     ) {
-        // Row taps come from list indices; ignore out-of-range values so we do not run transitions
-        // or keyboard focus restoration for a non-existent row (e.g. stale index after a data race).
+        // Row taps come from list indices. Ignore out-of-range `tapIndex` so we do not run transitions
+        // or keyboard focus restoration when the index is stale (e.g. list position vs. `operations.count`
+        // briefly disagree during SwiftUI updates).
         guard tapIndex >= 0, tapIndex < context.operations.count else { return }
         let handled = JournalScreenEntryHandling.performEntryTap(
             tapIndex: tapIndex,


### PR DESCRIPTION
## Headline

Prevents bad taps from driving entry transitions or keyboard focus when the list and tapped index disagree.

## User impact

Tapping a journal row could briefly line up with an invalid index if the list changed between the tap and handling (for example under timing pressure). That could cause odd transitions or unwanted keyboard behavior. The app now ignores taps whose index no longer matches the current rows, so editing and focus stay aligned with what is on screen.

## What changed

Row taps are keyed off list indices. A guard was added at the start of the entry-tap handler so only indices from zero up to (but not including) the current operation count are processed. If the index is out of range, the coordinator returns without calling entry handling or restoring input focus. A short comment documents that this guards against stale indices after races between updates and taps.

## Verification

On a Mac with Xcode and the project’s grace CLI, run `grace ci` (or `grace test` with the usual simulator destination from gracenotes-dev.toml). Manually, open Today, add or remove entries quickly, and tap rows; confirm no spurious focus or transition when the list changes right as you tap.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
