### PR TITLE
Import: reset merge-conflict cancel state and read files off the main thread

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/ImportExportSettingsScreen.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/ImportExportSettingsScreen.swift
@@ -674,7 +674,9 @@ private extension ImportExportSettingsScreen {
         let mode = importMode
         let calendar = Calendar.current
         do {
-            let fileData = try loadManualImportFileData(from: url)
+            let fileData = try await Task.detached(priority: .userInitiated) {
+                try Self.loadManualImportFileData(from: url)
+            }.value
             let summary = try await Task.detached(priority: .userInitiated) {
                 let backgroundContext = ModelContext(container)
                 return try importService.importData(
@@ -737,7 +739,7 @@ private extension ImportExportSettingsScreen {
         return String(localized: "settings.dataPrivacy.import.error.generic")
     }
 
-    private func loadManualImportFileData(from url: URL) throws -> Data {
+    private static func loadManualImportFileData(from url: URL) throws -> Data {
         if ScheduledBackupPreferences.fileURLIsUnderScheduledBackupFolder(url) {
             return try ScheduledBackupPreferences.withFolderSecurityScopedAccess { _ in
                 try readImportFileData(from: url)
@@ -752,7 +754,7 @@ private extension ImportExportSettingsScreen {
         return try readImportFileData(from: url)
     }
 
-    private func readImportFileData(from url: URL) throws -> Data {
+    private static func readImportFileData(from url: URL) throws -> Data {
         if let byteCount = JournalDataImportService.resolvedFileByteCount(at: url) {
             try JournalDataImportService.checkImportPayloadByteCount(byteCount)
         }

--- a/GraceNotes/GraceNotes/Features/Settings/ImportExportSettingsScreen.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/ImportExportSettingsScreen.swift
@@ -303,6 +303,7 @@ struct ImportExportSettingsScreen: View {
             Button(String(localized: "common.cancel"), role: .cancel) {
                 pendingImportURL = nil
                 mergeConflictDays = []
+                showMergeConflictResolution = false
             }
         } message: {
             Text(mergeConflictAlertMessage(count: mergeConflictDays.count))


### PR DESCRIPTION
## Headline

Smoother, more reliable manual imports when merge conflicts appear or files are large.

## User impact

Dismissing the merge-conflict alert with Cancel no longer leaves a half-finished import hanging in memory, so you are less likely to see odd follow-up behavior. Reading the chosen JSON off the main thread keeps Settings responsive while a big backup file is loaded.

## What changed

The merge-conflict alert’s Cancel action now clears the pending import URL and the list of conflicting days so abandoned flows do not retain stale state.

Manual import now loads file data in a user-initiated background task (with helpers made static so the work can run without capturing the view), matching the existing pattern for the heavier import step and reducing main-thread stalls when reading large files or resolving security-scoped backup paths.

## Verification

On a Mac with Xcode and the project’s grace CLI installed, run `swiftlint lint` from the repo root and `grace ci` (or `grace test` with the usual simulator destination) to confirm the GraceNotes scheme still builds and tests pass.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
