### PR TITLE
Avoid allocating dates array when finding earliest journal day

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregates.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregates.swift
@@ -409,7 +409,7 @@ private extension WeeklyReviewAggregatesBuilder {
         let weekLastStart = calendar.startOfDay(for: weekLastInclusive)
         let referenceDayStart = calendar.startOfDay(for: referenceDate)
         let endDayInclusive = min(weekLastStart, referenceDayStart)
-        guard let entryMinRaw = allEntries.map({ calendar.startOfDay(for: $0.entryDate) }).min() else {
+        guard let entryMinRaw = allEntries.lazy.map({ calendar.startOfDay(for: $0.entryDate) }).min() else {
             return nil
         }
         let pastWindowStart = calendar.startOfDay(for: pastStatisticsHistoryLowerBound)


### PR DESCRIPTION
## Headline

Weekly review rhythm stats compute the earliest entry day without materializing a full day array.

## User impact

Users with large journals get snappier weekly review and past-statistics aggregation with less transient memory use while scrolling or refreshing review screens. Behavior stays the same: the code still finds the minimum calendar day the same way, just without building every intermediate date upfront.

## What changed

Computing the earliest calendar day across all entries used a non-lazy map, which built a full array of normalized day values before taking the minimum. That extra allocation scales with total entries and is unnecessary for a min scan. The path now uses a lazy map so only one day at a time is produced while the minimum is computed, cutting peak allocation for the same logical result.

## Verification

On a Mac with Xcode, run `swiftlint lint` on the touched file or repo, then `grace ci` (or `grace test`) from the project root to confirm the GraceNotes scheme still builds and tests pass.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
