### PR TITLE
⚡ Optimize review insights traversal

### DIFF
--- a/GraceNotes/GraceNotes/Features/Journal/Services/ReviewInsightsProvider.swift
+++ b/GraceNotes/GraceNotes/Features/Journal/Services/ReviewInsightsProvider.swift
@@ -82,8 +82,15 @@ struct ReviewInsightsProvider: Sendable {
     ) -> ReviewInsights {
         let weekRange = ReviewInsightsPeriod.currentPeriod(containing: referenceDate, calendar: calendar)
         let previousPeriod = ReviewInsightsPeriod.previousPeriod(before: weekRange, calendar: calendar)
-        let currentWeekEntries = entries.filter { weekRange.contains($0.entryDate) }
-        let previousWeekEntries = entries.filter { previousPeriod.contains($0.entryDate) }
+        var currentWeekEntries: [Journal] = []
+        var previousWeekEntries: [Journal] = []
+        for entry in entries {
+            if weekRange.contains(entry.entryDate) {
+                currentWeekEntries.append(entry)
+            } else if previousPeriod.contains(entry.entryDate) {
+                previousWeekEntries.append(entry)
+            }
+        }
         let aggregates = aggregatesBuilder.build(
             currentPeriod: weekRange,
             currentWeekEntries: currentWeekEntries,


### PR DESCRIPTION
💡 **What:** Replaced two `filter` passes with a single `for` loop in `ReviewInsightsProvider.sparseFallbackInsights`.

🎯 **Why:** To improve performance by reducing the number of traversals through the `entries` array, halving the time complexity factor in this code path.

📊 **Measured Improvement:** While I cannot run benchmarks in this environment, this is a textbook O(2n) to O(n) optimization that also reduces closure allocation overhead.

---
*PR created automatically by Jules for task [15753753599722683979](https://jules.google.com/task/15753753599722683979) started by @kipyin*