### PR TITLE
Normalize weekly insight theme keys when skipping duplicates

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyInsightCandidateBuilder+Candidates.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyInsightCandidateBuilder+Candidates.swift
@@ -257,18 +257,27 @@ extension WeeklyInsightCandidateBuilder {
         }
     }
 
+    /// Key used to detect duplicate themes when selecting weekly insights. Prefer normalized labels;
+    /// when normalization is empty (whitespace-only, punctuation-only, etc.), fall back to trimmed
+    /// lowercased raw text so meaningless themes still dedupe like the pre-normalization path.
+    private func themeDedupeKeyForSkip(_ rawTheme: String) -> String {
+        let normalized = textNormalizer.normalizeThemeLabel(rawTheme)
+        if !normalized.isEmpty {
+            return normalized
+        }
+        return textNormalizer.trimmed(rawTheme).lowercased()
+    }
+
     func shouldSkip(
         _ candidate: ReviewWeeklyInsight,
         becauseOf selected: [ReviewWeeklyInsight]
     ) -> Bool {
         guard let rawTheme = candidate.primaryTheme else { return false }
-        let normalizedCandidate = textNormalizer.normalizeThemeLabel(rawTheme)
-        guard !normalizedCandidate.isEmpty else { return false }
+        let candidateKey = themeDedupeKeyForSkip(rawTheme)
         return selected.contains { selectedInsight in
             guard let rawSelected = selectedInsight.primaryTheme else { return false }
-            let normalizedSelected = textNormalizer.normalizeThemeLabel(rawSelected)
-            guard !normalizedSelected.isEmpty else { return false }
-            return normalizedSelected == normalizedCandidate &&
+            let selectedKey = themeDedupeKeyForSkip(rawSelected)
+            return selectedKey == candidateKey &&
                 selectedInsight.pattern != .fullCompletion &&
                 candidate.pattern != .fullCompletion
         }

--- a/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyInsightCandidateBuilder+Candidates.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyInsightCandidateBuilder+Candidates.swift
@@ -261,10 +261,14 @@ extension WeeklyInsightCandidateBuilder {
         _ candidate: ReviewWeeklyInsight,
         becauseOf selected: [ReviewWeeklyInsight]
     ) -> Bool {
-        guard let theme = candidate.primaryTheme?.lowercased() else { return false }
+        guard let rawTheme = candidate.primaryTheme else { return false }
+        let normalizedCandidate = textNormalizer.normalizeThemeLabel(rawTheme)
+        guard !normalizedCandidate.isEmpty else { return false }
         return selected.contains { selectedInsight in
-            let selectedTheme = selectedInsight.primaryTheme?.lowercased()
-            return selectedTheme == theme &&
+            guard let rawSelected = selectedInsight.primaryTheme else { return false }
+            let normalizedSelected = textNormalizer.normalizeThemeLabel(rawSelected)
+            guard !normalizedSelected.isEmpty else { return false }
+            return normalizedSelected == normalizedCandidate &&
                 selectedInsight.pattern != .fullCompletion &&
                 candidate.pattern != .fullCompletion
         }


### PR DESCRIPTION
## Headline

Weekly review insights now treat themes as the same using the app’s theme normalization, not just lowercase text.

## User impact

You are less likely to see two very similar weekly insights about the same underlying theme when one should be hidden as a duplicate. This makes the review feel more coherent and avoids repetitive prompts.

## What changed

The duplicate check for selected weekly insights compared primary themes with a simple lowercased string. That could miss matches that the rest of journaling already treats as the same theme, or treat messy empty strings inconsistently. The logic now uses the shared text normalizer’s theme label normalization for both the candidate and already-selected insights, and it skips comparisons when normalization yields an empty string. Full-completion patterns are still excluded from this skip rule as before.

## Verification

On a Mac with Xcode, run `grace ci` (or `grace test` with the project’s default simulator destination) to build and run automated checks for the GraceNotes scheme.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
