### PR TITLE
Derive completion badge info card tint from badge cases

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/CompletionBadgeInfo.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/CompletionBadgeInfo.swift
@@ -68,14 +68,14 @@ enum CompletionBadgeInfo: Equatable, Sendable {
     }
 
     func infoCardTintColor(using palette: TodayJournalPalette) -> Color {
-        switch completionLevel {
-        case .soil:
+        switch self {
+        case .empty:
             return palette.textMuted
-        case .sprout:
+        case .started:
             return palette.quickCheckInText
-        case .twig, .leaf:
+        case .growing, .balanced:
             return palette.standardText
-        case .bloom:
+        case .full:
             return palette.fullText
         }
     }


### PR DESCRIPTION
## Headline

Info card accent colors now follow the completion badge cases directly instead of an extra mapping hop.

## User impact

Completion badge help text should look the same as before, with tint colors still matching each growth stage. The change makes styling easier to reason about and safer to maintain if completion levels or mappings evolve.

## What changed

The info card tint helper used to branch on the mapped `JournalCompletionLevel` (soil through bloom). It now switches on `CompletionBadgeInfo` itself (empty through full), which matches how titles and descriptions are already expressed. The color choices stay aligned with the previous mapping: earliest stage muted, light check-in accent, middle stages standard text, and full completion using the full-stage text color.

## Verification

On a Mac with Xcode, run `grace ci` (or `grace test` per project docs) to confirm the GraceNotes scheme builds and tests pass; spot-check the journal completion badge info card in the simulator to confirm tint still matches each stage.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
