### PR TITLE
Keep scheduled backup single-flight until MainActor bookkeeping finishes

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/Services/ScheduledBackupRunner.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/Services/ScheduledBackupRunner.swift
@@ -7,8 +7,11 @@ private let scheduledBackupLogger = Logger(
     category: "ScheduledBackup"
 )
 
-/// Prevents overlapping scheduled backup runs until `runIfDue` finishes, including MainActor
-/// bookkeeping (`lastRunAt`, export history). Each `active` transition spawns a new `Task` in ``GraceNotesApp``.
+/// Prevents overlapping scheduled backup runs until the detached export + MainActor bookkeeping
+/// completes. `end()` runs in a `defer` on that detached task so `inFlight` is not cleared if
+/// `runIfDue`’s caller task is cancelled while awaiting the detached work (which would otherwise
+/// allow a second run while export/file I/O is still in flight). Each `active` transition spawns
+/// a new `Task` in ``GraceNotesApp``.
 private final class ScheduledBackupSingleFlight: @unchecked Sendable {
     private let lock = NSLock()
     private var inFlight = false
@@ -45,31 +48,32 @@ enum ScheduledBackupRunner {
         }
 
         guard scheduledBackupSingleFlight.tryBegin() else { return }
-        defer { scheduledBackupSingleFlight.end() }
 
-        let result = await Task.detached(priority: .utility) {
-            Self.performScheduledExport(modelContainer: modelContainer)
-        }.value
+        await Task.detached(priority: .utility) {
+            defer { scheduledBackupSingleFlight.end() }
 
-        switch result {
-        case .success(let fileName):
-            await MainActor.run {
-                ScheduledBackupPreferences.lastRunAt = Date()
-                ScheduledBackupPreferences.lastFailedAttemptAt = nil
-                BackupExportHistoryStore.record(
-                    success: true,
-                    kind: .scheduledFolder,
-                    detail: fileName
+            let result = Self.performScheduledExport(modelContainer: modelContainer)
+
+            switch result {
+            case .success(let fileName):
+                await MainActor.run {
+                    ScheduledBackupPreferences.lastRunAt = Date()
+                    ScheduledBackupPreferences.lastFailedAttemptAt = nil
+                    BackupExportHistoryStore.record(
+                        success: true,
+                        kind: .scheduledFolder,
+                        detail: fileName
+                    )
+                }
+            case .exportFailed:
+                await recordScheduledFailure(
+                    detail: String(localized: "settings.dataPrivacy.scheduledBackup.failureDetail")
                 )
+            case .copyFailed(let error):
+                let detail = failureDetail(for: error)
+                await recordScheduledFailure(detail: detail)
             }
-        case .exportFailed:
-            await recordScheduledFailure(
-                detail: String(localized: "settings.dataPrivacy.scheduledBackup.failureDetail")
-            )
-        case .copyFailed(let error):
-            let detail = failureDetail(for: error)
-            await recordScheduledFailure(detail: detail)
-        }
+        }.value
     }
 
     private enum ScheduledExportResult {
@@ -153,6 +157,7 @@ enum ScheduledBackupRunner {
     private static func exportToTemporaryFile(modelContainer: ModelContainer, exportDate: Date) -> ExportToTempResult {
         do {
             let exportService = JournalDataExportService()
+            // `ModelContext` is created and used only on this detached task (not the main actor).
             let backgroundContext = ModelContext(modelContainer)
             let tempFile = try exportService.exportArchiveFile(context: backgroundContext, now: exportDate)
             return .success(tempFile)

--- a/GraceNotes/GraceNotes/Features/Settings/Services/ScheduledBackupRunner.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/Services/ScheduledBackupRunner.swift
@@ -7,8 +7,8 @@ private let scheduledBackupLogger = Logger(
     category: "ScheduledBackup"
 )
 
-/// Prevents overlapping scheduled backup runs when the app becomes active repeatedly before
-/// `lastRunAt` is updated (each transition spawns a new `Task` in ``GraceNotesApp``).
+/// Prevents overlapping scheduled backup runs until `runIfDue` finishes, including MainActor
+/// bookkeeping (`lastRunAt`, export history). Each `active` transition spawns a new `Task` in ``GraceNotesApp``.
 private final class ScheduledBackupSingleFlight: @unchecked Sendable {
     private let lock = NSLock()
     private var inFlight = false
@@ -45,10 +45,10 @@ enum ScheduledBackupRunner {
         }
 
         guard scheduledBackupSingleFlight.tryBegin() else { return }
+        defer { scheduledBackupSingleFlight.end() }
 
         let result = await Task.detached(priority: .utility) {
-            defer { scheduledBackupSingleFlight.end() }
-            return Self.performScheduledExport(modelContainer: modelContainer)
+            Self.performScheduledExport(modelContainer: modelContainer)
         }.value
 
         switch result {


### PR DESCRIPTION
## Headline

Scheduled backups no longer release their overlap lock before last-run time and history are updated.

## User impact

Rapid app activations could start a second scheduled backup while the first run was still finishing preference and export-history updates on the main thread, risking duplicate work or confusing backup status. The lock now covers the full run so only one scheduled backup flow is in flight until everything is recorded.

## What changed

The single-flight guard for scheduled backups used to end as soon as the background export task returned, which was before updating last-run time and export history on the main actor. The completion handler was moved so the guard stays active for the entire async function, including main-thread bookkeeping. The documentation was updated to describe that behavior and why each activation can spawn a new task.

## Verification

On a Mac with Xcode and the project’s grace CLI installed, run `grace ci` from the repo root (or `grace test` with the usual simulator destination) to lint and build; exercise scheduled backup by switching away and back quickly with backups enabled and confirm only one run completes before the next can start.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
