### PR TITLE
Derive search match line text from Entry and optimize field hashing

### DIFF
--- a/GraceNotes/GraceNotes/Data/JournalSearchMatch.swift
+++ b/GraceNotes/GraceNotes/Data/JournalSearchMatch.swift
@@ -8,11 +8,11 @@ struct JournalSearchMatch: Identifiable, Equatable, Sendable {
     let source: ReviewThemeSourceCategory
     let content: String
 
-    init(entryDate: Date, journalEntryId: UUID, item: Entry, source: ReviewThemeSourceCategory, content: String) {
+    init(entryDate: Date, journalEntryId: UUID, item: Entry, source: ReviewThemeSourceCategory) {
         self.id = "\(journalEntryId.uuidString)|\(source.rawValue)|\(item.id.uuidString)"
         self.entryDate = entryDate
         self.source = source
-        self.content = content
+        self.content = item.fullText
     }
 
     init(entryDate: Date, journalEntryId: UUID, source: ReviewThemeSourceCategory, content: String) {
@@ -28,7 +28,11 @@ struct JournalSearchMatch: Identifiable, Equatable, Sendable {
         source: ReviewThemeSourceCategory,
         content: String
     ) -> String {
-        let digest = SHA256.hash(data: Data(content.utf8))
+        let digest = content.utf8.withContiguousStorageIfAvailable({ buffer -> SHA256.Digest in
+            var hasher = SHA256()
+            hasher.update(bufferPointer: UnsafeRawBufferPointer(buffer))
+            return hasher.finalize()
+        }) ?? SHA256.hash(data: Data(content.utf8))
         // Use the full digest so truncated-hash collisions cannot map two different bodies of text to one `id`.
         let fingerprint = digest.map { String(format: "%02x", $0) }.joined()
         return "\(journalEntryId.uuidString)|\(source.rawValue)|\(fingerprint)"


### PR DESCRIPTION
## Headline

Past search line items now always reflect the entry’s stored text, and long-field IDs hash UTF-8 with less overhead.

## User impact

Search results for line-based matches stay aligned with what is actually saved in the journal, so highlights and snippets are less likely to drift from the source. For whole-field matches (for example reading notes or reflections), computing stable IDs should be a bit lighter on memory when hashing large text.

## What changed

The initializer that builds a match from an `Entry` no longer takes a separate `content` argument. It always fills the match’s text from the entry’s full text, so callers cannot accidentally pass a different string than what is stored. For fingerprinting whole-field matches, SHA-256 now prefers hashing the string’s UTF-8 bytes in place when the backing storage allows it, and only falls back to building a `Data` buffer when it must. The public shape of `JournalSearchMatch` and the meaning of its `id` for field matches are unchanged.

## Verification

On a Mac with Xcode and the project’s `grace` CLI installed, run `grace ci` (or `grace test` with the usual simulator destination) to confirm the app builds and tests pass.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
