### PR TITLE
Generate weekly review insights with a single pass over journal entries

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/DeterministicReviewInsightsGenerator.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/DeterministicReviewInsightsGenerator.swift
@@ -11,8 +11,18 @@ struct DeterministicReviewInsightsGenerator: ReviewInsightsGenerating {
     ) async throws -> ReviewInsights {
         let currentPeriod = ReviewInsightsPeriod.currentPeriod(containing: referenceDate, calendar: calendar)
         let previousPeriod = ReviewInsightsPeriod.previousPeriod(before: currentPeriod, calendar: calendar)
-        let currentWeekEntries = entries.filter { currentPeriod.contains($0.entryDate) }
-        let previousWeekEntries = entries.filter { previousPeriod.contains($0.entryDate) }
+
+        var currentWeekEntries: [Journal] = []
+        var previousWeekEntries: [Journal] = []
+        for entry in entries {
+            let date = entry.entryDate
+            if currentPeriod.contains(date) {
+                currentWeekEntries.append(entry)
+            } else if previousPeriod.contains(date) {
+                previousWeekEntries.append(entry)
+            }
+        }
+
         let analysis = ruleEngine.analyze(
             currentPeriod: currentPeriod,
             currentWeekEntries: currentWeekEntries,


### PR DESCRIPTION
## Headline

Weekly review insight generation does less redundant work when scanning your journal history.

## User impact

Faster, more efficient insight generation when you have many entries, with the same weekly review behavior. You should see snappier review screens and less unnecessary CPU work on device.

## What changed

Building the current- and previous-week entry lists used two full scans of every journal entry—one filter for this week and another for last week. That duplicated work for large libraries. The generator now walks the entry list once, assigns each entry to this week, last week, or neither, and passes those lists into the same analysis as before. Logic for which entries belong to which period is unchanged; only how we collect them is streamlined.

## Verification

On a Mac with the repo and Xcode, run `grace ci` (or `grace test` with the project’s default simulator destination) to confirm the app builds and tests pass after the change.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
