### PR TITLE
Prioritize Bloom toast when multiple journal milestones unlock at once

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalTutorialUnlockEvaluator.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Tutorial/JournalTutorialUnlockEvaluator.swift
@@ -36,13 +36,15 @@ enum JournalTutorialUnlockEvaluator {
         let shouldRecordLeaf = crossedBalanced && !input.hasCelebratedFirstLeaf
         let shouldRecordBloom = crossedFull && !input.hasCelebratedFirstBloom
 
+        // Prefer the strongest growth-stage toast when several milestones cross in one update
+        // (e.g. empty → balanced or Bloom in a single save); recording flags below still capture each first.
         let highlight: JournalUnlockMilestoneHighlight
-        if shouldRecordTripleOne {
-            highlight = .firstOneOneOne
+        if shouldRecordBloom {
+            highlight = .firstFull
         } else if shouldRecordLeaf {
             highlight = .firstBalanced
-        } else if shouldRecordBloom {
-            highlight = .firstFull
+        } else if shouldRecordTripleOne {
+            highlight = .firstOneOneOne
         } else {
             return nil
         }


### PR DESCRIPTION
## Headline

When one save crosses several first-time milestones, the app now shows the strongest growth toast instead of the earliest rule in the list.

## User impact

Users who fill out their journal in one go can see a celebration that matches their biggest step forward (Bloom over Leaf over 1/1/1) instead of a weaker or misleading first toast. Behind the scenes, first-time flags still record each milestone so nothing is silently skipped.

## What changed

The journal tutorial unlock evaluator already detects when someone crosses 1/1/1, reaches Leaf (balanced), or reaches Bloom for the first time. When more than one of those happens in a single update, only one highlight drives the toast. The logic was reordered so Bloom is preferred, then Leaf, then the 1/1/1 milestone. A short comment documents that behavior and that the separate recording booleans still mark each first-time achievement.

## Verification

On a Mac with the repo’s dev setup, run `grace test` (or `grace ci` for lint plus simulator build) to confirm unit tests and the GraceNotes scheme still pass.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
