### PR TITLE
ci: use pull_request.base.ref for same-repo PR gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,8 @@ jobs:
     name: Lint & build (iPhone 17 Pro)
     if: >
       github.event_name == 'pull_request' &&
-      (github.base_ref == 'main' || startsWith(github.base_ref, 'release/'))
+      (github.event.pull_request.base.ref == 'main' ||
+      startsWith(github.event.pull_request.base.ref, 'release/'))
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
@@ -130,7 +131,8 @@ jobs:
     name: PR full-ci — lint, test, UI smoke
     if: >
       github.event_name == 'pull_request' &&
-      (github.base_ref == 'main' || startsWith(github.base_ref, 'release/')) &&
+      (github.event.pull_request.base.ref == 'main' ||
+      startsWith(github.event.pull_request.base.ref, 'release/')) &&
       contains(github.event.pull_request.labels.*.name, 'full-ci')
     runs-on: macos-15
     steps:


### PR DESCRIPTION
**Root cause:** `github.base_ref` is empty for **same-repository** `pull_request` runs, so release-line PRs never matched the gate and lint never ran.

**Fix:** Compare `github.event.pull_request.base.ref` to `main` or `release/*` via `startsWith(..., 'release/')`.

**Verification:** Merge, then synchronize PR #504; `Lint & build` should report.