### PR TITLE
Tighten UI test bundle detection and hosted unit-test session checks

### DIFF
--- a/GraceNotes/GraceNotes/Application/ProcessInfo+GraceNotesUITesting.swift
+++ b/GraceNotes/GraceNotes/Application/ProcessInfo+GraceNotesUITesting.swift
@@ -7,7 +7,9 @@ extension ProcessInfo {
     /// True when the app runs under UI tests: UITest bundle path from XCTest, or `-ui-testing` launch argument.
     static var graceNotesIsRunningUITests: Bool {
         let processInfo = Self.processInfo
-        let isUITestBundle = processInfo.environment["XCTestBundlePath"]?.contains("UITests") == true
+        // Match the UI test `.xctest` bundle (e.g. `GraceNotesUITests.xctest`), not arbitrary `UITests` in a path component.
+        let bundlePath = processInfo.environment["XCTestBundlePath"] ?? ""
+        let isUITestBundle = bundlePath.contains("UITests.xctest")
         let hasUITestLaunchArgument = processInfo.arguments.contains("-ui-testing")
         return isUITestBundle || hasUITestLaunchArgument
     }
@@ -17,7 +19,8 @@ extension ProcessInfo {
     /// Keep in sync with `GraceNotesApp.init` and `GraceNotesAppDelegate`—single definition of “hosted unit tests.”
     static var graceNotesIsRunningHostedUnitTests: Bool {
         let processInfo = Self.processInfo
-        let isXCTestSession = processInfo.environment["XCTestConfigurationFilePath"] != nil
+        let configPath = processInfo.environment["XCTestConfigurationFilePath"] ?? ""
+        let isXCTestSession = !configPath.isEmpty
         return isXCTestSession && !graceNotesIsRunningUITests
     }
 


### PR DESCRIPTION
## Headline

The app now recognizes UI tests and hosted unit tests more reliably so test-only behavior stays correct.

## User impact

Mis-detected test modes could make the app apply the wrong startup path (for example treating a run like a UI test when it was not), which hurts reliability and can confuse automated checks. This change reduces false positives so test-only setup and production-like runs stay aligned with what Xcode actually launched.

## What changed

Detection of UI tests no longer treats any path containing the substring “UITests” as a UI test bundle. It now keys off the actual UI test package name pattern (the UITests .xctest bundle in the XCTest bundle path). For hosted unit tests, the code now treats the XCTest configuration path as “present” only when it is a non-empty string, instead of only checking that the environment variable exists.

## Verification

On a Mac with Xcode and the project’s grace CLI: run `grace ci` (or `grace test`) to confirm lint and simulator builds/tests still pass. Optionally run a UI test and a hosted unit test target once to confirm app behavior under each mode matches expectations.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
