### PR TITLE
Align Past insights refresh snapshots with calendar-day week ranges

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/ReviewInsightsRefreshPolicy.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ReviewInsightsRefreshPolicy.swift
@@ -39,12 +39,13 @@ struct ReviewInsightsRefreshKey: Hashable {
         let snapshots = entries.compactMap { entry -> ReviewEntrySnapshot? in
             let entryDay = calendar.startOfDay(for: entry.entryDate)
             let inHistoryWindow = entryDay >= historyRange.lowerBound && entryDay < historyRange.upperBound
-            let inCurrentWeek = currentReviewPeriod.contains(entry.entryDate)
-            let inPreviousWeek = previousPeriod.contains(entry.entryDate)
+            let inCurrentWeek =
+                entryDay >= currentReviewPeriod.lowerBound && entryDay < currentReviewPeriod.upperBound
+            let inPreviousWeek = entryDay >= previousPeriod.lowerBound && entryDay < previousPeriod.upperBound
             guard inHistoryWindow || inCurrentWeek || inPreviousWeek else { return nil }
             return ReviewEntrySnapshot(id: entry.id, updatedAt: entry.updatedAt)
         }
-        return snapshots.sorted { $0.id.uuidString < $1.id.uuidString }
+        return snapshots.sorted { $0.id < $1.id }
     }
 }
 


### PR DESCRIPTION
## Headline

Past-tab review insights now refresh on a consistent day calendar, not mixed timestamps.

## User impact

Entries saved at different times on the same day could be treated inconsistently when deciding which journals affect Past insights and trend weeks. That could cause insights to update too often, too little, or feel out of sync with what you actually wrote. This change makes that logic line up with how the rest of the window uses calendar days.

## What changed

The code that picks which journal entries belong in the current and previous review weeks no longer uses raw date containment on the entry timestamp. It compares the entry’s calendar day (start of day) to each week range’s lower and upper bounds, the same way the past-statistics history window already works. Snapshot ordering for the refresh key now sorts entry IDs as UUIDs instead of stringifying them first, which keeps ordering stable with less overhead.

## Verification

On a Mac with the repo’s Xcode setup, run `grace ci` (or at least `grace test`) to confirm the GraceNotes scheme still builds and tests pass.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
