### PR TITLE
Harden ShareSheet popover configuration and async setup

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/ShareSheet.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ShareSheet.swift
@@ -24,6 +24,8 @@ private enum ShareSheetPopover {
             width: 0,
             height: 0
         )
+        // Empty set avoids default arrow anchoring that can clash with chained sheets (e.g. journal share after another popover).
+        popover.permittedArrowDirections = []
     }
 }
 

--- a/GraceNotes/GraceNotes/Features/Journal/Views/ShareSheet.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ShareSheet.swift
@@ -24,7 +24,6 @@ private enum ShareSheetPopover {
             width: 0,
             height: 0
         )
-        popover.permittedArrowDirections = []
     }
 }
 
@@ -53,7 +52,8 @@ struct ShareSheet: UIViewControllerRepresentable {
             applicationActivities: applicationActivities
         )
         ShareSheetPopover.configureIfNeeded(for: controller)
-        DispatchQueue.main.async {
+        DispatchQueue.main.async { [weak controller] in
+            guard let controller else { return }
             ShareSheetPopover.configureIfNeeded(for: controller)
         }
         return controller


### PR DESCRIPTION
## Headline

Sharing on iPad and large layouts should anchor the share popover reliably without odd presentation quirks.

## User impact

On iPad and other horizontally regular layouts, the share sheet uses a popover; misconfiguration can make sharing feel broken or visually wrong. This update lets the system choose sensible popover arrow directions and avoids touching a share controller after it may have been dismissed or torn down.

## What changed

The popover setup no longer clears permitted arrow directions, so the system can pick a natural anchor instead of forcing an empty set that can interact badly with layout. The deferred main-queue configuration now holds a weak reference to the activity view controller and bails out if it is gone, which prevents stray work on deallocated UI and reduces lifetime issues around the initial presentation frame.

## Verification

On a Mac with Xcode, build and run the GraceNotes scheme; on iPad simulator or a horizontally regular size class, open journal sharing and confirm the share popover presents with a stable anchor. Run `grace ci` (or `grace test` with the project’s default destination) to match CI.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
