### PR TITLE
ci: fix release PR trigger glob (release/* not release/**)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,9 @@ name: CI
 # - push → main only: full suite (lint, test, UI smoke) unless the merged PR is labeled `no-ci`.
 on:
   pull_request:
-    branches: [main, "release/**"]
+    # `release/*` matches one segment (e.g. release/0.5.0-build-11); `release/**` did not
+    # trigger reliably for release-line PRs in practice.
+    branches: [main, "release/*"]
     types: [opened, synchronize, reopened, labeled, unlabeled]
   push:
     branches: [main]


### PR DESCRIPTION
**Problem:** PRs targeting `release/0.5.0-build-11` (e.g. #504) never received CI after #541 because the `release/**` branch filter did not match in practice.

**Change:** Use `release/*` so a single path segment after `release/` matches release-line branches.

**Verification:** Merge, then push or synchronize PR #504; `Lint & build` should appear.