### PR TITLE
Speed up streak calculation with a single journal pass

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/StreakCalculator.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/StreakCalculator.swift
@@ -23,33 +23,25 @@ struct StreakCalculator {
 
     func summary(from entries: [Journal], now: Date = .now) -> StreakSummary {
         let today = calendar.startOfDay(for: now)
-        let basicByDay = buildCompletionByDay(entries: entries) { $0.hasMeaningfulContent }
-        // "Perfect" = Harvest: all fifteen chips. `completedAt` alone must not inflate this streak.
-        let perfectByDay = buildCompletionByDay(entries: entries) { $0.hasReachedBloom }
+        let yesterday = calendar.date(byAdding: .day, value: -1, to: today)
+            .map { calendar.startOfDay(for: $0) }
+        var basicByDay: [Date: Bool] = [:]
+        var perfectByDay: [Date: Bool] = [:]
+        for entry in entries {
+            let day = calendar.startOfDay(for: entry.entryDate)
+            basicByDay[day] = (basicByDay[day] ?? false) || entry.hasMeaningfulContent
+            perfectByDay[day] = (perfectByDay[day] ?? false) || entry.hasReachedBloom
+        }
 
         return StreakSummary(
-            basicCurrent: currentStreakLength(byDay: basicByDay, today: today),
-            perfectCurrent: currentStreakLength(byDay: perfectByDay, today: today),
+            basicCurrent: currentStreakLength(byDay: basicByDay, today: today, yesterday: yesterday),
+            perfectCurrent: currentStreakLength(byDay: perfectByDay, today: today, yesterday: yesterday),
             basicDoneToday: basicByDay[today] ?? false,
             perfectDoneToday: perfectByDay[today] ?? false
         )
     }
 
-    private func buildCompletionByDay(
-        entries: [Journal],
-        completion: (Journal) -> Bool
-    ) -> [Date: Bool] {
-        var completionByDay: [Date: Bool] = [:]
-        for entry in entries {
-            let day = calendar.startOfDay(for: entry.entryDate)
-            completionByDay[day] = (completionByDay[day] ?? false) || completion(entry)
-        }
-        return completionByDay
-    }
-
-    private func currentStreakLength(byDay: [Date: Bool], today: Date) -> Int {
-        let yesterday = calendar.date(byAdding: .day, value: -1, to: today)
-            .map { calendar.startOfDay(for: $0) }
+    private func currentStreakLength(byDay: [Date: Bool], today: Date, yesterday: Date?) -> Int {
         let startDay: Date
         if byDay[today] == true {
             startDay = today

--- a/GraceNotes/GraceNotes/Features/Journal/Services/StreakCalculator.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/StreakCalculator.swift
@@ -30,6 +30,7 @@ struct StreakCalculator {
         for entry in entries {
             let day = calendar.startOfDay(for: entry.entryDate)
             basicByDay[day] = (basicByDay[day] ?? false) || entry.hasMeaningfulContent
+            // Perfect streak uses harvest (all chips / Bloom), not `completedAt`, so completion time cannot inflate it.
             perfectByDay[day] = (perfectByDay[day] ?? false) || entry.hasReachedBloom
         }
 


### PR DESCRIPTION
## Headline

Streak counts now build both completion maps in one scan and reuse yesterday’s date.

## User impact

Streak numbers and “done today” behavior stay the same, but computing them does less work. That keeps streak updates snappier when you have many journal days loaded and avoids repeating the same date math for basic and perfect streaks.

## What changed

Streak summary used to walk every journal entry twice—once to see which days had meaningful content and again for “perfect” (full harvest) days—because two separate helpers each built a per-day map. That is now a single loop that fills both maps at once. The calendar step that finds “yesterday” relative to today is done once in the summary and passed into streak length, instead of being recalculated inside each streak path. The private helper that only built one map was removed because its job is folded into that loop.

## Verification

On a Mac with Xcode and the project’s dev CLI installed, run `grace ci` (or `grace test` with your usual simulator destination) so lint and simulator tests cover this path.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
