### PR TITLE
ci: run PR checks for release/* base branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,11 @@
 name: CI
 
 # Triggers (avoid duplicate runs):
-# - pull_request → PRs targeting main (default `grace ci`: lint + simulator build; full suite when label `full-ci`).
+# - pull_request → PRs targeting main or release lines (default `grace ci`: lint + simulator build; full suite when label `full-ci`).
 # - push → main only: full suite (lint, test, UI smoke) unless the merged PR is labeled `no-ci`.
 on:
   pull_request:
-    branches: [main]
+    branches: [main, "release/**"]
     types: [opened, synchronize, reopened, labeled, unlabeled]
   push:
     branches: [main]


### PR DESCRIPTION
**User impact:** Pull requests that target a `release/*` line (including Sentry automation) get the same lint-and-build gate as PRs to `main`, so merge automation can see green checks instead of an empty status.

**What changed:** The CI workflow `pull_request` trigger now includes `release/**` in addition to `main`.

**Verification:** Workflow YAML only; merge then re-push or empty-commit the open release-target PR (e.g. #504) to trigger a run.

**Note:** PR #504 was also rebased onto `release/0.5.0-build-11` and force-pushed so it is mergeable; stale `sentry-review-fix-*` and orphan `sentry/auto-*` remote branches were removed.