### PR TITLE
🔒 [security fix] Missing Error Handling on File Removal

### DIFF
--- a/GraceNotes/GraceNotes/Data/Persistence/SwiftData/PersistenceController.swift
+++ b/GraceNotes/GraceNotes/Data/Persistence/SwiftData/PersistenceController.swift
@@ -1,8 +1,14 @@
 import CryptoKit
 import Foundation
+import os
 import SwiftData
 
 final class PersistenceController {
+    private static let logger = Logger(
+        subsystem: "com.gracenotes.GraceNotes",
+        category: "PersistenceController"
+    )
+
     private static let startupBootstrapQueue = DispatchQueue(
         label: "com.gracenotes.persistence.bootstrap",
         qos: .userInitiated
@@ -49,7 +55,11 @@ final class PersistenceController {
         guard ProcessInfo.processInfo.arguments.contains("-grace-notes-reset-uitest-store") else { return }
         let url = uiTestStoreURL
         if FileManager.default.fileExists(atPath: url.path) {
-            try? FileManager.default.removeItem(at: url)
+            do {
+                try FileManager.default.removeItem(at: url)
+            } catch {
+                logger.error("Failed to reset UI test store at \(url.path): \(error.localizedDescription)")
+            }
         }
         ReviewInsightsCache.wipeDiskPayloadForUITestStoreReset()
     }
@@ -199,7 +209,11 @@ final class PersistenceController {
             if isHashedUITestStoreFileName(name) {
                 continue
             }
-            try? fileManager.removeItem(at: url)
+            do {
+                try fileManager.removeItem(at: url)
+            } catch {
+                logger.error("Failed to remove legacy UI test store at \(url.path): \(error.localizedDescription)")
+            }
         }
     }
 


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
Missing error handling when attempting to remove UI test store files. Previously, `try?` was used, which silently ignored any failures (e.g., permission issues, file locks).

### ⚠️ Risk: The potential impact if left unfixed
Silent failures can lead to disk space exhaustion or data accumulation in the UI testing environment if orphaned store files are not properly cleaned up. It also hinders debugging when file system operations fail unexpectedly.

### 🛡️ Solution: How the fix addresses the vulnerability
Introduced structured error handling using `do-catch` blocks. Failures are now explicitly caught and logged using `os.Logger`, ensuring that any issues are visible for debugging and auditing while maintaining the intended cleanup logic.

---
*PR created automatically by Jules for task [16196720099230689994](https://jules.google.com/task/16196720099230689994) started by @kipyin*