### PR TITLE
Make journal export timestamps thread-safe without shared DateFormatter

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/Services/JournalDataExportService.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/Services/JournalDataExportService.swift
@@ -73,7 +73,8 @@ struct JournalDataExportService {
     }
 
     /// UTC `yyyyMMdd-HHmmss` stamp for export filenames; deterministic and locale-insensitive (`en_US_POSIX`).
-    /// Uses `Calendar` + `String(format:)` so concurrent exports (e.g. `Task.detached`) do not share a `DateFormatter`, which is not thread-safe.
+    /// Uses `Calendar` + `String(format:)` so concurrent exports (e.g. `Task.detached`) do not share a `DateFormatter`,
+    /// which is not thread-safe.
     func exportFilenameTimestamp(for date: Date) -> String {
         var calendar = Calendar(identifier: .gregorian)
         calendar.locale = Locale(identifier: "en_US_POSIX")

--- a/GraceNotes/GraceNotes/Features/Settings/Services/JournalDataExportService.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/Services/JournalDataExportService.swift
@@ -73,18 +73,23 @@ struct JournalDataExportService {
     }
 
     /// UTC `yyyyMMdd-HHmmss` stamp for export filenames; deterministic and locale-insensitive (`en_US_POSIX`).
+    /// Uses `Calendar` + `String(format:)` so concurrent exports (e.g. `Task.detached`) do not share a `DateFormatter`, which is not thread-safe.
     func exportFilenameTimestamp(for date: Date) -> String {
-        Self.exportFilenameTimestampFormatter.string(from: date)
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.locale = Locale(identifier: "en_US_POSIX")
+        calendar.timeZone = TimeZone(secondsFromGMT: 0) ?? TimeZone(identifier: "UTC")!
+        let components = calendar.dateComponents([.year, .month, .day, .hour, .minute, .second], from: date)
+        return String(
+            format: "%04d%02d%02d-%02d%02d%02d",
+            locale: Locale(identifier: "en_US_POSIX"),
+            components.year ?? 0,
+            components.month ?? 0,
+            components.day ?? 0,
+            components.hour ?? 0,
+            components.minute ?? 0,
+            components.second ?? 0
+        )
     }
-
-    private static let exportFilenameTimestampFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.calendar = Calendar(identifier: .gregorian)
-        formatter.timeZone = TimeZone(secondsFromGMT: 0) ?? TimeZone(identifier: "GMT")!
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.dateFormat = "yyyyMMdd-HHmmss"
-        return formatter
-    }()
 }
 
 struct JournalDataExportArchive: Codable, Equatable {


### PR DESCRIPTION
## Headline

Export filenames stay stable in UTC while avoiding unsafe shared formatters under concurrency.

## User impact

Journal data exports still use the same UTC timestamp pattern in filenames, but the app no longer risks data races from a single shared DateFormatter when multiple exports run at once. That reduces rare crashes or corrupted filenames and makes background or overlapping exports more reliable.

## What changed

The export filename timestamp used a static DateFormatter, which Apple documents as not thread-safe. That becomes a problem if exports are triggered from concurrent work (for example detached tasks) because every call would share the same formatter instance.

The change removes that shared formatter. Timestamps are built with a Gregorian calendar in UTC, POSIX locale, and fixed-width numeric formatting so the string matches the previous yyyyMMdd-HHmmss style without depending on locale. A brief comment documents why this approach is safer under concurrency.

## Verification

On a Mac with Xcode and the project’s grace CLI installed, run `grace ci` (or `grace test` with the usual simulator destination) from the repo root to lint, build, and exercise tests.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
