### PR TITLE
Harden journal completion morph bloom against invalid progress values

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/JournalCompletionPill.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/JournalCompletionPill.swift
@@ -15,9 +15,11 @@ struct JournalCompletionPill: View {
     var morphAccentColor: Color = .clear
     var morphBloomProgress: CGFloat = 0
 
-    /// Defensive clamp so morph bloom visuals stay stable if progress is driven past 0…1.
+    /// Defensive clamp so morph bloom visuals stay stable if progress is outside 0…1 or non-finite.
     private var clampedMorphBloomProgress: CGFloat {
-        min(max(morphBloomProgress, 0), 1)
+        let raw = morphBloomProgress
+        guard raw.isFinite else { return 0 }
+        return min(max(raw, 0), 1)
     }
 
     var body: some View {


### PR DESCRIPTION
## Headline

Keeps the completion pill’s morph animation stable when progress math goes bad.

## User impact

If bloom progress ever became NaN or infinite (for example from a bad animation handoff or edge-case math), the outline and scale around the completion pill could behave unpredictably or disappear. This change treats those values as zero so the pill stays visible and predictable instead of glitching.

## What changed

The completion pill already clamped morph bloom progress to the 0–1 range for normal values. That clamp did not protect against non-finite floats, which can still flow through min/max and break opacity and scale. The morph bloom progress path now checks finiteness first and falls back to a safe value, then applies the same 0–1 clamp. The comment was updated to describe that behavior in plain terms.

## Verification

On a Mac with Xcode and the project’s grace CLI installed, run `grace ci` (or `grace test` with the usual simulator destination from gracenotes-dev.toml) to confirm the app builds and tests pass. Manually spot-check the journal header completion pill during any morph/celebration transition if you want extra confidence in the visual path.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
