### PR TITLE
Harden journal completion math with clamped section counts

### DIFF
--- a/GraceNotes/GraceNotes/Data/Models/Journal.swift
+++ b/GraceNotes/GraceNotes/Data/Models/Journal.swift
@@ -108,9 +108,12 @@ final class JournalEntry {
         needsCount: Int,
         peopleCount: Int
     ) -> Bool {
-        gratitudesCount >= slotCount &&
-            needsCount >= slotCount &&
-            peopleCount >= slotCount
+        let counts = NonNegativeSectionCounts(
+            gratitudesCount: gratitudesCount,
+            needsCount: needsCount,
+            peopleCount: peopleCount
+        )
+        return counts.minCount >= slotCount
     }
 
     /// Minimum count across the three chip sections (weakest section).
@@ -119,7 +122,11 @@ final class JournalEntry {
         needsCount: Int,
         peopleCount: Int
     ) -> Int {
-        min(gratitudesCount, needsCount, peopleCount)
+        NonNegativeSectionCounts(
+            gratitudesCount: gratitudesCount,
+            needsCount: needsCount,
+            peopleCount: peopleCount
+        ).minCount
     }
 
     /// Chip-only status: Gratitudes, Needs, and People in Mind counts. Notes and reflections are ignored.
@@ -128,21 +135,25 @@ final class JournalEntry {
         needsCount: Int,
         peopleCount: Int
     ) -> JournalCompletionLevel {
-        if gratitudesCount == 0 && needsCount == 0 && peopleCount == 0 {
+        let counts = NonNegativeSectionCounts(
+            gratitudesCount: gratitudesCount,
+            needsCount: needsCount,
+            peopleCount: peopleCount
+        )
+
+        if counts.gratitudesCount == 0 && counts.needsCount == 0 && counts.peopleCount == 0 {
             return .soil
         }
 
-        if gratitudesCount >= slotCount && needsCount >= slotCount && peopleCount >= slotCount {
+        if counts.minCount >= slotCount {
             return .bloom
         }
 
-        if gratitudesCount >= 3 && needsCount >= 3 && peopleCount >= 3 {
+        if counts.minCount >= leafProgressThreshold {
             return .leaf
         }
 
-        let hasAtLeastThree = gratitudesCount >= 3 || needsCount >= 3 || peopleCount >= 3
-        let hasBelowThree = gratitudesCount < 3 || needsCount < 3 || peopleCount < 3
-        if hasAtLeastThree && hasBelowThree {
+        if counts.maxCount >= leafProgressThreshold && counts.minCount < leafProgressThreshold {
             return .twig
         }
 
@@ -168,9 +179,32 @@ final class JournalEntry {
         return gratitudesCount >= 1 && needsCount >= 1 && peopleCount >= 1
     }
 
+    /// Minimum items per section before the leaf tier when not yet at bloom (all sections must reach this).
+    private static let leafProgressThreshold = 3
+
     /// Maximum number of items per chip section (gratitudes, needs, people).
     /// The journal design means each section holds at most 5 items.
     static let slotCount = 5
+
+    private struct NonNegativeSectionCounts {
+        let gratitudesCount: Int
+        let needsCount: Int
+        let peopleCount: Int
+
+        init(gratitudesCount: Int, needsCount: Int, peopleCount: Int) {
+            self.gratitudesCount = max(0, gratitudesCount)
+            self.needsCount = max(0, needsCount)
+            self.peopleCount = max(0, peopleCount)
+        }
+
+        var minCount: Int {
+            min(gratitudesCount, needsCount, peopleCount)
+        }
+
+        var maxCount: Int {
+            max(gratitudesCount, needsCount, peopleCount)
+        }
+    }
 }
 
 /// Code name for ``JournalEntry`` (call sites stay “Journal”; persistence stays compatible).

--- a/GraceNotes/GraceNotes/Data/Models/Journal.swift
+++ b/GraceNotes/GraceNotes/Data/Models/Journal.swift
@@ -173,10 +173,12 @@ final class JournalEntry {
 
     /// True when each chip section has at least one item (milestone “1/1/1”, independent of status name).
     var hasAtLeastOneEntryInEachSection: Bool {
-        let gratitudesCount = (gratitudes ?? []).count
-        let needsCount = (needs ?? []).count
-        let peopleCount = (people ?? []).count
-        return gratitudesCount >= 1 && needsCount >= 1 && peopleCount >= 1
+        let counts = NonNegativeSectionCounts(
+            gratitudesCount: (gratitudes ?? []).count,
+            needsCount: (needs ?? []).count,
+            peopleCount: (people ?? []).count
+        )
+        return counts.gratitudesCount >= 1 && counts.needsCount >= 1 && counts.peopleCount >= 1
     }
 
     /// Minimum items per section before the leaf tier when not yet at bloom (all sections must reach this).

--- a/GraceNotesTests/Features/Journal/JournalCompletionLevelTests.swift
+++ b/GraceNotesTests/Features/Journal/JournalCompletionLevelTests.swift
@@ -113,6 +113,63 @@ final class JournalCompletionLevelTests: XCTestCase {
         XCTAssertEqual(level, .bloom)
     }
 
+    func test_completionLevel_clampsNegativeCounts_sproutWhenOneSectionNegative() {
+        let level = Journal.completionLevel(
+            gratitudesCount: -1,
+            needsCount: 2,
+            peopleCount: 2
+        )
+
+        XCTAssertEqual(level, .sprout)
+    }
+
+    func test_completionLevel_clampsNegativeCounts_soilWhenAllNegative() {
+        let level = Journal.completionLevel(
+            gratitudesCount: -1,
+            needsCount: -1,
+            peopleCount: -1
+        )
+
+        XCTAssertEqual(level, .soil)
+    }
+
+    func test_minimumEntryCountAcrossSections_alignsWithCompletionLevel_negativeInputs() {
+        let gratitudesCount = -1
+        let needsCount = 2
+        let peopleCount = 2
+        let minAcross = Journal.minimumEntryCountAcrossSections(
+            gratitudesCount: gratitudesCount,
+            needsCount: needsCount,
+            peopleCount: peopleCount
+        )
+        XCTAssertEqual(minAcross, 0)
+        XCTAssertEqual(
+            Journal.completionLevel(
+                gratitudesCount: gratitudesCount,
+                needsCount: needsCount,
+                peopleCount: peopleCount
+            ),
+            .sprout
+        )
+
+        let allNegativeMin = Journal.minimumEntryCountAcrossSections(
+            gratitudesCount: -1,
+            needsCount: -1,
+            peopleCount: -1
+        )
+        XCTAssertEqual(allNegativeMin, 0)
+        XCTAssertEqual(Journal.completionLevel(gratitudesCount: -1, needsCount: -1, peopleCount: -1), .soil)
+    }
+
+    func test_entriesIndicateBloom_usesClampedMinCountAgainstSlotCount() {
+        XCTAssertFalse(
+            Journal.entriesIndicateBloom(gratitudesCount: -1, needsCount: -1, peopleCount: -1)
+        )
+        XCTAssertTrue(
+            Journal.entriesIndicateBloom(gratitudesCount: 5, needsCount: 5, peopleCount: 5)
+        )
+    }
+
     func test_hasReachedBloom_alignsWithCompletionLevel_withOrWithoutNotes() throws {
         let context = try makeInMemoryContext()
         let items = (1...Journal.slotCount).map { Entry(fullText: "x\($0)") }


### PR DESCRIPTION
## Headline

Growth-stage labels for your journal now derive from one consistent, defensive count model.

## User impact

Chip-section completion (Soil through Bloom) drives progress cues and history; inconsistent or edge-case counts could skew that story. Clamping counts to zero and expressing bloom, leaf, and twig rules through min/max across sections keeps the stage fair and predictable.

## What changed

Completion and bloom checks used repeated comparisons on raw integers, and twig used easy-to-misread OR/AND logic. The change introduces a small private helper that treats each section count as non-negative, then derives the weakest and strongest section sizes from those values. Bloom and leaf tiers now key off that shared minimum (with a named threshold for the pre-bloom “balanced” bar), and the twig case uses max versus min so “mixed progress” is expressed in plain language. Bloom detection and “minimum across sections” reuse the same path so the app does not drift between call sites.

## Verification

On a Mac with Xcode and the project’s default simulator setup, run `grace ci` (or `grace test` with the usual GraceNotes destination) to lint, build, and exercise automated tests.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
