### PR TITLE
Harden share-card redaction against invalid line indices

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/ShareCardDraft.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ShareCardDraft.swift
@@ -128,6 +128,7 @@ struct ShareCardDraft: Equatable, Sendable {
 
 private extension Set where Element == Int {
     mutating func toggleMembership(_ index: Int) {
+        guard index >= 0 else { return }
         if contains(index) {
             remove(index)
         } else {
@@ -356,8 +357,9 @@ enum ShareRenderPayloadBuilder {
         redacted: Set<Int>,
         identity: (Int) -> ShareLineIdentity
     ) -> [ShareLineDisplayItem] {
-        strings.enumerated().map { index, raw in
-            if redacted.contains(index) {
+        let activeRedactions = redacted.intersection(0 ..< strings.count)
+        return strings.enumerated().map { index, raw in
+            if activeRedactions.contains(index) {
                 .redacted(identity: identity(index))
             } else {
                 .visible(
@@ -374,8 +376,9 @@ enum ShareRenderPayloadBuilder {
         identity: (Int) -> ShareLineIdentity
     ) -> [ShareLineDisplayItem] {
         let lines = proseLines(text)
+        let activeRedactions = redacted.intersection(0 ..< lines.count)
         return lines.enumerated().map { index, raw in
-            if redacted.contains(index) {
+            if activeRedactions.contains(index) {
                 .redacted(identity: identity(index))
             } else {
                 .visible(


### PR DESCRIPTION
## Headline

Share images only honor redactions for lines that actually exist, and toggles cannot store invalid indices.

## User impact

Stale or out-of-range redaction indices (for example after editing or shortening journal text) could hide the wrong lines or leave privacy expectations unclear. Negative indices could also pollute stored state. The share card now treats redactions as valid only for the current line count and ignores invalid toggles.

## What changed

The redaction toggle helper now ignores negative indices so the draft never records impossible line numbers.

When building list and prose lines for the share preview, redaction is applied using only indices that fall within the current number of lines. Indices that are out of range are ignored, so the rendered card stays consistent with what is on screen and avoids mis-applying redaction across edits.

## Verification

From the repo root on macOS: run `swiftlint lint` (style). For a full simulator build aligned with CI, run `grace ci` (or `grace test` with your usual destination). Exercise the share composer: toggle redactions, edit entries so line counts change, and confirm only intended lines are hidden on the share preview.

## Risk

Medium

## Touch class

`business-logic`
---
*Automated by `grace sentry`.* Merge is normally unblocked by CI and review resolution; if stuck, an allowlisted account may post `/sentry-approve` as an emergency override.
