### PR TITLE
Use POSIX locale for journal appearance key normalization

### DIFF
--- a/GraceNotes/GraceNotes/DesignSystem/JournalAppearanceMode.swift
+++ b/GraceNotes/GraceNotes/DesignSystem/JournalAppearanceMode.swift
@@ -8,11 +8,12 @@ enum JournalAppearanceMode: String, CaseIterable, Identifiable, Sendable {
     var id: String { rawValue }
 
     /// Interprets persisted `@AppStorage` / `UserDefaults` strings, including legacy `"summer"`.
-    /// Trims surrounding whitespace and lowercases before matching so hand-edited or oddly-cased values do not
-    /// silently fall back to Standard.
+    /// Trims surrounding whitespace and lowercases before matching so hand-edited or oddly-cased values
+    /// still resolve to ``bloom`` or ``standard`` when the meaning is clear. Unknown strings become
+    /// ``standard``.
     static func resolveStored(rawValue: String) -> JournalAppearanceMode {
         let normalized = normalizedStoredRawValue(rawValue)
-        if normalized == "summer" {
+        if normalized == legacySummerStoredRawValue {
             return .bloom
         }
         return JournalAppearanceMode(rawValue: normalized) ?? .standard
@@ -38,8 +39,13 @@ enum JournalAppearanceMode: String, CaseIterable, Identifiable, Sendable {
         defaults.set(canonical, forKey: key)
     }
 
+    private static let legacySummerStoredRawValue = "summer"
+    /// Locale used for lowercasing stored keys so casing matches do not depend on the user's
+    /// language/region settings (identifier-style strings, not prose).
+    private static let storedKeyLocale = Locale(identifier: "en_US_POSIX")
+
     private static func normalizedStoredRawValue(_ rawValue: String) -> String {
-        rawValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        rawValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(with: storedKeyLocale)
     }
 }
 

--- a/GraceNotesTests/JournalAppearancePersistenceTests.swift
+++ b/GraceNotesTests/JournalAppearancePersistenceTests.swift
@@ -1,6 +1,12 @@
 import XCTest
 @testable import GraceNotes
 
+/// Persistence tests for Today journal appearance (`JournalAppearanceMode`).
+///
+/// ``JournalAppearanceMode/resolveStored(rawValue:)`` lowercases stored keys with `en_US_POSIX` so
+/// identifier matching stays stable across user locales. If normalization used `Locale.current` or
+/// `String.lowercased()` alone, Turkish (and other) linguistic rules would diverge from POSIX for
+/// Latin `I` (see ``testPOSIXLowercasingDiffersFromTurkishForLatinCapitalI``).
 final class JournalAppearancePersistenceTests: XCTestCase {
     override func tearDown() {
         UserDefaults.standard.removeObject(forKey: JournalAppearanceStorageKeys.todayMode)
@@ -37,6 +43,16 @@ final class JournalAppearancePersistenceTests: XCTestCase {
     func test_resolveStored_normalizesWhitespaceAndCaseForStandard() {
         XCTAssertEqual(JournalAppearanceMode.resolveStored(rawValue: " Standard "), .standard)
         XCTAssertEqual(JournalAppearanceMode.resolveStored(rawValue: "Standard"), .standard)
+        XCTAssertEqual(JournalAppearanceMode.resolveStored(rawValue: "STANDARD"), .standard)
+    }
+
+    func testPOSIXLowercasingDiffersFromTurkishForLatinCapitalI() {
+        let capitalILatin = "I"
+        let posix = capitalILatin.lowercased(with: Locale(identifier: "en_US_POSIX"))
+        let turkish = capitalILatin.lowercased(with: Locale(identifier: "tr_TR"))
+        XCTAssertEqual(posix, "i")
+        XCTAssertEqual(turkish, "ı")
+        XCTAssertNotEqual(posix, turkish)
     }
 
     func test_migrateLegacyJournalAppearance_rewritesSummerRawToBloom() {


### PR DESCRIPTION
## Headline

Journal appearance settings now match stored values consistently regardless of device language.

## User impact

If you had changed the Today journal look in Settings, the app could misread the saved value in rare cases where lowercasing depends on language or region (for example, Turkish locale and certain letters). The journal chrome should now stay on Bloom or Standard as intended after relaunch or migration.

## What changed

The change normalizes saved appearance strings with a fixed English POSIX locale instead of the user’s current locale, so trimming and lowercasing behave like stable identifier matching rather than prose. The legacy Summer-to-Bloom string is a named constant, and the documentation now states that recognizable values still map to Bloom or Standard while unknown values fall back to Standard.

## Verification

On a Mac with the Grace Notes repo, run `grace ci` (or `grace test` with the project’s usual simulator destination) to confirm the app builds and tests pass. Optionally set the device language to Turkish, toggle Today journal appearance in Settings, force-quit and relaunch, and confirm the chosen style persists.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
