### PR TITLE
Treat cancellation-like errors as benign when reading iCloud account status

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/Services/ICloudAccountStatusService.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/Services/ICloudAccountStatusService.swift
@@ -23,7 +23,7 @@ final class ICloudAccountStatusService: ICloudAccountStatusProviding {
             }.value
             return ICloudAccountBucket(status)
         } catch {
-            if !(error is CancellationError) {
+            if !isCancellationLike(error) {
                 let nsError = error as NSError
                 iCloudAccountStatusLogger.error(
                     """


### PR DESCRIPTION
## Headline

Stop flagging normal CloudKit or URL cancellations as iCloud status failures in logs.

## User impact

When iCloud work is cancelled or interrupted in ways CloudKit reports as operation cancelled (not only Swift task cancellation), Settings and diagnostics see fewer scary “failed to fetch iCloud account status” messages. That makes real sync or account problems easier to spot and reduces noise during normal navigation or teardown.

## What changed

The iCloud account status fetch already had a helper that recognizes several cancellation shapes (Swift cancellation, CloudKit operation cancelled, URL cancelled, and nested underlying errors). The catch path only skipped logging for plain Swift CancellationError, so other cancellation forms were still logged as errors even though the code already treated any failure the same for the user-facing bucket. The catch path now uses the same cancellation detection before logging, so benign cancellations are not reported as failures.

## Verification

On a Mac with Xcode and the repo’s grace CLI installed, run `grace ci` (or `grace test` with the project’s default simulator destination) to confirm the GraceNotes scheme still builds and tests pass.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
