### PR TITLE
Harden export history detail normalization for whitespace and invisible text

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/ImportExportTechnicalDetailFormatting.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/ImportExportTechnicalDetailFormatting.swift
@@ -4,6 +4,7 @@ struct ExportHistoryLineParts {
     let kindLabel: String
     let statusLabel: String
     /// Non-nil when `entry.detail` has visible content after normalization (trim; line breaks flattened).
+    /// For this purpose, Unicode scalars in General Category `.control` or `.format` count as non-visible.
     let detail: String?
 }
 
@@ -51,7 +52,9 @@ enum ImportExportTechnicalDetailFormatting {
     /// history rows and accessibility labels stay single-line. Each newline-delimited segment is
     /// trimmed; empty segments are dropped so spacing collapses to single spaces between words.
     /// Runs of horizontal whitespace on a line collapse to a single space; strings that contain no
-    /// visible characters after that (e.g. only zero-width format scalars) are treated as absent.
+    /// visible Unicode scalars after that are treated as absent. Visibility ignores **all** scalars
+    /// whose General Category is `.control` or `.format` (including zero-width characters, joiners,
+    /// and BOM-style scalars), not a hand-picked zero-width subset.
     private static func normalizedExportHistoryDetail(_ raw: String) -> String? {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
@@ -63,6 +66,7 @@ enum ImportExportTechnicalDetailFormatting {
         let joined = segments.joined(separator: " ")
         let collapsed = joined.split(whereSeparator: \.isWhitespace).joined(separator: " ")
         guard !collapsed.isEmpty else { return nil }
+        // Non-visible for this row: every scalar in General Category `.control` or `.format`.
         let hasVisibleScalar = collapsed.unicodeScalars.contains { scalar in
             switch scalar.properties.generalCategory {
             case .control, .format:

--- a/GraceNotes/GraceNotes/Features/Settings/ImportExportTechnicalDetailFormatting.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/ImportExportTechnicalDetailFormatting.swift
@@ -50,6 +50,8 @@ enum ImportExportTechnicalDetailFormatting {
     /// Trims surrounding whitespace, treats whitespace-only as absent, and flattens line breaks so
     /// history rows and accessibility labels stay single-line. Each newline-delimited segment is
     /// trimmed; empty segments are dropped so spacing collapses to single spaces between words.
+    /// Runs of horizontal whitespace on a line collapse to a single space; strings that contain no
+    /// visible characters after that (e.g. only zero-width format scalars) are treated as absent.
     private static func normalizedExportHistoryDetail(_ raw: String) -> String? {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
@@ -58,6 +60,17 @@ enum ImportExportTechnicalDetailFormatting {
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
         guard !segments.isEmpty else { return nil }
-        return segments.joined(separator: " ")
+        let joined = segments.joined(separator: " ")
+        let collapsed = joined.split(whereSeparator: \.isWhitespace).joined(separator: " ")
+        guard !collapsed.isEmpty else { return nil }
+        let hasVisibleScalar = collapsed.unicodeScalars.contains { scalar in
+            switch scalar.properties.generalCategory {
+            case .control, .format:
+                return false
+            default:
+                return true
+            }
+        }
+        return hasVisibleScalar ? collapsed : nil
     }
 }

--- a/GraceNotesTests/Features/Settings/ImportExportDetailFormattingTests.swift
+++ b/GraceNotesTests/Features/Settings/ImportExportDetailFormattingTests.swift
@@ -98,6 +98,23 @@ final class ImportExportDetailFormattingTests: XCTestCase {
         XCTAssertEqual(plain.components(separatedBy: " · ").count, 2)
     }
 
+    func test_exportHistoryLineParts_formatAndControlOnlyDetailIsNil() {
+        // U+FEFF (BOM) and U+200B (ZWSP) are `.format`; U+0001 is `.control` — all non-visible for the row.
+        let detail = "\u{FEFF}\u{200B}\u{0001}"
+        let entry = BackupExportHistoryEntry(
+            id: UUID(),
+            finishedAt: Date(),
+            success: true,
+            kind: .manualShare,
+            detail: detail
+        )
+        let parts = ImportExportTechnicalDetailFormatting.exportHistoryLineParts(for: entry)
+        XCTAssertNil(parts.detail)
+        let plain = ImportExportTechnicalDetailFormatting.exportHistoryPlainLabel(for: entry)
+        XCTAssertEqual(plain, "\(parts.kindLabel) · \(parts.statusLabel)")
+        XCTAssertEqual(plain.components(separatedBy: " · ").count, 2)
+    }
+
     func test_exportHistoryLineParts_trimsSegmentsAroundNewlinesNoDoubleSpaces() {
         let entry = BackupExportHistoryEntry(
             id: UUID(),


### PR DESCRIPTION
## Headline

Backup export history hides meaningless detail strings and reads more cleanly when spacing is messy.

## User impact

Export history lines and VoiceOver labels no longer surface odd gaps from extra spaces or tabs, and they omit detail text that would only show invisible characters (for example zero-width format characters). That keeps Settings clearer and avoids confusing or empty-looking metadata.

## What changed

The shared normalizer for export history detail now collapses consecutive horizontal whitespace to a single space after line breaks are flattened. It also checks Unicode scalar categories so control and format characters do not count as visible content; if nothing visible remains, the detail is treated as absent, matching the intent that only meaningful text appears in the row and accessibility strings.

## Verification

On a Mac with the repo and Xcode, run `grace ci` (or `grace test` per your usual workflow) to confirm the project still builds and tests pass; optionally spot-check Settings import/export history with odd spacing or edge-case detail strings if you have fixtures.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
