### PR TITLE
Fix inline sentence editor caret jumps and Dynamic Type minimum height

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/InlineSentenceEditorField.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/InlineSentenceEditorField.swift
@@ -12,10 +12,20 @@ private enum InlineSentenceEditorFieldLayout {
     static let bodyFontName = "SourceSerif4Roman-Regular"
     static let bodyFontSize: CGFloat = 17
 
+    private static var cachedScaledBodyFont: UIFont?
+    private static var cachedContentSizeCategoryForFont: UIContentSizeCategory?
+
     static func bodyUIFont() -> UIFont {
+        let category = UITraitCollection.current.preferredContentSizeCategory
+        if let cached = cachedScaledBodyFont, cachedContentSizeCategoryForFont == category {
+            return cached
+        }
         let baseFont = UIFont(name: bodyFontName, size: bodyFontSize)
             ?? UIFont.preferredFont(forTextStyle: .body)
-        return UIFontMetrics(forTextStyle: .body).scaledFont(for: baseFont)
+        let scaled = UIFontMetrics(forTextStyle: .body).scaledFont(for: baseFont)
+        cachedScaledBodyFont = scaled
+        cachedContentSizeCategoryForFont = category
+        return scaled
     }
 }
 
@@ -53,14 +63,17 @@ private struct InlineSentenceEditorTextView: UIViewRepresentable {
 
         if uiView.text != text {
             if uiView.isFirstResponder {
-                let previousRange = uiView.selectedRange
-                uiView.text = text
-                let nsText = text as NSString
-                let length = nsText.length
-                let location = min(previousRange.location, length)
-                let remaining = length - location
-                let len = min(previousRange.length, remaining)
-                uiView.selectedRange = NSRange(location: location, length: len)
+                // Avoid clobbering IME composition when an external binding update races marked text.
+                if uiView.markedTextRange == nil {
+                    let previousRange = uiView.selectedRange
+                    uiView.text = text
+                    let nsText = text as NSString
+                    let length = nsText.length
+                    let location = min(previousRange.location, length)
+                    let remaining = length - location
+                    let len = min(previousRange.length, remaining)
+                    uiView.selectedRange = NSRange(location: location, length: len)
+                }
             } else {
                 uiView.text = text
             }

--- a/GraceNotes/GraceNotes/Features/Journal/Views/InlineSentenceEditorField.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/InlineSentenceEditorField.swift
@@ -31,7 +31,9 @@ private struct InlineSentenceEditorTextView: UIViewRepresentable {
     let primaryTextUIColor: UIColor
     let onSubmit: () -> Void
 
-    static let minimumHeight = ceil(InlineSentenceEditorFieldLayout.bodyUIFont().lineHeight)
+    static func minimumHeight() -> CGFloat {
+        ceil(InlineSentenceEditorFieldLayout.bodyUIFont().lineHeight)
+    }
 
     func makeCoordinator() -> Coordinator {
         Coordinator(parent: self)
@@ -50,7 +52,18 @@ private struct InlineSentenceEditorTextView: UIViewRepresentable {
         configure(uiView)
 
         if uiView.text != text {
-            uiView.text = text
+            if uiView.isFirstResponder {
+                let previousRange = uiView.selectedRange
+                uiView.text = text
+                let nsText = text as NSString
+                let length = nsText.length
+                let location = min(previousRange.location, length)
+                let remaining = length - location
+                let len = min(previousRange.length, remaining)
+                uiView.selectedRange = NSRange(location: location, length: len)
+            } else {
+                uiView.text = text
+            }
         }
 
         // UIKit can end editing (scroll-dismiss, keyboard hide) before SwiftUI flips @FocusState.
@@ -76,7 +89,7 @@ private struct InlineSentenceEditorTextView: UIViewRepresentable {
         let fittingSize = uiView.sizeThatFits(CGSize(width: width, height: .greatestFiniteMagnitude))
         let lineHeight = uiView.font?.lineHeight ?? InlineSentenceEditorFieldLayout.bodyUIFont().lineHeight
         let maxHeight = ceil(lineHeight * CGFloat(InlineSentenceEditorFieldLayout.maxVisibleLines))
-        let height = min(max(fittingSize.height, Self.minimumHeight), maxHeight)
+        let height = min(max(fittingSize.height, Self.minimumHeight()), maxHeight)
         uiView.isScrollEnabled = fittingSize.height > maxHeight
         return CGSize(width: width, height: height)
     }
@@ -195,7 +208,7 @@ struct InlineSentenceEditorField: View {
                 primaryTextUIColor: UIColor(palette.textPrimary),
                 onSubmit: onSubmit
             )
-            .frame(minHeight: InlineSentenceEditorTextView.minimumHeight, alignment: .leading)
+            .frame(minHeight: InlineSentenceEditorTextView.minimumHeight(), alignment: .leading)
         }
         .warmPaperInputStyle()
         .modifier(SequentialSectionEntryRow.ConditionalAccessibilityIdentifier(identifier: editorIdentifier))


### PR DESCRIPTION
## Headline

Journal sentence fields keep a stable caret while typing and size correctly with body text settings.

## User impact

Editing gratitudes and other inline sentences should feel steadier: the insertion point and selection no longer jump when SwiftUI refreshes the field while you are typing. Minimum height now follows the scaled body font, so the editor layout stays sensible when you change text size or Dynamic Type.

## What changed

The UITextView bridge used to apply binding updates by assigning the full string whenever it differed from the view, which resets the selection while the field is first responder. The view now reapplies external text with the caret restored and clamped to valid UTF-16 ranges so edits stay where you expect.

The minimum height was a static value computed once from the body font line height. It is now computed on demand so it tracks UIFontMetrics scaling and stays consistent with the live font used for layout and measurement.

## Verification

On a Mac with Xcode and the iOS Simulator, run `grace ci` (or `grace test` with the project’s default destination). Manually open Today journal editing, type in an inline sentence field with the keyboard up, and change Settings ▸ Accessibility ▸ Display & Text Size ▸ Larger Text while the field is visible to confirm layout and caret behavior.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
