### PR TITLE
Sync reminder toggle state after enabling or disabling daily reminders

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/SettingsScreen.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/SettingsScreen.swift
@@ -205,6 +205,7 @@ private extension SettingsScreen {
                 isReminderPickerExpanded = newValue
                 Task {
                     await reminderState.setReminderEnabled(newValue)
+                    syncReminderControlState(with: reminderState.liveStatus)
                 }
             }
         )

--- a/GraceNotes/GraceNotes/Features/Settings/SettingsScreen.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/SettingsScreen.swift
@@ -205,6 +205,11 @@ private extension SettingsScreen {
                 isReminderPickerExpanded = newValue
                 Task {
                     await reminderState.setReminderEnabled(newValue)
+                    // If disable was deferred while another reminder operation held `isWorking`, `liveStatus`
+                    // can still be `.enabled` until work drains; keep the optimistic OFF until `liveStatus` updates.
+                    if !newValue, reminderState.liveStatus == .enabled {
+                        return
+                    }
                     syncReminderControlState(with: reminderState.liveStatus)
                 }
             }


### PR DESCRIPTION
## Headline

Daily reminder switch in Settings now stays aligned with the real notification state after you change it.

## User impact

Turning daily reminders on or off could leave the toggle out of step with what the app actually scheduled or what iOS allowed. The switch and related UI now update from the live reminder status right after that change finishes, so what you see matches whether reminders are really on.

## What changed

The Settings screen already kept the reminder toggle in sync when the underlying live status changed from elsewhere. After the async work to turn reminders on or off completes, the screen now runs the same sync step it uses on load and on status changes, so the local toggle and guidance reflect the updated permission and scheduling outcome immediately.

This is a small behavioral fix in the reminders section only; no new strings or layout changes.

## Verification

On a Mac with Xcode and the project’s grace CLI installed, run `grace ci` (or `grace test` with your usual simulator destination) from the repo root to lint and build. Manually: open Settings, toggle Daily reminders on and off (including after denying or restoring notification permission) and confirm the switch and messaging stay consistent with the actual state.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
