### PR TITLE
Remove duplicate reminder time parsing from daily notification sync

### DIFF
--- a/GraceNotes/GraceNotes/Services/Reminders/DailyReminderNotificationSync.swift
+++ b/GraceNotes/GraceNotes/Services/Reminders/DailyReminderNotificationSync.swift
@@ -27,25 +27,4 @@ enum DailyReminderNotificationSync {
         }
         _ = await reminderScheduler.rescheduleEnabledReminder(at: reminderTime, body: body)
     }
-
-    /// Reads the saved clock time. `UserDefaults` is untyped; accept `NSNumber` and reject non-finite values.
-    private static func storedReminderTimeInterval(from userDefaults: UserDefaults) -> TimeInterval {
-        guard let raw = userDefaults.object(forKey: ReminderSettings.timeIntervalKey) else {
-            return ReminderSettings.defaultTimeInterval
-        }
-
-        let interval: TimeInterval
-        if let number = raw as? NSNumber {
-            interval = number.doubleValue
-        } else if let value = raw as? TimeInterval {
-            interval = value
-        } else {
-            return ReminderSettings.defaultTimeInterval
-        }
-
-        if !interval.isFinite {
-            return ReminderSettings.defaultTimeInterval
-        }
-        return interval
-    }
 }


### PR DESCRIPTION
## Headline

Daily reminder rescheduling now relies on one shared, validated clock-time reader.

## User impact

Reminder scheduling behavior stays the same for people who use daily reminders, but the app no longer carries two different ways to interpret the saved time from UserDefaults. That reduces the risk of future edits accidentally changing behavior in one path but not the other.

## What changed

`DailyReminderNotificationSync` already used `ReminderSettings.coercedTimeInterval(fromUserDefaults:)` when computing the next reminder time. A private helper that duplicated the same UserDefaults parsing and validation was left in the file but never called, so it was removed. Reminder time coercion and non-finite value handling remain centralized in `ReminderSettings`, which is the single place reviewers should look for that logic.

## Verification

On a Mac with Xcode and the project’s `grace` CLI installed, run `grace ci` (or `grace test` with the repo’s default simulator destination) to confirm the GraceNotes scheme still builds and tests pass.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
