### PR TITLE
🧹 Refactor WeeklyReviewAggregatesBuilder.build parameters

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/ReviewInsightsProvider.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ReviewInsightsProvider.swift
@@ -85,13 +85,15 @@ struct ReviewInsightsProvider: Sendable {
         let currentWeekEntries = entries.filter { weekRange.contains($0.entryDate) }
         let previousWeekEntries = entries.filter { previousPeriod.contains($0.entryDate) }
         let aggregates = aggregatesBuilder.build(
-            currentPeriod: weekRange,
-            currentWeekEntries: currentWeekEntries,
-            previousWeekEntries: previousWeekEntries,
-            allEntries: entries,
-            calendar: calendar,
-            referenceDate: referenceDate,
-            pastStatisticsInterval: pastStatisticsInterval
+            input: WeeklyReviewAggregatesInput(
+                currentPeriod: weekRange,
+                currentWeekEntries: currentWeekEntries,
+                previousWeekEntries: previousWeekEntries,
+                allEntries: entries,
+                calendar: calendar,
+                referenceDate: referenceDate,
+                pastStatisticsInterval: pastStatisticsInterval
+            )
         )
         let carryIntoNextWeek = String(localized: "review.prompts.carryIntoNextWeek")
         let fallbackInsight = ReviewWeeklyInsight(

--- a/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyInsightRuleEngine.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyInsightRuleEngine.swift
@@ -16,7 +16,6 @@ struct WeeklyInsightRuleEngine {
     private let aggregatesBuilder = WeeklyReviewAggregatesBuilder()
     private let textNormalizer = WeeklyInsightTextNormalizer()
 
-    // swiftlint:disable:next function_parameter_count
     func analyze(
         currentPeriod: Range<Date>,
         currentWeekEntries: [Journal],
@@ -28,13 +27,15 @@ struct WeeklyInsightRuleEngine {
     ) -> WeeklyInsightAnalysis {
         let candidateBuilder = WeeklyInsightCandidateBuilder(textNormalizer: textNormalizer)
         let aggregates = aggregatesBuilder.build(
-            currentPeriod: currentPeriod,
-            currentWeekEntries: currentWeekEntries,
-            previousWeekEntries: previousWeekEntries,
-            allEntries: allEntries,
-            calendar: calendar,
-            referenceDate: referenceDate,
-            pastStatisticsInterval: pastStatisticsInterval
+            input: WeeklyReviewAggregatesInput(
+                currentPeriod: currentPeriod,
+                currentWeekEntries: currentWeekEntries,
+                previousWeekEntries: previousWeekEntries,
+                allEntries: allEntries,
+                calendar: calendar,
+                referenceDate: referenceDate,
+                pastStatisticsInterval: pastStatisticsInterval
+            )
         )
 
         let candidates = candidateBuilder.buildCandidates(inputs: aggregates.candidateInputs)

--- a/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregates.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/WeeklyReviewAggregates.swift
@@ -17,6 +17,34 @@ struct ThemeSummary {
     let firstSeenOrder: Int
 }
 
+struct WeeklyReviewAggregatesInput {
+    let currentPeriod: Range<Date>
+    let currentWeekEntries: [Journal]
+    let previousWeekEntries: [Journal]
+    let allEntries: [Journal]
+    let calendar: Calendar
+    let referenceDate: Date
+    let pastStatisticsInterval: PastStatisticsIntervalSelection
+
+    init(
+        currentPeriod: Range<Date>,
+        currentWeekEntries: [Journal],
+        previousWeekEntries: [Journal],
+        allEntries: [Journal],
+        calendar: Calendar,
+        referenceDate: Date,
+        pastStatisticsInterval: PastStatisticsIntervalSelection = .default
+    ) {
+        self.currentPeriod = currentPeriod
+        self.currentWeekEntries = currentWeekEntries
+        self.previousWeekEntries = previousWeekEntries
+        self.allEntries = allEntries
+        self.calendar = calendar
+        self.referenceDate = referenceDate
+        self.pastStatisticsInterval = pastStatisticsInterval
+    }
+}
+
 struct CandidateInputs {
     let entries: [Journal]
     let currentDayCount: Int
@@ -73,34 +101,25 @@ struct WeeklyReviewAggregatesBuilder {
     let textNormalizer = WeeklyInsightTextNormalizer()
     var themeJournalLanguageResolver: any ReviewJournalThemeLanguageResolving = ReviewJournalThemeLanguageResolver()
 
-    // swiftlint:disable:next function_parameter_count
-    func build(
-        currentPeriod: Range<Date>,
-        currentWeekEntries: [Journal],
-        previousWeekEntries: [Journal],
-        allEntries: [Journal],
-        calendar: Calendar,
-        referenceDate: Date,
-        pastStatisticsInterval: PastStatisticsIntervalSelection = .default
-    ) -> WeeklyReviewAggregates {
-        let sortedCurrentEntries = sortedEntries(currentWeekEntries)
-        let sortedPreviousEntries = sortedEntries(previousWeekEntries)
-        let reflectionDays = reflectionDayCount(from: sortedCurrentEntries, calendar: calendar)
+    func build(input: WeeklyReviewAggregatesInput) -> WeeklyReviewAggregates {
+        let sortedCurrentEntries = sortedEntries(input.currentWeekEntries)
+        let sortedPreviousEntries = sortedEntries(input.previousWeekEntries)
+        let reflectionDays = reflectionDayCount(from: sortedCurrentEntries, calendar: input.calendar)
 
         let gratitudeStats = buildChipStats(
             from: sortedCurrentEntries,
             itemsExtractor: { $0.gratitudes ?? [] },
-            calendar: calendar
+            calendar: input.calendar
         )
         let needStats = buildChipStats(
             from: sortedCurrentEntries,
             itemsExtractor: { $0.needs ?? [] },
-            calendar: calendar
+            calendar: input.calendar
         )
         let peopleStats = buildChipStats(
             from: sortedCurrentEntries,
             itemsExtractor: { $0.people ?? [] },
-            calendar: calendar
+            calendar: input.calendar
         )
 
         let candidateInputs = CandidateInputs(
@@ -109,9 +128,9 @@ struct WeeklyReviewAggregatesBuilder {
             needs: needStats,
             gratitudes: gratitudeStats,
             people: peopleStats,
-            currentContinuity: buildContinuityStats(from: sortedCurrentEntries, calendar: calendar),
-            previousContinuity: buildContinuityStats(from: sortedPreviousEntries, calendar: calendar),
-            calendar: calendar
+            currentContinuity: buildContinuityStats(from: sortedCurrentEntries, calendar: input.calendar),
+            previousContinuity: buildContinuityStats(from: sortedPreviousEntries, calendar: input.calendar),
+            calendar: input.calendar
         )
 
         return WeeklyReviewAggregates(
@@ -120,13 +139,9 @@ struct WeeklyReviewAggregatesBuilder {
             recurringNeeds: topThemes(from: needStats),
             recurringPeople: topThemes(from: peopleStats),
             stats: buildWeekStats(
-                currentPeriod: currentPeriod,
-                entries: sortedCurrentEntries,
-                allEntries: allEntries,
-                reflectionDays: reflectionDays,
-                calendar: calendar,
-                referenceDate: referenceDate,
-                pastStatisticsInterval: pastStatisticsInterval
+                input: input,
+                sortedCurrentEntries: sortedCurrentEntries,
+                reflectionDays: reflectionDays
             )
         )
     }
@@ -311,51 +326,50 @@ private extension WeeklyReviewAggregatesBuilder {
             }
     }
 
-    // swiftlint:disable:next function_body_length function_parameter_count
+    // swiftlint:disable:next function_body_length
     func buildWeekStats(
-        currentPeriod: Range<Date>,
-        entries: [Journal],
-        allEntries: [Journal],
-        reflectionDays: Int,
-        calendar: Calendar,
-        referenceDate: Date,
-        pastStatisticsInterval: PastStatisticsIntervalSelection
+        input: WeeklyReviewAggregatesInput,
+        sortedCurrentEntries: [Journal],
+        reflectionDays: Int
     ) -> ReviewWeekStats {
-        let meaningfulEntryCount = meaningfulEntryCount(from: entries)
-        let weekStrongestByDay = ReviewHistoryWindowing.strongestCompletionByDay(from: entries, calendar: calendar)
+        let meaningfulEntryCount = meaningfulEntryCount(from: sortedCurrentEntries)
+        let weekStrongestByDay = ReviewHistoryWindowing.strongestCompletionByDay(
+            from: sortedCurrentEntries,
+            calendar: input.calendar
+        )
         let completionMix = buildCompletionMix(from: weekStrongestByDay)
         let activity = buildDayActivity(
-            currentPeriod: currentPeriod,
-            entries: entries,
+            currentPeriod: input.currentPeriod,
+            entries: sortedCurrentEntries,
             strongestCompletionByDay: weekStrongestByDay,
-            calendar: calendar
+            calendar: input.calendar
         )
-        let historyRange = pastStatisticsInterval.validated.resolvedHistoryRange(
-            referenceDate: referenceDate,
-            calendar: calendar,
-            allEntries: allEntries
+        let historyRange = input.pastStatisticsInterval.validated.resolvedHistoryRange(
+            referenceDate: input.referenceDate,
+            calendar: input.calendar,
+            allEntries: input.allEntries
         )
         let rhythmHistory = buildRhythmHistory(
-            allEntries: allEntries,
-            currentPeriod: currentPeriod,
-            calendar: calendar,
-            referenceDate: referenceDate,
+            allEntries: input.allEntries,
+            currentPeriod: input.currentPeriod,
+            calendar: input.calendar,
+            referenceDate: input.referenceDate,
             pastStatisticsHistoryLowerBound: historyRange.lowerBound
         )
         let sectionTotals = ReviewWeekSectionTotals(
-            gratitudeMentions: entries.reduce(0) { $0 + ($1.gratitudes ?? []).count },
-            needMentions: entries.reduce(0) { $0 + ($1.needs ?? []).count },
-            peopleMentions: entries.reduce(0) { $0 + ($1.people ?? []).count }
+            gratitudeMentions: sortedCurrentEntries.reduce(0) { $0 + ($1.gratitudes ?? []).count },
+            needMentions: sortedCurrentEntries.reduce(0) { $0 + ($1.needs ?? []).count },
+            peopleMentions: sortedCurrentEntries.reduce(0) { $0 + ($1.people ?? []).count }
         )
         let entriesInHistoryRange = ReviewHistoryWindowing.entriesInValidatedHistoryWindow(
-            allEntries: allEntries,
-            referenceDate: referenceDate,
-            calendar: calendar,
-            pastStatisticsInterval: pastStatisticsInterval
+            allEntries: input.allEntries,
+            referenceDate: input.referenceDate,
+            calendar: input.calendar,
+            pastStatisticsInterval: input.pastStatisticsInterval
         )
         let historyStrongestByDay = ReviewHistoryWindowing.strongestCompletionByDay(
             from: entriesInHistoryRange,
-            calendar: calendar
+            calendar: input.calendar
         )
         // Same invariant as week ``completionMix``: bucket totals sum to calendar days with ≥1 persisted
         // entry in the entry set used for the per-day strongest level (here, entries in the past-stats window).
@@ -366,10 +380,10 @@ private extension WeeklyReviewAggregatesBuilder {
             peopleMentions: entriesInHistoryRange.reduce(0) { $0 + ($1.people ?? []).count }
         )
         let sections = buildThemeSections(
-            from: sortedEntries(allEntries),
-            currentPeriod: currentPeriod,
-            calendar: calendar,
-            referenceDate: referenceDate,
+            from: sortedEntries(input.allEntries),
+            currentPeriod: input.currentPeriod,
+            calendar: input.calendar,
+            referenceDate: input.referenceDate,
             mostRecurringWindow: historyRange
         )
         return ReviewWeekStats(

--- a/GraceNotesTests/Features/Journal/WeeklyReviewAggregatesMostRecurringTests.swift
+++ b/GraceNotesTests/Features/Journal/WeeklyReviewAggregatesMostRecurringTests.swift
@@ -28,14 +28,14 @@ extension WeeklyReviewAggregatesMostRecurringTests {
             makeEntry(on: date(year: 2026, month: 3, day: 17), needs: ["recover"]),
             makeEntry(on: date(year: 2026, month: 3, day: 18), needs: ["休息"])
         ]
-        let aggregates = builder.build(
+        let aggregates = builder.build(input: WeeklyReviewAggregatesInput(
             currentPeriod: period,
             currentWeekEntries: entries.filter { period.contains($0.entryDate) },
             previousWeekEntries: entries.filter { previous.contains($0.entryDate) },
             allEntries: entries,
             calendar: calendar,
             referenceDate: referenceDate
-        )
+        ))
 
         let restTheme = try XCTUnwrap(aggregates.stats.mostRecurringThemes.first(where: { $0.label == "休息" }))
         XCTAssertEqual(restTheme.totalCount, 3)
@@ -52,14 +52,14 @@ extension WeeklyReviewAggregatesMostRecurringTests {
             makeEntry(on: date(year: 2026, month: 3, day: 18), needs: ["休息"])
         ]
         builder.themeJournalLanguageResolver = FixedReviewJournalThemeLanguageResolver(locale: Locale(identifier: "en"))
-        let aggregates = builder.build(
+        let aggregates = builder.build(input: WeeklyReviewAggregatesInput(
             currentPeriod: period,
             currentWeekEntries: entries.filter { period.contains($0.entryDate) },
             previousWeekEntries: entries.filter { previous.contains($0.entryDate) },
             allEntries: entries,
             calendar: calendar,
             referenceDate: referenceDate
-        )
+        ))
 
         let restTheme = try XCTUnwrap(aggregates.stats.mostRecurringThemes.first(where: { $0.label == "Rest" }))
         XCTAssertEqual(restTheme.totalCount, 3)
@@ -81,7 +81,7 @@ extension WeeklyReviewAggregatesMostRecurringTests {
         ]
 
         let fourWeeksStats = PastStatisticsIntervalSelection(mode: .custom, quantity: 4, unit: .week)
-        let aggregates = builder.build(
+        let aggregates = builder.build(input: WeeklyReviewAggregatesInput(
             currentPeriod: period,
             currentWeekEntries: insideWindow.filter { period.contains($0.entryDate) },
             previousWeekEntries: insideWindow.filter { previous.contains($0.entryDate) },
@@ -89,7 +89,7 @@ extension WeeklyReviewAggregatesMostRecurringTests {
             calendar: calendar,
             referenceDate: referenceDate,
             pastStatisticsInterval: fourWeeksStats
-        )
+        ))
 
         let recurring = aggregates.stats.mostRecurringThemes
         let quiet = try XCTUnwrap(recurring.first(where: { $0.label == "Quiet time" }))
@@ -107,14 +107,14 @@ extension WeeklyReviewAggregatesMostRecurringTests {
             makeEntry(on: date(year: 2026, month: 3, day: 17), needs: ["recover"]),
             makeEntry(on: date(year: 2026, month: 3, day: 18), needs: ["休息"])
         ]
-        let aggregates = builder.build(
+        let aggregates = builder.build(input: WeeklyReviewAggregatesInput(
             currentPeriod: period,
             currentWeekEntries: entries.filter { period.contains($0.entryDate) },
             previousWeekEntries: entries.filter { previous.contains($0.entryDate) },
             allEntries: entries,
             calendar: calendar,
             referenceDate: referenceDate
-        )
+        ))
 
         let restTheme = try XCTUnwrap(aggregates.stats.mostRecurringThemes.first(where: { $0.label == "Rest" }))
         XCTAssertEqual(restTheme.totalCount, 3)
@@ -131,14 +131,14 @@ extension WeeklyReviewAggregatesMostRecurringTests {
             makeEntry(on: date(year: 2026, month: 3, day: 16), gratitudes: ["rest"]),
             makeEntry(on: date(year: 2026, month: 3, day: 17), gratitudes: ["rest"])
         ]
-        let aggregates = builder.build(
+        let aggregates = builder.build(input: WeeklyReviewAggregatesInput(
             currentPeriod: period,
             currentWeekEntries: entries.filter { period.contains($0.entryDate) },
             previousWeekEntries: entries.filter { previous.contains($0.entryDate) },
             allEntries: entries,
             calendar: calendar,
             referenceDate: referenceDate
-        )
+        ))
 
         let restTheme = try XCTUnwrap(
             aggregates.stats.mostRecurringThemes.first(where: { $0.label == "Rest" })
@@ -156,14 +156,14 @@ extension WeeklyReviewAggregatesMostRecurringTests {
             makeEntry(on: date(year: 2026, month: 3, day: 17), people: ["mia"]),
             makeEntry(on: date(year: 2026, month: 3, day: 18), people: [" Mia "])
         ]
-        let aggregates = builder.build(
+        let aggregates = builder.build(input: WeeklyReviewAggregatesInput(
             currentPeriod: period,
             currentWeekEntries: entries.filter { period.contains($0.entryDate) },
             previousWeekEntries: entries.filter { previous.contains($0.entryDate) },
             allEntries: entries,
             calendar: calendar,
             referenceDate: referenceDate
-        )
+        ))
 
         let literal = try XCTUnwrap(aggregates.stats.mostRecurringThemes.first(where: { $0.label == "Mia" }))
         XCTAssertEqual(literal.totalCount, 3)
@@ -193,14 +193,14 @@ extension WeeklyReviewAggregatesMostRecurringTests {
                 people: ["Rest"]
             )
         ]
-        let aggregates = builder.build(
+        let aggregates = builder.build(input: WeeklyReviewAggregatesInput(
             currentPeriod: period,
             currentWeekEntries: entries.filter { period.contains($0.entryDate) },
             previousWeekEntries: entries.filter { previous.contains($0.entryDate) },
             allEntries: entries,
             calendar: calendar,
             referenceDate: referenceDate
-        )
+        ))
 
         let restTheme = try XCTUnwrap(
             aggregates.stats.mostRecurringThemes.first(where: { $0.label == "Rest" })
@@ -238,14 +238,14 @@ extension WeeklyReviewAggregatesMostRecurringTests {
             makeEntry(on: date(year: 2026, month: 3, day: 16), needs: ["focus"])
         ]
 
-        let stats = builder.build(
+        let stats = builder.build(input: WeeklyReviewAggregatesInput(
             currentPeriod: period,
             currentWeekEntries: entries.filter { period.contains($0.entryDate) },
             previousWeekEntries: entries.filter { previous.contains($0.entryDate) },
             allEntries: entries,
             calendar: calendar,
             referenceDate: referenceDate
-        ).stats
+        )).stats
         let trending = stats.movementThemes
         let buckets = stats.trendingBuckets
 
@@ -283,14 +283,14 @@ extension WeeklyReviewAggregatesMostRecurringTests {
             makeEntry(on: date(year: 2026, month: 3, day: 17), needs: ["therapy"])
         ]
 
-        let stats = builder.build(
+        let stats = builder.build(input: WeeklyReviewAggregatesInput(
             currentPeriod: period,
             currentWeekEntries: entries.filter { period.contains($0.entryDate) },
             previousWeekEntries: entries.filter { previous.contains($0.entryDate) },
             allEntries: entries,
             calendar: calendar,
             referenceDate: referenceDate
-        ).stats
+        )).stats
 
         let therapy = try XCTUnwrap(stats.trendingBuckets.newThemes.first(where: { $0.label == "Therapy" }))
         XCTAssertEqual(therapy.trend, .new)
@@ -313,14 +313,14 @@ extension WeeklyReviewAggregatesMostRecurringTests {
                 needs: ["recover"]
             )
         ]
-        let aggregates = builder.build(
+        let aggregates = builder.build(input: WeeklyReviewAggregatesInput(
             currentPeriod: period,
             currentWeekEntries: entries.filter { period.contains($0.entryDate) },
             previousWeekEntries: entries.filter { previous.contains($0.entryDate) },
             allEntries: entries,
             calendar: calendar,
             referenceDate: referenceDate
-        )
+        ))
         let rest = try XCTUnwrap(aggregates.stats.mostRecurringThemes.first(where: { $0.label == "Rest" }))
         XCTAssertEqual(
             rest.totalCount,
@@ -360,14 +360,14 @@ extension WeeklyReviewAggregatesMostRecurringTests {
             makeEntry(on: date(year: 2026, month: 3, day: 16), gratitudes: [surfacePhrase]),
             makeEntry(on: date(year: 2026, month: 3, day: 17), gratitudes: [surfacePhrase])
         ]
-        let aggregates = builder.build(
+        let aggregates = builder.build(input: WeeklyReviewAggregatesInput(
             currentPeriod: period,
             currentWeekEntries: entries.filter { period.contains($0.entryDate) },
             previousWeekEntries: entries.filter { previous.contains($0.entryDate) },
             allEntries: entries,
             calendar: calendar,
             referenceDate: referenceDate
-        )
+        ))
 
         let recurring = aggregates.stats.mostRecurringThemes
         let walking = try XCTUnwrap(recurring.first(where: { $0.label == "Walking" }))
@@ -396,14 +396,14 @@ extension WeeklyReviewAggregatesMostRecurringTests {
             makeEntry(on: date(year: 2026, month: 3, day: 16), needs: ["rest"]),
             makeEntry(on: date(year: 2026, month: 3, day: 17), needs: ["rest"])
         ]
-        let recurring = builder.build(
+        let recurring = builder.build(input: WeeklyReviewAggregatesInput(
             currentPeriod: period,
             currentWeekEntries: entries.filter { period.contains($0.entryDate) },
             previousWeekEntries: entries.filter { previous.contains($0.entryDate) },
             allEntries: entries,
             calendar: calendar,
             referenceDate: referenceDate
-        ).stats.mostRecurringThemes
+        )).stats.mostRecurringThemes
 
         XCTAssertTrue(recurring.contains(where: { $0.label == "Rest" }))
         let bannedLabels: Set<String> = ["Reflection", "Journal", "Things"]
@@ -419,14 +419,14 @@ extension WeeklyReviewAggregatesMostRecurringTests {
             makeEntry(on: date(year: 2026, month: 3, day: 16), needs: ["work"]),
             makeEntry(on: date(year: 2026, month: 3, day: 17), needs: ["work"])
         ]
-        let recurring = builder.build(
+        let recurring = builder.build(input: WeeklyReviewAggregatesInput(
             currentPeriod: period,
             currentWeekEntries: entries.filter { period.contains($0.entryDate) },
             previousWeekEntries: entries.filter { previous.contains($0.entryDate) },
             allEntries: entries,
             calendar: calendar,
             referenceDate: referenceDate
-        ).stats.mostRecurringThemes
+        )).stats.mostRecurringThemes
 
         XCTAssertFalse(recurring.contains(where: { $0.label == "Work" }))
     }
@@ -445,14 +445,14 @@ extension WeeklyReviewAggregatesMostRecurringTests {
             entries.append(makeEntry(on: day, gratitudes: ["rest"], needs: ["focus"], people: ["Dad"]))
         }
 
-        let stats = builder.build(
+        let stats = builder.build(input: WeeklyReviewAggregatesInput(
             currentPeriod: period,
             currentWeekEntries: entries.filter { period.contains($0.entryDate) },
             previousWeekEntries: entries.filter { previous.contains($0.entryDate) },
             allEntries: entries,
             calendar: calendar,
             referenceDate: referenceDate
-        ).stats
+        )).stats
 
         let dad = try XCTUnwrap(stats.mostRecurringThemes.first(where: { $0.label == "Dad" }))
         XCTAssertTrue(dad.evidence.contains { $0.source == .people })
@@ -485,24 +485,24 @@ extension WeeklyReviewAggregatesMostRecurringTests {
             makeEntry(on: date(year: 2026, month: 3, day: 16), gratitudes: ["walking"])
         ]
 
-        let warmUpStats = builder.build(
+        let warmUpStats = builder.build(input: WeeklyReviewAggregatesInput(
             currentPeriod: period,
             currentWeekEntries: entries.filter { period.contains($0.entryDate) },
             previousWeekEntries: entries.filter { previous.contains($0.entryDate) },
             allEntries: entries,
             calendar: calendar,
             referenceDate: warmUpReference
-        ).stats
+        )).stats
         XCTAssertNil(warmUpStats.movementThemes.first(where: { $0.label == "Walking" }))
 
-        let balancedStats = builder.build(
+        let balancedStats = builder.build(input: WeeklyReviewAggregatesInput(
             currentPeriod: period,
             currentWeekEntries: entries.filter { period.contains($0.entryDate) },
             previousWeekEntries: entries.filter { previous.contains($0.entryDate) },
             allEntries: entries,
             calendar: calendar,
             referenceDate: afterWarmUpReference
-        ).stats
+        )).stats
         let walking = try XCTUnwrap(balancedStats.movementThemes.first(where: { $0.label == "Walking" }))
         XCTAssertEqual(walking.trend, .down)
     }
@@ -518,14 +518,14 @@ extension WeeklyReviewAggregatesMostRecurringTests {
             makeEntry(on: date(year: 2026, month: 3, day: 17), needs: ["rest"])
         ]
 
-        let stats = builder.build(
+        let stats = builder.build(input: WeeklyReviewAggregatesInput(
             currentPeriod: period,
             currentWeekEntries: entries.filter { period.contains($0.entryDate) },
             previousWeekEntries: entries.filter { previous.contains($0.entryDate) },
             allEntries: entries,
             calendar: calendar,
             referenceDate: warmUpReference
-        ).stats
+        )).stats
 
         let rest = try XCTUnwrap(stats.movementThemes.first(where: { $0.label == "Rest" }))
         XCTAssertEqual(rest.trend, .rising)
@@ -544,14 +544,14 @@ extension WeeklyReviewAggregatesMostRecurringTests {
             makeEntry(on: date(year: 2026, month: 3, day: 12), gratitudes: ["walking"])
         ]
 
-        let stats = builder.build(
+        let stats = builder.build(input: WeeklyReviewAggregatesInput(
             currentPeriod: period,
             currentWeekEntries: entries.filter { period.contains($0.entryDate) },
             previousWeekEntries: entries.filter { previous.contains($0.entryDate) },
             allEntries: entries,
             calendar: calendar,
             referenceDate: warmUpReference
-        ).stats
+        )).stats
 
         let walking = try XCTUnwrap(stats.movementThemes.first(where: { $0.label == "Walking" }))
         XCTAssertEqual(walking.trend, .down)
@@ -582,14 +582,14 @@ extension WeeklyReviewAggregatesMostRecurringTests {
             )
         ]
 
-        let recurring = builder.build(
+        let recurring = builder.build(input: WeeklyReviewAggregatesInput(
             currentPeriod: period,
             currentWeekEntries: entries.filter { period.contains($0.entryDate) },
             previousWeekEntries: entries.filter { previous.contains($0.entryDate) },
             allEntries: entries,
             calendar: calendar,
             referenceDate: referenceDate
-        ).stats.mostRecurringThemes
+        )).stats.mostRecurringThemes
 
         let rest = try XCTUnwrap(recurring.first(where: { $0.label == "Rest" }))
         XCTAssertEqual(rest.totalCount, 2, "Reading/reflection evidence should not inflate count totals.")
@@ -619,14 +619,14 @@ extension WeeklyReviewAggregatesMostRecurringTests {
             )
         ]
 
-        let recurring = builder.build(
+        let recurring = builder.build(input: WeeklyReviewAggregatesInput(
             currentPeriod: period,
             currentWeekEntries: entries.filter { period.contains($0.entryDate) },
             previousWeekEntries: entries.filter { previous.contains($0.entryDate) },
             allEntries: entries,
             calendar: calendar,
             referenceDate: referenceDate
-        ).stats.mostRecurringThemes
+        )).stats.mostRecurringThemes
 
         let rest = try XCTUnwrap(recurring.first(where: { $0.label == "Rest" }))
         XCTAssertFalse(
@@ -652,14 +652,14 @@ extension WeeklyReviewAggregatesMostRecurringTests {
             needs: ["stretching"],
             people: ["Jordan"]
         )
-        let aggregates = builder.build(
+        let aggregates = builder.build(input: WeeklyReviewAggregatesInput(
             currentPeriod: period,
             currentWeekEntries: [entry].filter { period.contains($0.entryDate) },
             previousWeekEntries: [entry].filter { previousPeriod.contains($0.entryDate) },
             allEntries: [entry],
             calendar: calendar,
             referenceDate: referenceDate
-        )
+        ))
         XCTAssertTrue(
             aggregates.stats.movementThemes.isEmpty,
             "Expected no surfacing trends for seed data; got: \(aggregates.stats.movementThemes.map(\.label))"

--- a/GraceNotesTests/Features/Journal/WeeklyReviewChipOrderTests.swift
+++ b/GraceNotesTests/Features/Journal/WeeklyReviewChipOrderTests.swift
@@ -26,14 +26,14 @@ final class WeeklyReviewChipOrderTests: XCTestCase {
         let entries = [
             makeEntry(on: sameDay, gratitudes: ["Zebra", "Apple", "Mango", "Banana"])
         ]
-        let aggregates = builder.build(
+        let aggregates = builder.build(input: WeeklyReviewAggregatesInput(
             currentPeriod: period,
             currentWeekEntries: entries.filter { period.contains($0.entryDate) },
             previousWeekEntries: entries.filter { previous.contains($0.entryDate) },
             allEntries: entries,
             calendar: calendar,
             referenceDate: referenceDate
-        )
+        ))
 
         let gratitudeSummaries = aggregates.candidateInputs.gratitudes
         let expectedTopThree = Array(gratitudeSummaries.prefix(3)).map(\.displayLabel)
@@ -66,14 +66,14 @@ final class WeeklyReviewChipOrderTests: XCTestCase {
                 people: ["Yvonne", "Alex", "Quinn", "Pat"]
             )
         ]
-        let aggregates = builder.build(
+        let aggregates = builder.build(input: WeeklyReviewAggregatesInput(
             currentPeriod: period,
             currentWeekEntries: entries.filter { period.contains($0.entryDate) },
             previousWeekEntries: entries.filter { previous.contains($0.entryDate) },
             allEntries: entries,
             calendar: calendar,
             referenceDate: referenceDate
-        )
+        ))
 
         XCTAssertEqual(aggregates.recurringNeeds.map(\.label), ["Zebra", "Apple", "Mango"])
         XCTAssertEqual(aggregates.recurringPeople.map(\.label), ["Yvonne", "Alex", "Quinn"])

--- a/GraceNotesTests/Features/Journal/WeeklyReviewHistoryRollupsTests.swift
+++ b/GraceNotesTests/Features/Journal/WeeklyReviewHistoryRollupsTests.swift
@@ -30,14 +30,14 @@ final class WeeklyReviewHistoryRollupsTests: XCTestCase {
         let weekSparse = makeEntry(on: date(year: 2026, month: 3, day: 17), gratitudes: ["solo"])
 
         let allEntries = [priorFull, weekSparse]
-        let aggregates = builder.build(
+        let aggregates = builder.build(input: WeeklyReviewAggregatesInput(
             currentPeriod: period,
             currentWeekEntries: allEntries.filter { period.contains($0.entryDate) },
             previousWeekEntries: allEntries.filter { previous.contains($0.entryDate) },
             allEntries: allEntries,
             calendar: calendar,
             referenceDate: referenceDate
-        )
+        ))
 
         XCTAssertEqual(aggregates.stats.sectionTotals.gratitudeMentions, 1)
         XCTAssertEqual(aggregates.stats.sectionTotals.needMentions, 0)
@@ -71,7 +71,7 @@ final class WeeklyReviewHistoryRollupsTests: XCTestCase {
         let recentEntry = makeEntry(on: recent, gratitudes: ["new"])
         let allEntries = [ancientEntry, recentEntry]
         let oneWeek = PastStatisticsIntervalSelection(mode: .custom, quantity: 1, unit: .week)
-        let aggregates = builder.build(
+        let aggregates = builder.build(input: WeeklyReviewAggregatesInput(
             currentPeriod: period,
             currentWeekEntries: allEntries.filter { period.contains($0.entryDate) },
             previousWeekEntries: allEntries.filter { previous.contains($0.entryDate) },
@@ -79,7 +79,7 @@ final class WeeklyReviewHistoryRollupsTests: XCTestCase {
             calendar: calendar,
             referenceDate: referenceDate,
             pastStatisticsInterval: oneWeek
-        )
+        ))
         XCTAssertEqual(aggregates.stats.historyCompletionMix.totalDaysRepresented, 1)
     }
 
@@ -103,14 +103,14 @@ final class WeeklyReviewHistoryRollupsTests: XCTestCase {
         let allEntries = [outsideEntry, weekEntry]
         let weekSlice = allEntries.filter { period.contains($0.entryDate) }
 
-        let aggregates = builder.build(
+        let aggregates = builder.build(input: WeeklyReviewAggregatesInput(
             currentPeriod: period,
             currentWeekEntries: weekSlice,
             previousWeekEntries: allEntries.filter { previous.contains($0.entryDate) },
             allEntries: allEntries,
             calendar: calendar,
             referenceDate: referenceDate
-        )
+        ))
 
         XCTAssertEqual(distinctEntryDays(weekSlice), 1)
         XCTAssertEqual(aggregates.stats.completionMix.totalDaysRepresented, 1)
@@ -135,14 +135,14 @@ final class WeeklyReviewHistoryRollupsTests: XCTestCase {
         )
         let allEntries = [sparseSameDay, fullSameDay]
 
-        let aggregates = builder.build(
+        let aggregates = builder.build(input: WeeklyReviewAggregatesInput(
             currentPeriod: period,
             currentWeekEntries: allEntries.filter { period.contains($0.entryDate) },
             previousWeekEntries: allEntries.filter { previous.contains($0.entryDate) },
             allEntries: allEntries,
             calendar: calendar,
             referenceDate: referenceDate
-        )
+        ))
 
         XCTAssertEqual(distinctEntryDays(allEntries), 1)
         XCTAssertEqual(aggregates.stats.historyCompletionMix.totalDaysRepresented, 1)
@@ -178,14 +178,14 @@ final class WeeklyReviewHistoryRollupsTests: XCTestCase {
         let weekSparse = makeEntry(on: date(year: 2026, month: 3, day: 17), gratitudes: ["solo"])
 
         let allEntries = [priorFull, weekSparse]
-        let aggregates = builder.build(
+        let aggregates = builder.build(input: WeeklyReviewAggregatesInput(
             currentPeriod: period,
             currentWeekEntries: allEntries.filter { period.contains($0.entryDate) },
             previousWeekEntries: allEntries.filter { previous.contains($0.entryDate) },
             allEntries: allEntries,
             calendar: calendar,
             referenceDate: referenceDate
-        )
+        ))
 
         let interval = PastStatisticsIntervalSelection.default
         let windowed = ReviewHistoryWindowing.entriesInValidatedHistoryWindow(
@@ -243,14 +243,14 @@ final class WeeklyReviewHistoryRollupsTests: XCTestCase {
         let recentEntry = makeEntry(on: recent, gratitudes: ["new"])
         let allEntries = [ancientEntry, recentEntry]
 
-        let aggregates = builder.build(
+        let aggregates = builder.build(input: WeeklyReviewAggregatesInput(
             currentPeriod: period,
             currentWeekEntries: allEntries.filter { period.contains($0.entryDate) },
             previousWeekEntries: allEntries.filter { previous.contains($0.entryDate) },
             allEntries: allEntries,
             calendar: calendar,
             referenceDate: referenceDate
-        )
+        ))
 
         let rhythm = try XCTUnwrap(aggregates.stats.rhythmHistory)
         XCTAssertEqual(calendar.startOfDay(for: rhythm.first!.date), calendar.startOfDay(for: ancient))
@@ -271,14 +271,14 @@ final class WeeklyReviewHistoryRollupsTests: XCTestCase {
         let recentEntry = makeEntry(on: recent, gratitudes: ["new"])
         let allEntries = [oldEntry, recentEntry]
 
-        let aggregates = builder.build(
+        let aggregates = builder.build(input: WeeklyReviewAggregatesInput(
             currentPeriod: period,
             currentWeekEntries: allEntries.filter { period.contains($0.entryDate) },
             previousWeekEntries: allEntries.filter { previous.contains($0.entryDate) },
             allEntries: allEntries,
             calendar: calendar,
             referenceDate: referenceDate
-        )
+        ))
         let rhythm = try XCTUnwrap(aggregates.stats.rhythmHistory)
         XCTAssertLessThanOrEqual(rhythm.count, 731)
         let firstStart = calendar.startOfDay(for: rhythm.first!.date)
@@ -297,22 +297,22 @@ final class WeeklyReviewHistoryRollupsTests: XCTestCase {
         let weekEntry = makeEntry(on: entryDay, gratitudes: ["solo"])
         let allEntries = [weekEntry]
 
-        let skewed = builder.build(
+        let skewed = builder.build(input: WeeklyReviewAggregatesInput(
             currentPeriod: skewedPeriod,
             currentWeekEntries: allEntries,
             previousWeekEntries: allEntries.filter { previous.contains($0.entryDate) },
             allEntries: allEntries,
             calendar: calendar,
             referenceDate: referenceDate
-        )
-        let aligned = builder.build(
+        ))
+        let aligned = builder.build(input: WeeklyReviewAggregatesInput(
             currentPeriod: alignedPeriod,
             currentWeekEntries: allEntries,
             previousWeekEntries: allEntries.filter { previous.contains($0.entryDate) },
             allEntries: allEntries,
             calendar: calendar,
             referenceDate: referenceDate
-        )
+        ))
 
         XCTAssertEqual(skewed.stats.activity, aligned.stats.activity)
         for row in skewed.stats.activity {


### PR DESCRIPTION
This change addresses a code health issue where the `build()` method in `WeeklyReviewAggregatesBuilder` had too many parameters. By introducing a `WeeklyReviewAggregatesInput` parameter object, we've improved the maintainability and scan-ability of the code.

Key changes:
- Created `WeeklyReviewAggregatesInput` in `WeeklyReviewAggregates.swift`.
- Refactored `build(input:)` and `buildWeekStats(input:sortedCurrentEntries:reflectionDays:)`.
- Removed `swiftlint` parameter count overrides.
- Updated all call sites in production and unit tests.

The refactoring preserves all existing logic and ensures that the codebase remains clean and adheres to style guidelines.

---
*PR created automatically by Jules for task [10642846452640157667](https://jules.google.com/task/10642846452640157667) started by @kipyin*