### PR TITLE
Harden Past journal search highlighting and stabilize match ordering

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/PastJournalSearchViews.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/PastJournalSearchViews.swift
@@ -79,6 +79,7 @@ enum PastJournalSearchGrouping {
     }
 }
 
+/// File-scoped highlight rendering; ``text(content:highlightQuery:)`` is the only entry point used by views.
 private enum PastJournalSearchHighlighting {
     /// Body size matches ``AppTheme.warmPaperBody`` (17pt, scaled for Dynamic Type).
     private static let bodyPointSize: CGFloat = 17
@@ -97,8 +98,10 @@ private enum PastJournalSearchHighlighting {
         return UIFont(descriptor: boldDescriptor, size: size)
     }
 
+    /// `private` to this enum so new call sites cannot skip trimming; empty `trimmedQuery` returns `[]` because
+    /// `range(of:options:range:locale:)` would yield zero-width matches without advancing and could spin on the main
+    /// actor.
     private static func matchRanges(for content: String, trimmedQuery: String) -> [Range<String.Index>] {
-        // `range(of: "")` yields a zero-width match without advancing — would spin forever.
         guard !trimmedQuery.isEmpty else { return [] }
 
         var ranges: [Range<String.Index>] = []

--- a/GraceNotes/GraceNotes/Features/Journal/Views/PastJournalSearchViews.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/PastJournalSearchViews.swift
@@ -18,7 +18,7 @@ enum PastJournalSearchDebouncer {
         }
 
         do {
-            try await Task.sleep(nanoseconds: 250_000_000)
+            try await Task.sleep(for: .milliseconds(250))
         } catch {
             return
         }
@@ -66,7 +66,11 @@ enum PastJournalSearchGrouping {
                 ReviewThemeSourceCategory.allCases.compactMap { source in
                     guard let rows = bySource[source], !rows.isEmpty else { return nil }
                     let sortedRows = rows.sorted {
-                        $0.content.localizedCaseInsensitiveCompare($1.content) == .orderedAscending
+                        let ordering = $0.content.localizedCaseInsensitiveCompare($1.content)
+                        if ordering != .orderedSame {
+                            return ordering == .orderedAscending
+                        }
+                        return $0.id < $1.id
                     }
                     return (source: source, rows: sortedRows)
                 }
@@ -94,6 +98,9 @@ private enum PastJournalSearchHighlighting {
     }
 
     private static func matchRanges(for content: String, trimmedQuery: String) -> [Range<String.Index>] {
+        // `range(of: "")` yields a zero-width match without advancing — would spin forever.
+        guard !trimmedQuery.isEmpty else { return [] }
+
         var ranges: [Range<String.Index>] = []
         var searchStart = content.startIndex
         while searchStart < content.endIndex,


### PR DESCRIPTION
## Headline

Past search now avoids a pathological hang, keeps identical matches in a stable order, and uses a clearer debounce delay.

## User impact

Searching past journals should feel more predictable when multiple hits look the same, and the app avoids freezing if highlight logic ever runs with an empty query. The debounce behavior is unchanged in duration but expressed in a clearer, maintainable way.

## What changed

The debounced search wait now uses a duration-based sleep API instead of a raw nanosecond count, with the same quarter-second delay.

Within each day and section, search results that compare as equal under localized case-insensitive rules are ordered consistently by match id so the list does not jump unpredictably between updates.

The helper that finds highlight ranges in entry text now returns no ranges when the trimmed query is empty, so it cannot loop forever on a zero-length string match that never advances the search position.

## Verification

On a Mac with Xcode and the project’s grace CLI installed, run `grace ci` (or `grace test` with the usual simulator destination from gracenotes-dev.toml). Manually smoke-test Past search: type a query, confirm results and highlights update; try edge cases with whitespace-only input clearing to empty after trim if applicable.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
