### PR TITLE
Let VoiceOver announce share preview stub text

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/JournalShareCardView.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/JournalShareCardView.swift
@@ -266,7 +266,6 @@ private extension JournalShareCardView {
             .foregroundStyle(surface.stubInk)
             .fixedSize(horizontal: false, vertical: true)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .accessibilityLabel(String(localized: "sharing.a11y.sectionStub"))
     }
 
     private var redactionBarShape: some View {


### PR DESCRIPTION
## Headline

Journal share preview stubs now speak their on-screen message instead of a separate generic label.

## User impact

People using VoiceOver hear the same italic preview line that sighted users read, which is clearer than a second, generic announcement. It also avoids overriding the real stub copy with a redundant accessibility label.

## What changed

In the journal share card, preview stub rows are plain text lines with italic styling. The view had an explicit accessibility label on those rows, which could cause VoiceOver to announce a generic string instead of (or in addition to) the visible stub message. That custom label was removed so accessibility falls back to the line’s text content, matching the visual copy and reducing confusing or duplicate speech.

## Verification

On a Mac with Xcode, run `grace ci` (or `grace test` with the project’s usual simulator destination). For a manual check, open the share card with VoiceOver enabled and move to a preview stub line; it should read the full stub message as shown on screen.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
