### PR TITLE
Reset pending import state when merge conflict alert is canceled

### DIFF
--- a/GraceNotes/GraceNotes/Features/Settings/ImportExportSettingsScreen.swift
+++ b/GraceNotes/GraceNotes/Features/Settings/ImportExportSettingsScreen.swift
@@ -300,7 +300,10 @@ struct ImportExportSettingsScreen: View {
             Button(String(localized: "settings.dataPrivacy.import.mergeConflict.keepDevice")) {
                 runConflictResolution(.preferLocal)
             }
-            Button(String(localized: "common.cancel"), role: .cancel) {}
+            Button(String(localized: "common.cancel"), role: .cancel) {
+                pendingImportURL = nil
+                mergeConflictDays = []
+            }
         } message: {
             Text(mergeConflictAlertMessage(count: mergeConflictDays.count))
         }


### PR DESCRIPTION
## Headline

Canceling a JSON merge conflict now abandons the import cleanly instead of leaving stale state behind.

## User impact

If you backed out of resolving merge conflicts, the app could still hold onto the pending file and conflict list. That could make a later import confusing or behave as if an old import was still in flight. Cancel now clears that state so Settings reflects what you actually chose.

## What changed

The merge-conflict alert’s Cancel action used to do nothing beyond dismissing the sheet. It now clears the pending import URL and empties the list of conflicting days so abandoned imports do not linger in memory.

This is a small state-management fix in Import & Export settings; no change to how merge, keep-device, or keep-backup resolution works when you confirm a choice.

## Verification

On a Mac with Xcode and the repo’s dev tooling, run `grace ci` (or `grace test` with the project’s default simulator destination) after reproducing merge conflicts during JSON import and tapping Cancel; confirm a new import can start without odd carryover from the canceled flow.

## Risk

Medium

## Touch class

`ui-ux`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
