### PR TITLE
Use shared export filename timestamp for scheduled backups

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/Services/ScheduledBackupRunner.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/Services/ScheduledBackupRunner.swift
@@ -122,13 +122,9 @@ enum ScheduledBackupRunner {
     }
 
     private static func copyTempExport(at tempFile: URL, to folderURL: URL, exportDate: Date) throws -> String {
-        let formatter = DateFormatter()
-        formatter.calendar = Calendar(identifier: .gregorian)
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(secondsFromGMT: 0)
-        formatter.dateFormat = "yyyyMMdd-HHmmss"
+        let stamp = JournalDataExportService().exportFilenameTimestamp(for: exportDate)
         // UUID avoids same-second overwrites (copyTempFile replaces an existing destination name).
-        let name = "grace-notes-scheduled-\(formatter.string(from: exportDate))-\(UUID().uuidString).json"
+        let name = "grace-notes-scheduled-\(stamp)-\(UUID().uuidString).json"
         return try BackupFolderJSONExport.copyTempFile(
             tempFile,
             into: folderURL,


### PR DESCRIPTION
## Headline

Scheduled folder backups now use the same timestamp rules as the rest of journal export naming.

## User impact

Backup file names stay aligned with exports you trigger elsewhere in the app, so files sort and read consistently in the chosen folder. One shared implementation also means future timestamp tweaks cannot silently diverge between flows.

## What changed

Scheduled backup filenames no longer configure their own DateFormatter for the time stamp. The runner asks JournalDataExportService for the stamp via exportFilenameTimestamp(for:) and keeps the existing grace-notes-scheduled prefix, UUID suffix, and .json extension. Behavior stays the same idea—sortable, unique names—while centralizing how the stamp is produced.

## Verification

On macOS with Xcode and the iOS Simulator available, run grace ci from the repository root (or grace test with your usual destination from gracenotes-dev.toml) to confirm the GraceNotes scheme builds and automated checks pass.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
