### PR TITLE
Cancel iCloud account refresh task on teardown

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/ICloudAccountStatusModel.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/ICloudAccountStatusModel.swift
@@ -16,6 +16,10 @@ final class ICloudAccountStatusModel: ObservableObject {
         self.provider = provider
     }
 
+    deinit {
+        refreshTask?.cancel()
+    }
+
     func refresh() {
         refreshTask?.cancel()
         refreshGeneration += 1


### PR DESCRIPTION
## Headline

Stops leftover CloudKit account-status work when Settings no longer needs it.

## User impact

If someone opens Settings and leaves before iCloud status finishes loading, the app no longer keeps that fetch running in the background. That trims unnecessary work and avoids odd edge cases around a view model that is already gone.

## What changed

The iCloud account status helper already cancels superseded refreshes and ignores stale results. This adds the same cleanup when the observable object is destroyed: any in-flight refresh task is cancelled on teardown so work tied to a dismissed screen does not continue.

## Verification

On a Mac with Xcode and the repo’s grace CLI installed, run `grace ci` from the repository root (or `grace test` with the project’s default simulator destination) to confirm the app still builds and tests pass.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
