### PR TITLE
Refactor ReviewGrowthStageSkylineGlyph metrics into a small struct

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewGrowthStageSkylineGlyph.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewGrowthStageSkylineGlyph.swift
@@ -2,29 +2,19 @@ import SwiftUI
 
 /// Capsule-wrapped growth glyph shared by the Past skyline columns and drill-down chrome (issue #186).
 struct ReviewGrowthStageSkylineGlyph: View {
-    private enum Metrics {
-        case skyline(DynamicTypeSize)
-        case calendarDayTeaser
+    private struct Metrics {
+        let glyphSize: CGFloat
+        let glyphChrome: CGFloat
 
-        fileprivate var glyphSize: CGFloat {
-            switch self {
-            case .skyline(let dynamicTypeSize):
-                let scale = ReviewHistoryPanelLayoutScale.skylineMetricsScale(for: dynamicTypeSize)
-                return (14 * scale).rounded(.toNearestOrAwayFromZero)
-            case .calendarDayTeaser:
-                return 11
-            }
+        static func skyline(dynamicTypeSize: DynamicTypeSize) -> Metrics {
+            let scale = ReviewHistoryPanelLayoutScale.skylineMetricsScale(for: dynamicTypeSize)
+            return Metrics(
+                glyphSize: (14 * scale).rounded(.toNearestOrAwayFromZero),
+                glyphChrome: (26 * scale).rounded(.toNearestOrAwayFromZero)
+            )
         }
 
-        fileprivate var glyphChrome: CGFloat {
-            switch self {
-            case .skyline(let dynamicTypeSize):
-                let scale = ReviewHistoryPanelLayoutScale.skylineMetricsScale(for: dynamicTypeSize)
-                return (26 * scale).rounded(.toNearestOrAwayFromZero)
-            case .calendarDayTeaser:
-                return 20
-            }
-        }
+        static let calendarDayTeaser = Metrics(glyphSize: 11, glyphChrome: 20)
     }
 
     let level: JournalCompletionLevel
@@ -32,7 +22,7 @@ struct ReviewGrowthStageSkylineGlyph: View {
 
     init(level: JournalCompletionLevel, dynamicTypeSize: DynamicTypeSize) {
         self.level = level
-        self.metrics = .skyline(dynamicTypeSize)
+        self.metrics = .skyline(dynamicTypeSize: dynamicTypeSize)
     }
 
     /// Smaller glyph for calendar day cells.


### PR DESCRIPTION
## Headline

Growth-stage skyline glyphs now compute Dynamic Type scaling in one place instead of two parallel switches.

## User impact

The Past skyline and calendar teaser growth icons should look the same as before. The change mainly improves maintainability so future tweaks to size or scaling are less likely to drift or get out of sync.

## What changed

The internal `Metrics` helper was replaced from an enum with duplicated `switch` logic in `glyphSize` and `glyphChrome` to a lightweight struct that holds both numbers together. Skyline sizing uses a single `skyline(dynamicTypeSize:)` factory that applies the existing layout scale once; the calendar day teaser keeps fixed dimensions as a static preset. The public initializers and the view body are unchanged in behavior.

## Verification

On a Mac with Xcode and the project’s `grace` CLI, run `grace ci` (or `grace test` per your usual workflow) to confirm the app builds and tests pass; spot-check the Review Past skyline and calendar day cells to confirm growth glyphs still align and scale as expected at a few Dynamic Type sizes.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
