### PR TITLE
Align Sprout unlock suppression with real App Tour eligibility

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalTodayOrientationPolicy.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalTodayOrientationPolicy.swift
@@ -55,4 +55,30 @@ enum JournalTodayOrientationPolicy {
         guard newLevel == .sprout else { return false }
         return appTourOutcome(for: orientationInputs) != nil
     }
+
+    /// Bridge for call sites that pass orientation fields separately (for example ``JournalScreen``), using
+    /// the same app-wide defaults for UITesting and guided-journal completion as a fully specified ``Inputs``.
+    static func shouldSuppressSproutUnlockToast(
+        isTodayEntry: Bool,
+        newLevel: JournalCompletionLevel,
+        hasSeenAppTour: Bool,
+        milestoneHighlight: JournalUnlockMilestoneHighlight,
+        hasAtLeastOneEntryInEachSection: Bool
+    ) -> Bool {
+        let guidedDone = UserDefaults.standard.bool(
+            forKey: JournalOnboardingStorageKeys.completedGuidedJournal
+        )
+        let orientationInputs = Inputs(
+            isTodayEntry: isTodayEntry,
+            isRunningUITests: ProcessInfo.graceNotesIsRunningUITests,
+            hasSeenAppTour: hasSeenAppTour,
+            hasCompletedGuidedJournal: guidedDone,
+            hasAtLeastOneEntryInEachSection: hasAtLeastOneEntryInEachSection
+        )
+        return shouldSuppressSproutUnlockToast(
+            newLevel: newLevel,
+            milestoneHighlight: milestoneHighlight,
+            orientationInputs: orientationInputs
+        )
+    }
 }

--- a/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalTodayOrientationPolicy.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalTodayOrientationPolicy.swift
@@ -38,14 +38,14 @@ enum JournalTodayOrientationPolicy {
     /// present at **1/1/1**—for both the generic rank-up case and the first 1/1/1 milestone highlight.
     /// The first line alone in a section still shows feedback (`hasAtLeastOneEntryInEachSection` is false).
     ///
-    /// **Keep in sync** with `AppTourTrigger.evaluate`: tour eligibility uses the same entry counts as
-    /// `hasAtLeastOneEntryInEachSection`.
+    /// **Keep in sync** with `appTourOutcome` / `AppTourTrigger.evaluate`: suppression only applies when the
+    /// tour would actually be eligible to present (not under UI tests, where the tour is suppressed).
+    /// `hasCompletedGuidedJournal` on `orientationInputs` is ignored; include it so callers can pass
+    /// ``JournalScreen/todayOrientationInputs()``.
     static func shouldSuppressSproutUnlockToast(
-        isTodayEntry: Bool,
         newLevel: JournalCompletionLevel,
-        hasSeenAppTour: Bool,
         milestoneHighlight: JournalUnlockMilestoneHighlight,
-        hasAtLeastOneEntryInEachSection: Bool
+        orientationInputs: Inputs
     ) -> Bool {
         switch milestoneHighlight {
         case .none, .firstOneOneOne:
@@ -53,8 +53,11 @@ enum JournalTodayOrientationPolicy {
         case .firstBalanced, .firstFull:
             return false
         }
-        guard isTodayEntry, newLevel == .sprout, !hasSeenAppTour else { return false }
-        guard hasAtLeastOneEntryInEachSection else { return false }
+        guard !orientationInputs.isRunningUITests else { return false }
+        guard orientationInputs.isTodayEntry, newLevel == .sprout, !orientationInputs.hasSeenAppTour else {
+            return false
+        }
+        guard orientationInputs.hasAtLeastOneEntryInEachSection else { return false }
         return true
     }
 }

--- a/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalTodayOrientationPolicy.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalTodayOrientationPolicy.swift
@@ -38,10 +38,9 @@ enum JournalTodayOrientationPolicy {
     /// present at **1/1/1**—for both the generic rank-up case and the first 1/1/1 milestone highlight.
     /// The first line alone in a section still shows feedback (`hasAtLeastOneEntryInEachSection` is false).
     ///
-    /// **Keep in sync** with `appTourOutcome` / `AppTourTrigger.evaluate`: suppression only applies when the
-    /// tour would actually be eligible to present (not under UI tests, where the tour is suppressed).
-    /// `hasCompletedGuidedJournal` on `orientationInputs` is ignored; include it so callers can pass
-    /// ``JournalScreen/todayOrientationInputs()``.
+    /// Tour eligibility (Today, not UI tests, 1/1/1, not yet seen) is delegated to ``appTourOutcome(for:)``
+    /// so it cannot drift from `AppTourTrigger.evaluate`. ``Inputs/hasCompletedGuidedJournal`` only affects
+    /// congratulations skipping inside the tour, not whether suppression applies.
     static func shouldSuppressSproutUnlockToast(
         newLevel: JournalCompletionLevel,
         milestoneHighlight: JournalUnlockMilestoneHighlight,
@@ -53,11 +52,7 @@ enum JournalTodayOrientationPolicy {
         case .firstBalanced, .firstFull:
             return false
         }
-        guard !orientationInputs.isRunningUITests else { return false }
-        guard orientationInputs.isTodayEntry, newLevel == .sprout, !orientationInputs.hasSeenAppTour else {
-            return false
-        }
-        guard orientationInputs.hasAtLeastOneEntryInEachSection else { return false }
-        return true
+        guard newLevel == .sprout else { return false }
+        return appTourOutcome(for: orientationInputs) != nil
     }
 }


### PR DESCRIPTION
## Headline

Sprout feedback no longer hides during UI tests when the tour itself cannot appear.

## User impact

When the App Tour is blocked (for example under UI tests), the Sprout-stage unlock toast and header celebration were still being suppressed as if the full-screen tour were about to show. That could hide expected feedback in tests and misrepresent first-session behavior in those runs. The policy now only suppresses that feedback when the tour would actually be eligible to present.

## What changed

The sprout-unlock suppression helper now takes the same structured orientation inputs used elsewhere instead of separate boolean parameters, so call sites can pass through `todayOrientationInputs()` without splitting fields. A UI-test guard was added so suppression matches `appTourOutcome` and `AppTourTrigger.evaluate`: if the tour is not going to present (including because UI tests suppress it), the sprout toast and celebration are not withheld for that reason. Documentation was updated to describe this alignment and to note that guided-journal completion on the inputs struct is carried for convenience at the call site but is not used by this particular decision.

## Verification

On a Mac with Xcode and the project’s `grace` CLI, run `grace ci` (or `grace test` with your usual simulator destination) to confirm the GraceNotes scheme builds and tests pass.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
