### PR TITLE
Use monotonic system uptime for performance trace timing

### DIFF
--- a/GraceNotes/GraceNotes/Application/PerformanceTrace.swift
+++ b/GraceNotes/GraceNotes/Application/PerformanceTrace.swift
@@ -9,11 +9,11 @@ enum PerformanceTrace {
 
     static func begin(_ label: String) -> TimeInterval {
         logger.log("[BEGIN] \(label, privacy: .public)")
-        return CFAbsoluteTimeGetCurrent()
+        return ProcessInfo.processInfo.systemUptime
     }
 
     static func end(_ label: String, startedAt start: TimeInterval) {
-        let elapsedMs = (CFAbsoluteTimeGetCurrent() - start) * 1000
+        let elapsedMs = max(0, (ProcessInfo.processInfo.systemUptime - start) * 1000)
         logger.log("[END] \(label, privacy: .public) (\(elapsedMs, format: .fixed(precision: 2)) ms)")
     }
 

--- a/GraceNotes/GraceNotes/Application/PerformanceTrace.swift
+++ b/GraceNotes/GraceNotes/Application/PerformanceTrace.swift
@@ -13,7 +13,15 @@ enum PerformanceTrace {
     }
 
     static func end(_ label: String, startedAt start: TimeInterval) {
-        let elapsedMs = max(0, (ProcessInfo.processInfo.systemUptime - start) * 1000)
+        let now = ProcessInfo.processInfo.systemUptime
+        if now < start {
+            #if DEBUG
+            assertionFailure("PerformanceTrace: system uptime decreased before end; invalid span")
+            #endif
+            logger.log("[END] \(label, privacy: .public) (invalid span; monotonic clock decreased)")
+            return
+        }
+        let elapsedMs = (now - start) * 1000
         logger.log("[END] \(label, privacy: .public) (\(elapsedMs, format: .fixed(precision: 2)) ms)")
     }
 


### PR DESCRIPTION
## Headline

Performance logs now measure durations with a steady clock, so timings stay trustworthy when the clock jumps.

## User impact

Developers and diagnostics that rely on performance traces get durations that reflect real elapsed work instead of misleading spikes or negatives if the device time changes. This makes debugging and profiling notes from the field more reliable.

## What changed

Performance trace begin/end no longer uses wall-clock time from Core Foundation. It uses the system uptime clock instead, which moves forward in a stable way and is suited to measuring intervals. Elapsed milliseconds are clamped so logged durations never read as negative if something odd happens at the boundary.

## Verification

On a Mac with the repo and Xcode, run `grace ci` (or `grace test` with the project’s usual simulator destination) to confirm the app still builds and tests pass; optionally trigger a code path that logs performance traces and confirm end lines show sensible millisecond values.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
