### PR TITLE
Stabilize App Tour paging and path title metrics

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Tutorial/AppTourView.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Tutorial/AppTourView.swift
@@ -37,6 +37,11 @@ struct AppTourView: View {
         _iCloudAccountState = StateObject(wrappedValue: ICloudAccountStatusModel())
     }
 
+    /// Keeps `TabView` selection aligned with visible pages (e.g. congratulations page omitted).
+    private func clampedPageIndex(_ index: Int) -> Int {
+        min(max(index, firstPageIndex), lastPageIndex)
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             TabView(selection: $pageIndex) {
@@ -61,8 +66,14 @@ struct AppTourView: View {
         }
         .background(AppTheme.settingsBackground.ignoresSafeArea())
         .onAppear {
-            let clamped = min(max(pageIndex, firstPageIndex), lastPageIndex)
+            let clamped = clampedPageIndex(pageIndex)
             if clamped != pageIndex {
+                pageIndex = clamped
+            }
+        }
+        .onChange(of: pageIndex) { _, newValue in
+            let clamped = clampedPageIndex(newValue)
+            if clamped != newValue {
                 pageIndex = clamped
             }
         }
@@ -108,7 +119,7 @@ struct AppTourView: View {
 private enum AppTourPathTitleMetricsKey: PreferenceKey {
     static var defaultValue: CGFloat = 0
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = nextValue()
+        value = max(value, nextValue())
     }
 }
 


### PR DESCRIPTION
## Headline

Keeps the guided tour on valid pages and measures path titles more reliably.

## User impact

Users who skip the congratulations screen or swipe through the tour are less likely to land on a missing page or see a blank pager state. The growth-path strip should align dots with titles more consistently when layout updates.

## What changed

The tour now clamps the selected page whenever it changes, not only on first appearance, so the pager stays within the first and last visible tabs when the congratulations page is omitted or SwiftUI tries to select an invalid index. A small helper centralizes that range logic for clarity and reuse. The preference key that records each step’s title line height now merges child measurements with the maximum instead of the last value, which better matches multi-line or updating title layout.

## Verification

On a Mac with Xcode, run `grace ci` (or `grace test` with the project’s default simulator destination). Manually open the App Tour with congratulations both shown and skipped; swipe between pages and confirm paging, indicators, and path-strip alignment look correct.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
