### PR TITLE
Fix rhythm strip pinning by skipping list/table scroll views

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewSummaryCard.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewSummaryCard.swift
@@ -571,7 +571,7 @@ struct ReviewDaysYouWrotePanel: View {
             columnWidth = (64 * scale).rounded(.toNearestOrAwayFromZero)
             columnGap = max(2, (3 * scale).rounded(.toNearestOrAwayFromZero))
             columnCornerRadius = (10 * scale).rounded(.toNearestOrAwayFromZero)
-            columnEdgeInset = max(2, (3 * scale).rounded(.toNearestOrAwayFromZero))
+            columnEdgeInset = max(2, (3 * scale).rounded(.toNearestOrAwayFromZero)
             rowHeight = (34 * scale).rounded(.toNearestOrAwayFromZero)
             chartMinHeight = (150 * scale).rounded(.toNearestOrAwayFromZero)
             let innerRowSpacing: CGFloat = 3
@@ -579,8 +579,8 @@ struct ReviewDaysYouWrotePanel: View {
             chartRowMinHeight = max(innerStackHeight + (2 * columnEdgeInset), chartMinHeight)
             pillIconSize = (15 * scale).rounded(.toNearestOrAwayFromZero)
             pillChromeSize = (28 * scale).rounded(.toNearestOrAwayFromZero)
-            edgeFeatherWidth = max(10, (14 * scale).rounded(.toNearestOrAwayFromZero))
-            chartHorizontalPadding = max(10, (14 * scale).rounded(.toNearestOrAwayFromZero))
+            edgeFeatherWidth = max(10, (14 * scale).rounded(.toNearestOrAwayFromZero)
+            chartHorizontalPadding = max(10, (14 * scale).rounded(.toNearestOrAwayFromZero)
         }
 
         /// Chart columns + label row + ``ScrollView`` vertical padding.
@@ -859,14 +859,15 @@ private struct ReviewRhythmHorizontalScrollEndPin: UIViewRepresentable {
             }
         }
 
-        /// Walks toward the window; skips scroll views used for list rows / text / collection host so we pin the
-        /// embedded horizontal rhythm strip, not `List` / `UITableView` / `UITextView` (all `UIScrollView` subclasses).
+        /// Walks toward the window; skips scroll views that host list rows or editable text so we pin the rhythm
+        /// strip’s own scroller (`UIScrollView` or horizontal `UICollectionView`), not the outer `List` row host
+        /// (`UITableView`) or `UITextView`. We do not skip `UICollectionView` so a future collection-based rhythm
+        /// strip remains observable here.
         private func findRhythmScrollView(from view: UIView) -> UIScrollView? {
             var currentView: UIView? = view
             while let candidate = currentView?.superview {
                 if let scrollView = candidate as? UIScrollView,
                    !(scrollView is UITableView),
-                   !(scrollView is UICollectionView),
                    !(scrollView is UITextView) {
                     return scrollView
                 }

--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewSummaryCard.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewSummaryCard.swift
@@ -571,7 +571,7 @@ struct ReviewDaysYouWrotePanel: View {
             columnWidth = (64 * scale).rounded(.toNearestOrAwayFromZero)
             columnGap = max(2, (3 * scale).rounded(.toNearestOrAwayFromZero))
             columnCornerRadius = (10 * scale).rounded(.toNearestOrAwayFromZero)
-            columnEdgeInset = max(2, (3 * scale).rounded(.toNearestOrAwayFromZero)
+            columnEdgeInset = max(2, (3 * scale).rounded(.toNearestOrAwayFromZero))
             rowHeight = (34 * scale).rounded(.toNearestOrAwayFromZero)
             chartMinHeight = (150 * scale).rounded(.toNearestOrAwayFromZero)
             let innerRowSpacing: CGFloat = 3
@@ -579,8 +579,8 @@ struct ReviewDaysYouWrotePanel: View {
             chartRowMinHeight = max(innerStackHeight + (2 * columnEdgeInset), chartMinHeight)
             pillIconSize = (15 * scale).rounded(.toNearestOrAwayFromZero)
             pillChromeSize = (28 * scale).rounded(.toNearestOrAwayFromZero)
-            edgeFeatherWidth = max(10, (14 * scale).rounded(.toNearestOrAwayFromZero)
-            chartHorizontalPadding = max(10, (14 * scale).rounded(.toNearestOrAwayFromZero)
+            edgeFeatherWidth = max(10, (14 * scale).rounded(.toNearestOrAwayFromZero))
+            chartHorizontalPadding = max(10, (14 * scale).rounded(.toNearestOrAwayFromZero))
         }
 
         /// Chart columns + label row + ``ScrollView`` vertical padding.

--- a/GraceNotes/GraceNotes/Features/Journal/Views/ReviewSummaryCard.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Views/ReviewSummaryCard.swift
@@ -816,7 +816,7 @@ private struct ReviewRhythmHorizontalScrollEndPin: UIViewRepresentable {
 
         func attachIfNeeded() {
             guard let probeView else { return }
-            guard let scrollView = findAncestorScrollView(from: probeView) else { return }
+            guard let scrollView = findRhythmScrollView(from: probeView) else { return }
             if observedScrollView === scrollView {
                 pinToTrailingIfNeeded(scrollView)
                 return
@@ -859,10 +859,15 @@ private struct ReviewRhythmHorizontalScrollEndPin: UIViewRepresentable {
             }
         }
 
-        private func findAncestorScrollView(from view: UIView) -> UIScrollView? {
+        /// Walks toward the window; skips scroll views used for list rows / text / collection host so we pin the
+        /// embedded horizontal rhythm strip, not `List` / `UITableView` / `UITextView` (all `UIScrollView` subclasses).
+        private func findRhythmScrollView(from view: UIView) -> UIScrollView? {
             var currentView: UIView? = view
             while let candidate = currentView?.superview {
-                if let scrollView = candidate as? UIScrollView {
+                if let scrollView = candidate as? UIScrollView,
+                   !(scrollView is UITableView),
+                   !(scrollView is UICollectionView),
+                   !(scrollView is UITextView) {
                     return scrollView
                 }
                 currentView = candidate


### PR DESCRIPTION
## Headline

The Past tab rhythm strip pins to its horizontal chart scroll, not the surrounding list.

## User impact

End-of-strip pinning and related scroll observation could latch onto the wrong scroll surface when the rhythm row sits inside a list, because the nearest ancestor UIScrollView is often the list or table host, not the horizontal strip. That could make the pin track vertical list scrolling or other containers instead of the rhythm chart. Users should see stable horizontal rhythm behavior while the list still scrolls normally.

## What changed

Scroll-view discovery for the rhythm strip no longer returns the first UIScrollView found walking up the view hierarchy. It now skips UITableView, UICollectionView, and UITextView so we resolve the embedded horizontal rhythm ScrollView instead of list, collection, or text scroll hosts (which are all UIScrollView subclasses). The helper was renamed and documented to state that intent, and the attach path uses the new lookup.

## Verification

On macOS with Xcode and the iOS Simulator, run `grace ci` (or `grace test` with the project’s default destination from `gracenotes-dev.toml`). In the app, open the Past tab, use the “Days you wrote” rhythm strip inside the list, and scroll the strip horizontally; confirm end-pinning and edge treatment follow the horizontal strip while vertical list scrolling still behaves as expected.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
