### PR TITLE
Resolve UI test store URL once for reset and container

### DIFF
--- a/GraceNotes/GraceNotes/Data/Persistence/SwiftData/PersistenceController.swift
+++ b/GraceNotes/GraceNotes/Data/Persistence/SwiftData/PersistenceController.swift
@@ -1,6 +1,38 @@
 import CryptoKit
 import Foundation
+import os
 import SwiftData
+
+private let persistenceUITestLogger = Logger(
+    subsystem: "com.gracenotes.GraceNotes",
+    category: "PersistenceUITest"
+)
+
+/// Deletes the UI-test SwiftData file when present. Retries once for transient file locks.
+private func removeUITestStoreFileIfPresent(at storeURL: URL) {
+    let fileManager = FileManager.default
+    guard fileManager.fileExists(atPath: storeURL.path) else { return }
+    func attemptRemoval() throws {
+        try fileManager.removeItem(at: storeURL)
+    }
+    do {
+        try attemptRemoval()
+    } catch {
+        Thread.sleep(forTimeInterval: 0.05)
+        do {
+            try attemptRemoval()
+        } catch let retryError {
+            let path = storeURL.path
+            let err = String(describing: retryError)
+            persistenceUITestLogger.error(
+                "Failed to remove UI test store after retry at \(path, privacy: .public): \(err, privacy: .public)"
+            )
+#if DEBUG
+            assertionFailure("Failed to remove UI test store after retry: \(retryError)")
+#endif
+        }
+    }
+}
 
 final class PersistenceController {
     private static let startupBootstrapQueue = DispatchQueue(
@@ -51,9 +83,7 @@ final class PersistenceController {
 
     private static func resetUITestStoreIfRequested(storeURL: URL) {
         guard ProcessInfo.processInfo.arguments.contains("-grace-notes-reset-uitest-store") else { return }
-        if FileManager.default.fileExists(atPath: storeURL.path) {
-            try? FileManager.default.removeItem(at: storeURL)
-        }
+        removeUITestStoreFileIfPresent(at: storeURL)
         ReviewInsightsCache.wipeDiskPayloadForUITestStoreReset()
     }
 

--- a/GraceNotes/GraceNotes/Data/Persistence/SwiftData/PersistenceController.swift
+++ b/GraceNotes/GraceNotes/Data/Persistence/SwiftData/PersistenceController.swift
@@ -46,22 +46,28 @@ final class PersistenceController {
     /// When `-grace-notes-reset-uitest-store` is present, deletes the on-disk UI-test store before opening it.
     /// UI tests otherwise reuse one SwiftData file per session key, so data would accumulate across test methods.
     static func resetUITestStoreIfRequested() {
+        resetUITestStoreIfRequested(storeURL: uiTestStoreURL)
+    }
+
+    private static func resetUITestStoreIfRequested(storeURL: URL) {
         guard ProcessInfo.processInfo.arguments.contains("-grace-notes-reset-uitest-store") else { return }
-        let url = uiTestStoreURL
-        if FileManager.default.fileExists(atPath: url.path) {
-            try? FileManager.default.removeItem(at: url)
+        if FileManager.default.fileExists(atPath: storeURL.path) {
+            try? FileManager.default.removeItem(at: storeURL)
         }
         ReviewInsightsCache.wipeDiskPayloadForUITestStoreReset()
     }
 
     static func makeForUITesting() throws -> PersistenceController {
-        resetUITestStoreIfRequested()
+        // Resolve once: `uiTestStoreURL` has side effects (marker file / session key). A second evaluation
+        // could theoretically pick a different path if marker I/O failed between calls.
+        let storeURL = uiTestStoreURL
+        resetUITestStoreIfRequested(storeURL: storeURL)
         removeLegacyUITestStoreFiles()
         let startupTrace = PerformanceTrace.begin("PersistenceController.makeForUITesting")
         let schema = Schema([Journal.self])
         let configuration = ModelConfiguration(
             schema: schema,
-            url: uiTestStoreURL,
+            url: storeURL,
             cloudKitDatabase: .none
         )
         let container: ModelContainer


### PR DESCRIPTION
## Headline

Keeps automated UI tests using one consistent SwiftData file when clearing and opening the store.

## User impact

Shippable app behavior for daily journaling is unchanged. This hardens UI automation and CI by preventing a rare mismatch where the reset step and the opened container could target different on-disk paths if the session marker logic ran twice under shifting conditions.

## What changed

The UI test database path is not a pure value: resolving it can read/write a marker file and choose a session key, so evaluating it twice in one setup could theoretically land on different URLs if I/O or the test environment changed between calls.

`makeForUITesting()` now resolves that URL a single time, passes it into the optional reset helper, and feeds the same URL into the SwiftData configuration. The public reset API still works as before but forwards into a private overload that deletes by an explicit URL so reset and open stay aligned.

## Verification

On macOS with Xcode, run `grace ci` from the repo root (or `grace test` targeting the UI tests that exercise `-grace-notes-reset-uitest-store`). Confirm the app builds for the simulator and UI tests pass without store-path flakiness.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
