### PR TITLE
Handle non-string UserDefaults values in journal appearance migration

### DIFF
--- a/GraceNotes/GraceNotes/DesignSystem/JournalAppearanceMode.swift
+++ b/GraceNotes/GraceNotes/DesignSystem/JournalAppearanceMode.swift
@@ -23,7 +23,15 @@ enum JournalAppearanceMode: String, CaseIterable, Identifiable, Sendable {
     /// surrounding whitespace, unknown values, etc.).
     static func migrateLegacyJournalAppearanceRawValueIfNeeded(defaults: UserDefaults = .standard) {
         let key = JournalAppearanceStorageKeys.todayMode
-        guard let stored = defaults.string(forKey: key) else { return }
+        let stored: String
+        if let string = defaults.string(forKey: key) {
+            stored = string
+        } else if defaults.object(forKey: key) != nil {
+            // `string(forKey:)` is nil for non-string values; `@AppStorage` expects a string. Resolve as empty.
+            stored = ""
+        } else {
+            return
+        }
         let resolved = resolveStored(rawValue: stored)
         let canonical = resolved.rawValue
         guard stored != canonical else { return }


### PR DESCRIPTION
## Headline

Today tab journal appearance now migrates and normalizes even when the saved preference is not a string.

## User impact

If the journal appearance key was ever stored as a non-string (or otherwise read as nil by `string(forKey:)`), the app could skip cleanup and leave `@AppStorage` out of sync with what you see. After this change, those cases are treated as empty, resolved to the correct mode, and rewritten to a canonical string so the Today tab stays predictable and settings stay consistent.

## What changed

The migration helper for journal appearance no longer exits early whenever `UserDefaults.string(forKey:)` is nil. It now checks whether anything is stored under the key at all: real strings are used as before; if a value exists but is not a string, it is treated as an empty string so the existing normalization path can pick a valid mode and persist the canonical raw value. If the key is absent entirely, the function still returns without writing.

## Verification

On a Mac with Xcode and the project’s `grace` CLI, run `grace ci` (or `grace test` per your usual profile) to confirm lint and simulator builds pass. Optionally reset or seed `UserDefaults` with a non-string for `journalTodayAppearanceMode`, launch the app, and confirm Today appearance and migration behave as expected.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
