### PR TITLE
Stabilize most recurring theme rows and accessibility keys

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewMostRecurringCard.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewMostRecurringCard.swift
@@ -82,7 +82,7 @@ struct ReviewMostRecurringCard: View {
         ) {
             VStack(alignment: .leading, spacing: 10) {
                 VStack(alignment: .leading, spacing: 8) {
-                    ForEach(Array(themes.prefix(3)), id: \.mostRecurringRowIdentity) { theme in
+                    ForEach(Array(themes.prefix(3)), id: \.self) { theme in
                         mostRecurringThemeRow(theme)
                     }
                 }
@@ -121,7 +121,7 @@ struct ReviewMostRecurringCard: View {
         }
         .buttonStyle(PastTappablePressStyle())
         .accessibilityIdentifier(
-            "MostRecurringThemeRow.\(reviewInsightSanitizedThemeId(theme.mostRecurringRowIdentity))"
+            "MostRecurringThemeRow.\(reviewInsightSanitizedThemeId(mostRecurringAccessibilityKey(for: theme)))"
         )
         .accessibilityLabel(
             String(
@@ -174,18 +174,16 @@ struct ReviewMostRecurringCard: View {
     }
 }
 
-private extension ReviewMostRecurringTheme {
-    /// Row identity for `ForEach` and accessibility: display `label` is not unique across canonical themes.
-    var mostRecurringRowIdentity: String {
-        let evidenceKey = evidence.map(\.id).sorted().joined(separator: "\u{001e}")
-        let sep = "\u{001f}"
-        return [
-            label,
-            String(totalCount),
-            String(dayCount),
-            String(currentWeekCount),
-            String(previousWeekCount),
-            evidenceKey
-        ].joined(separator: sep)
-    }
+/// Stable key for accessibility / UI-test identifiers. `ReviewMostRecurringTheme.id` is label-only and can collide.
+private func mostRecurringAccessibilityKey(for theme: ReviewMostRecurringTheme) -> String {
+    let evidenceKey = theme.evidence.map(\.id).sorted().joined(separator: "\u{001e}")
+    let sep = "\u{001f}"
+    return [
+        theme.label,
+        String(theme.totalCount),
+        String(theme.dayCount),
+        String(theme.currentWeekCount),
+        String(theme.previousWeekCount),
+        evidenceKey
+    ].joined(separator: sep)
 }


### PR DESCRIPTION
## Headline

Separates SwiftUI row identity from UI-test identifiers so recurring-theme rows update reliably when labels collide.

## User impact

When two recurring themes looked the same by label, list updates could behave oddly and automation could target the wrong row. The card now keys rows in a way that matches the theme value while still using a composite key for accessibility identifiers when labels are not unique.

## What changed

The most recurring themes list no longer uses a custom string property as the ForEach identity. Rows are keyed by the theme value itself, which is appropriate when the model differentiates themes beyond the display label. The old composite string used for stable differentiation was moved into a small helper used only for accessibility and UI-test identifiers, so test IDs stay stable where labels can collide without tying that logic to list animation and updates.

## Verification

On a Mac with Xcode, run `grace ci` (or `grace test` with the project’s default destination) to lint and build. Manually open Review insights with overlapping or similarly labeled recurring themes and confirm rows update; if you have UI tests that hit `MostRecurringThemeRow.*` identifiers, re-run those to confirm they still resolve distinct rows.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
