### PR TITLE
Align weekly reflection day counts with meaningful content

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregates.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregates.swift
@@ -140,18 +140,13 @@ private extension WeeklyReviewAggregatesBuilder {
     func reflectionDayCount(from entries: [Journal], calendar: Calendar) -> Int {
         Set(
             entries
-                .filter { $0.hasMeaningfulContent || hasReflectionSurfaceText($0) }
+                .filter(\.hasMeaningfulContent)
                 .map { calendar.startOfDay(for: $0.entryDate) }
         ).count
     }
 
     func meaningfulEntryCount(from entries: [Journal]) -> Int {
         entries.filter(\.hasMeaningfulContent).count
-    }
-
-    func hasReflectionSurfaceText(_ entry: Journal) -> Bool {
-        !textNormalizer.trimmed(entry.readingNotes).isEmpty
-            || !textNormalizer.trimmed(entry.reflections).isEmpty
     }
 
     /// Joins non-empty trimmed notes and reflections without a stray lone space when both are empty.
@@ -478,7 +473,7 @@ private extension WeeklyReviewAggregatesBuilder {
     ) -> [ReviewDayActivity] {
         let activeDays = Set(
             entries
-                .filter { $0.hasMeaningfulContent || hasReflectionSurfaceText($0) }
+                .filter(\.hasMeaningfulContent)
                 .map { calendar.startOfDay(for: $0.entryDate) }
         )
         var activity: [ReviewDayActivity] = []


### PR DESCRIPTION
## Headline

Weekly review reflection days now follow the same meaningful-entry bar everywhere.

## User impact

Reflection-day totals and the week’s day activity strip stay consistent with how Grace Notes already scores a day as meaningful, so insights and completion signals are not inflated by notes-only or reflections-only stubs. Reviewers see fewer mismatches between “reflection days” and other weekly stats.

## What changed

Reflection day counting and the per-day activity set previously treated a day as active if an entry had meaningful content or only non-empty trimmed reading notes or reflections. That second path could bump reflection totals and disagree with `meaningfulEntryCount` and the rest of the weekly aggregates.

The builder now counts those days only when `hasMeaningfulContent` is true, matching the single definition used elsewhere, and removes the helper that only looked at notes and reflections text.

## Verification

On a Mac with Xcode and the project’s `grace` CLI, run `grace ci` (or `grace test` with your usual simulator destination). Optionally open Weekly Review for a week where some days have only notes or reflections and confirm reflection-day counts match expectations for meaningful entries.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
